### PR TITLE
Limitate accesible registries and implement a mock provider

### DIFF
--- a/docs/deployment/custom_function/Dockerfile
+++ b/docs/deployment/custom_function/Dockerfile
@@ -1,4 +1,4 @@
-FROM icr.io/quantum-public/quantum-serverless-ray-node:0.9.0-py39
+FROM icr.io/quantum-public/qiskit-serverless-ray-node:0.11.0-py310
 
 # install all necessary dependencies for your custom image
 

--- a/docs/deployment/custom_function/Dockerfile
+++ b/docs/deployment/custom_function/Dockerfile
@@ -3,5 +3,10 @@ FROM icr.io/quantum-public/qiskit-serverless-ray-node:0.11.0-py310
 # install all necessary dependencies for your custom image
 
 # copy our function implementation in `/runner.py` of the docker image
-RUN mkdir /runner
-COPY ./runner.py /runner/runner.py
+USER 0
+
+WORKDIR /runner
+COPY ./runner.py /runner
+WORKDIR /
+
+USER $RAY_UID

--- a/docs/deployment/deploying_custom_image_function.rst
+++ b/docs/deployment/deploying_custom_image_function.rst
@@ -55,7 +55,13 @@ In our simple case it will look something like this
     # install all necessary dependencies for your custom image
 
     # copy our function implementation in `/runner.py` of the docker image
-    COPY ./runner.py ./runner.py
+    USER 0
+
+    WORKDIR /runner
+    COPY ./runner.py /runner
+    WORKDIR /
+
+    USER $RAY_UID
 
 and then we need to build it
 

--- a/docs/deployment/deploying_custom_image_function.rst
+++ b/docs/deployment/deploying_custom_image_function.rst
@@ -84,6 +84,7 @@ Let define `QiskitFunction` with image we just build, give it a name and upload 
     function_with_custom_image = QiskitFunction(
         title="custom-image-function",
         image="icr.io/quantum-public/my-custom-function-image:1.0.0"
+        provider="mockprovider"
     )
     function_with_custom_image
 

--- a/gateway/api/serializers.py
+++ b/gateway/api/serializers.py
@@ -156,6 +156,8 @@ class ProgramSerializer(serializers.ModelSerializer):
     Serializer for the Program model.
     """
 
+    provider = serializers.CharField(source="provider.name", read_only=True)
+
     class Meta:
         model = Program
 

--- a/gateway/api/v1/serializers.py
+++ b/gateway/api/v1/serializers.py
@@ -12,12 +12,7 @@ class ProgramSerializer(serializers.ProgramSerializer):
     """
 
     class Meta(serializers.ProgramSerializer.Meta):
-        fields = [
-            "title",
-            "entrypoint",
-            "artifact",
-            "dependencies",
-        ]
+        fields = ["title", "entrypoint", "artifact", "dependencies", "provider"]
 
 
 class UploadProgramSerializer(serializers.UploadProgramSerializer):

--- a/gateway/api/v1/serializers.py
+++ b/gateway/api/v1/serializers.py
@@ -39,7 +39,7 @@ class UploadProgramSerializer(serializers.UploadProgramSerializer):
                 "At least one of attributes (entrypoint, image) is required."
             )
         title = attrs.get("title")
-        provider = attrs.get("provider")
+        provider = attrs.get("provider", None)
         if provider and "/" in title:
             raise ValidationError("Provider defined in title and in provider fields.")
         title_split = title.split("/")
@@ -47,6 +47,11 @@ class UploadProgramSerializer(serializers.UploadProgramSerializer):
             raise ValidationError(
                 "Qiskit Function title is malformed. It can only contain one slash."
             )
+        if image is not None:
+            if provider is None and len(title_split) != 2:
+                raise ValidationError(
+                    "Custom images are only available if you are a provider."
+                )
         return super().validate(attrs)
 
     class Meta(serializers.UploadProgramSerializer.Meta):

--- a/gateway/templates/main.tmpl
+++ b/gateway/templates/main.tmpl
@@ -3,7 +3,7 @@
 import os
 import sys
 
-from quantum_serverless import get_arguments, save_result
+from qiskit_serverless import get_arguments, save_result
 
 sys.path.append("{{mount_path}}")
 

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -124,7 +124,6 @@ class TestProgramApi(APITestCase):
             "/api/v1/programs/upload/",
             data={
                 "title": "Private function",
-                "entrypoint": "test_user_2_program.py",
                 "dependencies": "[]",
                 "env_vars": env_vars,
                 "image": "icr.io/awesome-namespace/awesome-title",
@@ -143,7 +142,6 @@ class TestProgramApi(APITestCase):
             "/api/v1/programs/upload/",
             data={
                 "title": "Private function",
-                "entrypoint": "test_user_2_program.py",
                 "dependencies": "[]",
                 "env_vars": env_vars,
                 "image": "icr.io/awesome-namespace/awesome-title",
@@ -156,7 +154,6 @@ class TestProgramApi(APITestCase):
             "/api/v1/programs/upload/",
             data={
                 "title": "default/Private function",
-                "entrypoint": "test_user_2_program.py",
                 "dependencies": "[]",
                 "env_vars": env_vars,
                 "image": "icr.io/awesome-namespace/awesome-title",

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -38,6 +38,25 @@ class TestProgramApi(APITestCase):
             "Program",
         )
 
+    def test_provider_programs_list(self):
+        """Tests programs list authorized."""
+
+        user = models.User.objects.get(username="test_user_2")
+        self.client.force_authenticate(user=user)
+
+        programs_response = self.client.get(reverse("v1:programs-list"), format="json")
+
+        self.assertEqual(programs_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(programs_response.data), 1)
+        self.assertEqual(
+            programs_response.data[0].get("provider"),
+            "default",
+        )
+        self.assertEqual(
+            programs_response.data[0].get("title"),
+            "Docker Image Program",
+        )
+
     def test_run(self):
         """Tests run existing authorized."""
 

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -128,7 +128,7 @@ class TestProgramApi(APITestCase):
                 "dependencies": "[]",
                 "env_vars": env_vars,
                 "image": "icr.io/awesome-namespace/awesome-title",
-                "provider": "default"
+                "provider": "default",
             },
         )
         self.assertEqual(programs_response.status_code, status.HTTP_404_NOT_FOUND)
