### PR TITLE
Issue 316

### DIFF
--- a/gateway/tests/api/test_schedule.py
+++ b/gateway/tests/api/test_schedule.py
@@ -48,7 +48,7 @@ class TestScheduleApi(APITestCase):
 
     @patch("tarfile.open")
     @patch("tarfile.os.path.basename")
-    @patch("api.schedule.os.remove", return_value=0)
+    @patch("os.remove", return_value=0)
     @patch.object(uuid, "uuid4", return_value="")
     def test_already_created_ray_cluster_execute_job(
         self, mock_open, mock_basename, mock_uuid, mock_remove


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Added coverage of execute_job condition where a ray cluster already exists. Since execute_job calls submit_job, coverage is added here as well. Coverage up to 79 (with recent commit we're at 81)%

### Details and comments
I have a couple questions:

1) When I use test_json in the GET, I'm required to have a ray_version. I used 2.6.1 because that's the one I had on my computer, but I'm not sure if we're okay with hardcoding a version here. If we are great, otherwise let me know.

2) For the third mocker.get, there is what seems to be a generated zip file name and I wasn't able to find where it's generated or how it's generated. I was also unable to find the path (api/packages/gcs...) when I did a search of the code. I assume I can mock the name of the zip if I know what's generating that, but I can't seem to find it.  Where would it be?
