### PR TITLE
add resources to gateway and scheduler containers

### DIFF
--- a/.github/workflows/kubernetes-deploy.yaml
+++ b/.github/workflows/kubernetes-deploy.yaml
@@ -53,6 +53,7 @@ jobs:
             --set gateway.application.ray.cpu=1 \
             --set gateway.application.limits.keepClusterOnComplete=false \
             .
+          sleep 120
       - name: setup python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/kubernetes-deploy.yaml
+++ b/.github/workflows/kubernetes-deploy.yaml
@@ -53,7 +53,8 @@ jobs:
             --set gateway.application.ray.cpu=1 \
             --set gateway.application.limits.keepClusterOnComplete=false \
             .
-          sleep 120
+          GATEWAY=$(kubectl get pod -l app.kubernetes.io/name=gateway -o name)
+          kubectl wait --for=condition=Ready "$GATEWAY" --timeout 5m 
       - name: setup python
         uses: actions/setup-python@v4
         with:

--- a/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
+++ b/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
@@ -78,6 +78,8 @@ spec:
             httpGet:
               path: /readiness
               port: http
+            initialDelaySeconds: 60
+            periodSeconds: 20
           volumeMounts:
             - mountPath: "/usr/src/app/media/"
               name: gateway-pv-storage
@@ -253,6 +255,8 @@ spec:
               name: gateway-pv-storage
             - mountPath: "/tmp/templates/"
               name: ray-cluster-template
+          resources:
+            {{- toYaml .Values.scheduler.resources | nindent 12 }}
           env:
             - name: DEBUG
               value: {{ .Values.application.debug | quote }}

--- a/charts/qiskit-serverless/charts/gateway/values.yaml
+++ b/charts/qiskit-serverless/charts/gateway/values.yaml
@@ -145,17 +145,21 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  limits:
+    cpu: "1500m"
+    memory: "1Gi"
+  requests:
+    cpu: "500m"
+    memory: "700Mi"
+scheduler:
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "270Mi"
+    requests:
+      cpu: "100m"
+      memory: "180Mi"
 
 autoscaling:
   enabled: false

--- a/charts/qiskit-serverless/charts/gateway/values.yaml
+++ b/charts/qiskit-serverless/charts/gateway/values.yaml
@@ -155,7 +155,7 @@ resources:
 scheduler:
   resources:
     limits:
-      cpu: "500m"
+      cpu: "1500m"
       memory: "270Mi"
     requests:
       cpu: "100m"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR adds `resources` in gateway and scheduler containers.

The `cpu` `limits` for gateway affects the startup time of the gateway pod.  The `readiness` probe configuration is changed to work with the  `cpu` `limits` value in this PR.


### Details and comments