@@ -194,9 +194,7 @@ class TestProgramApi(APITestCase):
         self.assertEqual(
             programs_response.data.get("entrypoint"), "test_user_3_program.py"
         )
-        self.assertEqual(
-            programs_response.data.get("title"), "Provider Function"
-        )
+        self.assertEqual(programs_response.data.get("title"), "Provider Function")
         self.assertRaises(
             Program.DoesNotExist,
             Program.objects.get,

--- a/gateway/tests/api/test_v1_serializers.py
+++ b/gateway/tests/api/test_v1_serializers.py
@@ -115,9 +115,30 @@ class SerializerTest(APITestCase):
         errors = serializer.errors
         self.assertListEqual(["dependencies"], list(errors.keys()))
 
-    def test_upload_program_with_custom_iamge(self):
+    def test_upload_program_with_custom_image_and_provider(self):
         """Tests image upload serializer."""
         title = "Hello world"
+        entrypoint = "main.py"
+        arguments = {}
+        dependencies = "[]"
+        image = "docker.io/awesome/awesome-image:latest"
+        provider = "ibm"
+
+        data = {}
+        data["title"] = title
+        data["entrypoint"] = entrypoint
+        data["arguments"] = arguments
+        data["dependencies"] = dependencies
+        data["image"] = image
+        data["provider"] = provider
+
+        serializer = UploadProgramSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+        self.assertTrue("image" in list(serializer.validated_data.keys()))
+    
+    def test_upload_program_with_custom_image_and_title_provider(self):
+        """Tests image upload serializer."""
+        title = "ibm/Hello world"
         entrypoint = "main.py"
         arguments = {}
         dependencies = "[]"
@@ -133,6 +154,24 @@ class SerializerTest(APITestCase):
         serializer = UploadProgramSerializer(data=data)
         self.assertTrue(serializer.is_valid())
         self.assertTrue("image" in list(serializer.validated_data.keys()))
+
+    def test_custom_image_without_provider(self):
+        """Tests image upload serializer."""
+        title = "Hello world"
+        entrypoint = "main.py"
+        arguments = {}
+        dependencies = "[]"
+        image = "docker.io/awesome/awesome-image:latest"
+
+        data = {}
+        data["title"] = title
+        data["entrypoint"] = entrypoint
+        data["arguments"] = arguments
+        data["dependencies"] = dependencies
+        data["image"] = image
+
+        serializer = UploadProgramSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
 
     def test_run_program_serializer_check_emtpy_data(self):
         data = {}

--- a/gateway/tests/api/test_v1_serializers.py
+++ b/gateway/tests/api/test_v1_serializers.py
@@ -135,7 +135,7 @@ class SerializerTest(APITestCase):
         serializer = UploadProgramSerializer(data=data)
         self.assertTrue(serializer.is_valid())
         self.assertTrue("image" in list(serializer.validated_data.keys()))
-    
+
     def test_upload_program_with_custom_image_and_title_provider(self):
         """Tests image upload serializer."""
         title = "ibm/Hello world"

--- a/gateway/tests/fixtures/fixtures.json
+++ b/gateway/tests/fixtures/fixtures.json
@@ -56,6 +56,18 @@
     }
   },
   {
+    "model": "api.program",
+    "pk": "6160a2ff-e482-443d-af23-15110b646ae2",
+    "fields": {
+      "created": "2023-02-01T15:30:43.281796Z",
+      "title": "Docker Image Program",
+      "image": "icr.io/awesome-namespace/awesome-title",
+      "author": 2,
+      "env_vars": "{\"PROGRAM_ENV1\": \"VALUE1\", \"PROGRAM_ENV2\": \"VALUE2\"}",
+      "provider": "bfe8aa6a-2127-4123-bf57-5b547293cbea"
+    }
+  },
+  {
     "model": "api.job",
     "pk": "1a7947f9-6ae8-4e3d-ac1e-e7d608deec82",
     "fields": {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Close #1340 , #1342 

This PR accomplish two requirements:

- It limitates the usage of Docker images to those users that has access to a provider
- With `mockuser` a `mockprovider` is created for local testing so now everyone can run docker images locally if they use `mockuser`

### Details and comments
- I just added a validation where if the user sets an image needs to specify a provider
- With `mockprovider` `mockgroup` is created too with VIEW and RUN permissions
- Update `list` method to return the `provider.name`. I forgot to add it before.