### PR TITLE
Issue 1314 | Client: get function by name

### DIFF
--- a/client/qiskit_serverless/core/client.py
+++ b/client/qiskit_serverless/core/client.py
@@ -358,6 +358,10 @@ class BaseClient(JsonSerializable):
         """Returns list of available programs."""
         raise NotImplementedError
 
+    def get(self, title: str) -> Optional[QiskitFunction]:
+        """Returns qiskit function based on title provided."""
+        raise NotImplementedError
+
 
 class BaseProvider(BaseClient):
     """
@@ -489,6 +493,19 @@ class ServerlessClient(BaseClient):
     def list(self, **kwargs) -> List[QiskitFunction]:
         """Returns list of available programs."""
         return self._job_client.get_programs(**kwargs)
+
+    def get(self, title: str) -> Optional[QiskitFunction]:
+        results = self._job_client.get_programs(title=title)
+        if len(results) > 1:
+            warnings.warn(
+                f"There are more than 1 program with title {title}"
+                "available. Returning most recent one. "
+                "If you want to get list of all functions "
+                "please, use `list` method."
+            )
+
+        functions = {function.title: function for function in results}
+        return functions.get(title)
 
     def _verify_token(self, token: str):
         """Verify token."""
@@ -726,6 +743,12 @@ class LocalClient(BaseClient):
 
     def list(self, **kwargs):
         return self.client.get_programs(**kwargs)
+
+    def get(self, title: str) -> Optional[QiskitFunction]:
+        functions = {
+            function.title: function for function in self.client.get_programs()
+        }
+        return functions.get(title)
 
 
 class LocalProvider(LocalClient):

--- a/client/qiskit_serverless/core/job.py
+++ b/client/qiskit_serverless/core/job.py
@@ -548,6 +548,7 @@ class GatewayJobClient(BaseJobClient):
                 request=lambda: requests.get(
                     f"{self.host}/api/{self.version}/programs",
                     headers={"Authorization": f"Bearer {self._token}"},
+                    params=kwargs,
                     timeout=REQUESTS_TIMEOUT,
                 )
             )

--- a/docs/getting_started/basic/01_running_program.ipynb
+++ b/docs/getting_started/basic/01_running_program.ipynb
@@ -86,12 +86,12 @@
     }
    ],
    "source": [
-    "serverless = ServerlessClient(\n",
+    "client = ServerlessClient(\n",
     "    token=os.environ.get(\"GATEWAY_TOKEN\", \"awesome_token\"),\n",
     "    host=os.environ.get(\"GATEWAY_HOST\", \"http://localhost:8000\"),\n",
     ")\n",
     "\n",
-    "serverless"
+    "client"
    ]
   },
   {
@@ -136,7 +136,7 @@
     "    title=\"my-first-pattern\", entrypoint=\"pattern.py\", working_dir=\"./source_files/\"\n",
     ")\n",
     "\n",
-    "serverless.upload(function)"
+    "client.upload(function)"
    ]
   },
   {
@@ -167,8 +167,7 @@
     }
    ],
    "source": [
-    "functions = {f.title: f for f in serverless.list()}\n",
-    "my_pattern_function = functions.get(\"my-first-pattern\")\n",
+    "my_pattern_function = client.get(\"my-first-pattern\")\n",
     "my_pattern_function"
    ]
   },
@@ -189,7 +188,7 @@
     {
      "data": {
       "text/plain": [
-       "<Job | 3148c695-0e48-4bfa-82ff-119288cfac00>"
+       "<Job | 50aaf775-7b14-40c9-bf35-51cb1f88fbe2>"
       ]
      },
      "execution_count": 5,
@@ -212,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "cc7ccea6-bbae-4184-ba7f-67b6c20a0b0b",
    "metadata": {},
    "outputs": [
@@ -222,7 +221,7 @@
        "'QUEUED'"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -241,21 +240,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "1dc78690-f61a-4dfe-bc0e-7007cf561a5b",
+   "execution_count": null,
+   "id": "ca05d063",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[{'0': 0.4999999999999999, '3': 0.4999999999999999}]"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "job.result()"
    ]
@@ -300,14 +288,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "id": "f24023e1-6ce4-481e-b43d-3e19bff81d57",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5a60a7e8d23f47eba55c583a5b679143",
+       "model_id": "96f50f9769514576a3a4499b5f2125a5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -315,13 +303,13 @@
        "Tab(children=(GridspecLayout(children=(Output(layout=Layout(grid_area='widget001')), Output(layout=Layout(grid…"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "serverless.widget()"
+    "client.widget()"
    ]
   },
   {
@@ -349,7 +337,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.19"
   }
  },
  "nbformat": 4,

--- a/docs/getting_started/basic/02_arguments_and_results.ipynb
+++ b/docs/getting_started/basic/02_arguments_and_results.ipynb
@@ -106,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -115,7 +115,7 @@
        "<gateway-client>"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -124,16 +124,16 @@
     "from qiskit_serverless import ServerlessClient\n",
     "import os\n",
     "\n",
-    "serverless = ServerlessClient(\n",
+    "client = ServerlessClient(\n",
     "    token=os.environ.get(\"GATEWAY_TOKEN\", \"awesome_token\"),\n",
     "    host=os.environ.get(\"GATEWAY_HOST\", \"http://localhost:8000\"),\n",
     ")\n",
-    "serverless"
+    "client"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -142,7 +142,7 @@
        "'pattern-with-arguments'"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -156,7 +156,7 @@
     "    working_dir=\"./source_files/\",\n",
     ")\n",
     "\n",
-    "serverless.upload(function)"
+    "client.upload(function)"
    ]
   },
   {
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -177,29 +177,28 @@
        "QiskitFunction(pattern-with-arguments)"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "functions = {f.title: f for f in serverless.list()}\n",
-    "my_function = functions.get(\"pattern-with-arguments\")\n",
+    "my_function = client.get(\"pattern-with-arguments\")\n",
     "my_function"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<Job | 1d087725-0f00-45e3-a56c-ccac10b551d2>"
+       "<Job | c937663c-b722-43a8-b14d-5ee843f63b7c>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -253,7 +252,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.19"
   }
  },
  "nbformat": 4,

--- a/docs/getting_started/basic/03_dependencies.ipynb
+++ b/docs/getting_started/basic/03_dependencies.ipynb
@@ -80,7 +80,7 @@
     {
      "data": {
       "text/plain": [
-       "<ServerlessProvider: gateway-provider>"
+       "<gateway-client>"
       ]
      },
      "execution_count": 2,
@@ -92,11 +92,11 @@
     "from qiskit_serverless import ServerlessClient\n",
     "import os\n",
     "\n",
-    "serverless = ServerlessClient(\n",
+    "client = ServerlessClient(\n",
     "    token=os.environ.get(\"GATEWAY_TOKEN\", \"awesome_token\"),\n",
     "    host=os.environ.get(\"GATEWAY_HOST\", \"http://localhost:8000\"),\n",
     ")\n",
-    "serverless"
+    "client"
    ]
   },
   {
@@ -107,7 +107,7 @@
     {
      "data": {
       "text/plain": [
-       "'pattern-with-dependencies'"
+       "QiskitFunction(pattern-with-dependencies)"
       ]
      },
      "execution_count": 4,
@@ -116,18 +116,30 @@
     }
    ],
    "source": [
-    "serverless.upload(function)\n",
-    "functions = {f.title: f for f in serverless.list()}\n",
-    "my_pattern_function = functions.get(\"pattern-with-dependencies\")"
+    "client.upload(function)\n",
+    "my_pattern_function = client.get(\"pattern-with-dependencies\")\n",
+    "my_pattern_function"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Job | 5c579361-13e6-4d7c-9fc3-98e0b57ae232>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "job = my_pattern_function.run()"
+    "job = my_pattern_function.run()\n",
+    "job"
    ]
   },
   {
@@ -187,7 +199,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.19"
   }
  },
  "nbformat": 4,

--- a/docs/getting_started/basic/04_distributed_workloads.ipynb
+++ b/docs/getting_started/basic/04_distributed_workloads.ipynb
@@ -78,7 +78,7 @@
     {
      "data": {
       "text/plain": [
-       "<ServerlessProvider: gateway-provider>"
+       "<gateway-client>"
       ]
      },
      "execution_count": 1,
@@ -90,12 +90,12 @@
     "from qiskit_serverless import ServerlessClient\n",
     "import os\n",
     "\n",
-    "serverless = ServerlessClient(\n",
+    "client = ServerlessClient(\n",
     "    token=os.environ.get(\"GATEWAY_TOKEN\", \"awesome_token\"),\n",
     "    host=os.environ.get(\"GATEWAY_HOST\", \"http://localhost:8000\"),\n",
     ")\n",
     "\n",
-    "serverless"
+    "client"
    ]
   },
   {
@@ -113,9 +113,9 @@
     {
      "data": {
       "text/plain": [
-       "[<qiskit.circuit.quantumcircuit.QuantumCircuit at 0x7fa03049b850>,\n",
-       " <qiskit.circuit.quantumcircuit.QuantumCircuit at 0x7fa03049b880>,\n",
-       " <qiskit.circuit.quantumcircuit.QuantumCircuit at 0x7fa03049b3a0>]"
+       "[<qiskit.circuit.quantumcircuit.QuantumCircuit at 0x7fa4e8422cd0>,\n",
+       " <qiskit.circuit.quantumcircuit.QuantumCircuit at 0x7fa4e8422340>,\n",
+       " <qiskit.circuit.quantumcircuit.QuantumCircuit at 0x7fa5206e49d0>]"
       ]
      },
      "execution_count": 2,
@@ -163,7 +163,7 @@
     "    working_dir=\"./source_files/\",\n",
     ")\n",
     "\n",
-    "serverless.upload(function)"
+    "client.upload(function)"
    ]
   },
   {
@@ -174,7 +174,7 @@
     {
      "data": {
       "text/plain": [
-       "<Job | 721339ce-1409-4326-8263-e0fa6b0bb6a8>"
+       "<Job | 5917cac2-1937-4657-9bd3-4054cb1a61bd>"
       ]
      },
      "execution_count": 4,
@@ -183,7 +183,8 @@
     }
    ],
    "source": [
-    "job = serverless.run(\"pattern-with-parallel-workflow\", arguments={\"circuits\": circuits})\n",
+    "parallel_function = client.get(\"pattern-with-parallel-workflow\")\n",
+    "job = parallel_function.run(circuits=circuits)\n",
     "job"
    ]
   },
@@ -246,7 +247,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.19"
   }
  },
  "nbformat": 4,

--- a/docs/getting_started/basic/05_retrieving_past_results.ipynb
+++ b/docs/getting_started/basic/05_retrieving_past_results.ipynb
@@ -29,7 +29,7 @@
     {
      "data": {
       "text/plain": [
-       "<ServerlessProvider: gateway-provider>"
+       "<gateway-client>"
       ]
      },
      "execution_count": 1,
@@ -41,11 +41,11 @@
     "from qiskit_serverless import ServerlessClient\n",
     "import os\n",
     "\n",
-    "serverless = ServerlessClient(\n",
+    "client = ServerlessClient(\n",
     "    token=os.environ.get(\"GATEWAY_TOKEN\", \"awesome_token\"),\n",
     "    host=os.environ.get(\"GATEWAY_HOST\", \"http://localhost:8000\"),\n",
     ")\n",
-    "serverless"
+    "client"
    ]
   },
   {
@@ -61,17 +61,33 @@
    "execution_count": 2,
    "id": "d51df836-3f22-467c-b637-5803145d5d8a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(<Job | 45493849-444d-4fd2-9221-5e30e6061b60>,\n",
+       " <Job | c124c352-93af-42ae-ab2a-1bc8b192d894>)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from qiskit_serverless import QiskitFunction\n",
     "\n",
     "function = QiskitFunction(\n",
     "    title=\"pattern-to-fetch-results\", entrypoint=\"pattern.py\", working_dir=\"./source_files/\"\n",
     ")\n",
-    "serverless.upload(function)\n",
+    "client.upload(function)\n",
     "\n",
-    "job1 = serverless.run(\"pattern-to-fetch-results\")\n",
-    "job2 = serverless.run(\"pattern-to-fetch-results\")"
+    "my_function = client.get(\"pattern-to-fetch-results\")\n",
+    "\n",
+    "job1 = my_function.run()\n",
+    "job2 = my_function.run()\n",
+    "\n",
+    "job1, job2"
    ]
   },
   {
@@ -138,8 +154,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "retrieved_job1 = serverless.get_job_by_id(job_id1)\n",
-    "retrieved_job2 = serverless.get_job_by_id(job_id2)"
+    "retrieved_job1 = client.get_job_by_id(job_id1)\n",
+    "retrieved_job2 = client.get_job_by_id(job_id2)"
    ]
   },
   {
@@ -228,7 +244,7 @@
     }
    ],
    "source": [
-    "serverless.get_jobs(limit=2, offset=1)"
+    "client.get_jobs(limit=2, offset=1)"
    ]
   }
  ],
@@ -248,7 +264,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.19"
   }
  },
  "nbformat": 4,

--- a/gateway/api/views.py
+++ b/gateway/api/views.py
@@ -111,6 +111,7 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
 
     def get_queryset(self):
         author = self.request.user
+        title = self.request.query_params.get("title")
 
         logger.info("ProgramViewSet get view_program permission")
         view_program_permission = Permission.objects.get(
@@ -137,9 +138,15 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
         author_groups_with_view_permissions_criteria = Q(
             instances__in=author_groups_with_view_permissions
         )
-        author_programs = Program.objects.filter(
-            author_criteria | author_groups_with_view_permissions_criteria
-        ).distinct()
+        if title:
+            author_programs = Program.objects.filter(
+                (author_criteria | author_groups_with_view_permissions_criteria)
+                & Q(title=title)
+            ).distinct()
+        else:
+            author_programs = Program.objects.filter(
+                author_criteria | author_groups_with_view_permissions_criteria
+            ).distinct()
         author_programs_count = author_programs.count()
         logger.info(
             "ProgramViewSet get author[%s] programs[%s]",

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -57,6 +57,28 @@ class TestProgramApi(APITestCase):
             "Docker Image Program",
         )
 
+    def test_program_list_with_title_query_parameter(self):
+        """Tests program list filtered with title."""
+        user = models.User.objects.get(username="test_user")
+        self.client.force_authenticate(user=user)
+
+        programs_response = self.client.get(
+            reverse("v1:programs-list"), {"title": "Program"}, format="json"
+        )
+
+        self.assertEqual(programs_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(programs_response.data), 1)
+        self.assertEqual(
+            programs_response.data[0].get("title"),
+            "Program",
+        )
+
+        empty_programs_response = self.client.get(
+            reverse("v1:programs-list"), {"title": "Non existing name"}, format="json"
+        )
+        self.assertEqual(empty_programs_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(empty_programs_response.data), 0)
+
     def test_run(self):
         """Tests run existing authorized."""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Get function by name using client

```python

client = ServerlessClient(...)

my_function = client.get("my-function")
# <QiskitFunction "my-function">

job = my_function.run()

```

### Details and comments

List programs got feature to filter by `title` field. So, `get` client method is reusing this endpoint. It already had all access policies, so it make code changes pretty neat. And also it avoids problems with unique migrations, etc.

Closes #1314 