### PR TITLE
Client: get method with provider arguments

### DIFF
--- a/client/qiskit_serverless/core/client.py
+++ b/client/qiskit_serverless/core/client.py
@@ -499,17 +499,7 @@ class ServerlessClient(BaseClient):
     def get(
         self, title: str, provider: Optional[str] = None
     ) -> Optional[QiskitFunction]:
-        results = self._job_client.get_programs(title=title, provider=provider)
-        if len(results) > 1:
-            warnings.warn(
-                f"There are more than 1 program with title {title}"
-                "available. Returning most recent one. "
-                "If you want to get list of all functions "
-                "please, use `list` method."
-            )
-
-        functions = {function.title: function for function in results}
-        return functions.get(title)
+        return self._job_client.get_program(title=title, provider=provider)
 
     def _verify_token(self, token: str):
         """Verify token."""

--- a/client/qiskit_serverless/core/client.py
+++ b/client/qiskit_serverless/core/client.py
@@ -358,7 +358,9 @@ class BaseClient(JsonSerializable):
         """Returns list of available programs."""
         raise NotImplementedError
 
-    def get(self, title: str) -> Optional[QiskitFunction]:
+    def get(
+        self, title: str, provider: Optional[str] = None
+    ) -> Optional[QiskitFunction]:
         """Returns qiskit function based on title provided."""
         raise NotImplementedError
 
@@ -494,8 +496,10 @@ class ServerlessClient(BaseClient):
         """Returns list of available programs."""
         return self._job_client.get_programs(**kwargs)
 
-    def get(self, title: str) -> Optional[QiskitFunction]:
-        results = self._job_client.get_programs(title=title)
+    def get(
+        self, title: str, provider: Optional[str] = None
+    ) -> Optional[QiskitFunction]:
+        results = self._job_client.get_programs(title=title, provider=provider)
         if len(results) > 1:
             warnings.warn(
                 f"There are more than 1 program with title {title}"
@@ -744,7 +748,9 @@ class LocalClient(BaseClient):
     def list(self, **kwargs):
         return self.client.get_programs(**kwargs)
 
-    def get(self, title: str) -> Optional[QiskitFunction]:
+    def get(
+        self, title: str, provider: Optional[str] = None
+    ) -> Optional[QiskitFunction]:
         functions = {
             function.title: function for function in self.client.get_programs()
         }

--- a/client/qiskit_serverless/core/job.py
+++ b/client/qiskit_serverless/core/job.py
@@ -70,6 +70,7 @@ from qiskit_serverless.serializers.program_serializers import (
     QiskitObjectsDecoder,
 )
 from qiskit_serverless.utils.json import is_jsonable, safe_json_request
+from qiskit_serverless.utils.formatting import format_provider_name_and_title
 
 RuntimeEnv = ray.runtime_env.RuntimeEnv
 
@@ -587,6 +588,10 @@ class GatewayJobClient(BaseJobClient):
         self, title: str, provider: Optional[str] = None
     ) -> Optional[QiskitFunction]:
         """Returns program based on parameters."""
+        provider, title = format_provider_name_and_title(
+            request_provider=provider, title=title
+        )
+
         tracer = trace.get_tracer("client.tracer")
         with tracer.start_as_current_span("program.get_by_title"):
             response_data = safe_json_request(

--- a/client/qiskit_serverless/utils/__init__.py
+++ b/client/qiskit_serverless/utils/__init__.py
@@ -27,8 +27,10 @@ Qiskit Serverless utilities
     S3Storage
     ErrorCodes
     JsonSerializable
+    format_provider_name_and_title
 """
 
 from .json import JsonSerializable
 from .errors import ErrorCodes
 from .storage import S3Storage, BaseStorage
+from .formatting import format_provider_name_and_title

--- a/client/qiskit_serverless/utils/formatting.py
+++ b/client/qiskit_serverless/utils/formatting.py
@@ -1,0 +1,44 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+==========================================================
+Json utilities (:mod:`qiskit_serverless.utils.formatting`)
+==========================================================
+
+.. currentmodule:: qiskit_serverless.utils.formatting
+
+Qiskit Serverless formatting utilities
+======================================
+
+.. autosummary::
+    :toctree: ../stubs/
+
+    format_provider_name_and_title
+"""
+from typing import Tuple, Union
+
+
+def format_provider_name_and_title(
+    request_provider, title
+) -> Tuple[Union[str, None], str]:
+    """
+    This method returns provider_name and title from a title with / if it contains it
+    """
+    if request_provider:
+        return request_provider, title
+
+    title_split = title.split("/")
+    if len(title_split) == 1:
+        return None, title_split[0]
+
+    return title_split[0], title_split[1]

--- a/gateway/api/views.py
+++ b/gateway/api/views.py
@@ -112,10 +112,12 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
     def get_queryset(self):
         author = self.request.user
         title = self.request.query_params.get("title")
-        provider = self.request.query_params.get("provider")
+        provider_name = self.request.query_params.get("provider")
 
         serializer = self.get_serializer_upload_program(data=self.request.data)
-        provider, title = serializer.get_provider_name_and_title(provider, title)
+        provider_name, title = serializer.get_provider_name_and_title(
+            provider_name, title
+        )
 
         logger.info("ProgramViewSet get view_program permission")
         view_program_permission = Permission.objects.get(
@@ -144,8 +146,8 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
         )
         if title:
             title_criteria = Q(title=title)
-            if provider:
-                title_criteria = Q(title=title, provider__name=provider)
+            if provider_name:
+                title_criteria = Q(title=title, provider__name=provider_name)
             author_programs = Program.objects.filter(
                 (author_criteria | author_groups_with_view_permissions_criteria)
                 & title_criteria

--- a/gateway/api/views.py
+++ b/gateway/api/views.py
@@ -114,11 +114,6 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
         title = self.request.query_params.get("title")
         provider_name = self.request.query_params.get("provider")
 
-        serializer = self.get_serializer_upload_program(data=self.request.data)
-        provider_name, title = serializer.get_provider_name_and_title(
-            provider_name, title
-        )
-
         logger.info("ProgramViewSet get view_program permission")
         view_program_permission = Permission.objects.get(
             codename=VIEW_PROGRAM_PERMISSION
@@ -145,6 +140,10 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
             instances__in=author_groups_with_view_permissions
         )
         if title:
+            serializer = self.get_serializer_upload_program(data=self.request.data)
+            provider_name, title = serializer.get_provider_name_and_title(
+                provider_name, title
+            )
             title_criteria = Q(title=title)
             if provider_name:
                 title_criteria = Q(title=title, provider__name=provider_name)

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -79,6 +79,56 @@ class TestProgramApi(APITestCase):
         self.assertEqual(empty_programs_response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(empty_programs_response.data), 0)
 
+    def test_program_list_with_title_query_title_and_provider(self):
+        """Tests program list filtered with title."""
+        user = models.User.objects.get(username="test_user_2")
+        self.client.force_authenticate(user=user)
+
+        programs_response = self.client.get(
+            reverse("v1:programs-list"),
+            {"title": "Docker Image Program"},
+            format="json",
+        )
+
+        self.assertEqual(programs_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(programs_response.data), 1)
+        self.assertEqual(programs_response.data[0].get("provider"), "default")
+
+        programs_response_with_provider = self.client.get(
+            reverse("v1:programs-list"),
+            {"title": "default/Docker Image Program"},
+            format="json",
+        )
+        self.assertEqual(
+            programs_response_with_provider.status_code, status.HTTP_200_OK
+        )
+        self.assertEqual(len(programs_response_with_provider.data), 1)
+        self.assertEqual(
+            programs_response_with_provider.data[0].get("provider"), "default"
+        )
+
+        programs_response_with_provider_as_parameter = self.client.get(
+            reverse("v1:programs-list"),
+            {"title": "Docker Image Program", "provider": "default"},
+            format="json",
+        )
+        self.assertEqual(
+            programs_response_with_provider_as_parameter.status_code, status.HTTP_200_OK
+        )
+        self.assertEqual(len(programs_response_with_provider_as_parameter.data), 1)
+        self.assertEqual(
+            programs_response_with_provider_as_parameter.data[0].get("provider"),
+            "default",
+        )
+
+        programs_response_empty = self.client.get(
+            reverse("v1:programs-list"),
+            {"title": "Docker Image Program", "provider": "non-existing-provider"},
+            format="json",
+        )
+        self.assertEqual(programs_response_empty.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(programs_response_empty.data), 0)
+
     def test_run(self):
         """Tests run existing authorized."""
 

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -54,7 +54,7 @@ class TestProgramApi(APITestCase):
         )
         self.assertEqual(
             programs_response.data[0].get("title"),
-            "Docker Image Program",
+            "Docker-Image-Program",
         )
 
     def test_program_list_with_title_query_parameter(self):
@@ -86,7 +86,7 @@ class TestProgramApi(APITestCase):
 
         programs_response = self.client.get(
             reverse("v1:programs-list"),
-            {"title": "Docker Image Program"},
+            {"title": "Docker-Image-Program"},
             format="json",
         )
 
@@ -96,7 +96,7 @@ class TestProgramApi(APITestCase):
 
         programs_response_with_provider = self.client.get(
             reverse("v1:programs-list"),
-            {"title": "default/Docker Image Program"},
+            {"title": "default/Docker-Image-Program"},
             format="json",
         )
         self.assertEqual(
@@ -109,7 +109,7 @@ class TestProgramApi(APITestCase):
 
         programs_response_with_provider_as_parameter = self.client.get(
             reverse("v1:programs-list"),
-            {"title": "Docker Image Program", "provider": "default"},
+            {"title": "Docker-Image-Program", "provider": "default"},
             format="json",
         )
         self.assertEqual(
@@ -123,7 +123,7 @@ class TestProgramApi(APITestCase):
 
         programs_response_empty = self.client.get(
             reverse("v1:programs-list"),
-            {"title": "Docker Image Program", "provider": "non-existing-provider"},
+            {"title": "Docker-Image-Program", "provider": "non-existing-provider"},
             format="json",
         )
         self.assertEqual(programs_response_empty.status_code, status.HTTP_200_OK)
@@ -384,3 +384,37 @@ class TestProgramApi(APITestCase):
             format="json",
         )
         self.assertEqual(programs_response.json(), '["runtime_job_3"]')
+
+    def test_get_by_title(self):
+        user = models.User.objects.get(username="test_user_2")
+        self.client.force_authenticate(user=user)
+        programs_response = self.client.get(
+            "/api/v1/programs/get_by_title/Docker-Image-Program/",
+            format="json",
+        )
+        self.assertEqual(programs_response.data.get("provider"), "default")
+        self.assertIsNotNone(programs_response.data.get("title"))
+
+        programs_response_with_provider = self.client.get(
+            "/api/v1/programs/get_by_title/Docker-Image-Program/",
+            {"provider": "default"},
+            format="json",
+        )
+        self.assertEqual(
+            programs_response_with_provider.data.get("provider"), "default"
+        )
+        self.assertIsNotNone(programs_response_with_provider.data.get("title"))
+
+        programs_response_non_existing_provider = self.client.get(
+            "/api/v1/programs/get_by_title/Docker-Image-Program/",
+            {"provider": "non-existing"},
+            format="json",
+        )
+        self.assertEqual(programs_response_non_existing_provider.status_code, 404)
+
+        programs_response_do_not_have_access = self.client.get(
+            "/api/v1/programs/get_by_title/Program/",
+            {"provider": "non-existing"},
+            format="json",
+        )
+        self.assertEqual(programs_response_do_not_have_access.status_code, 404)

--- a/gateway/tests/fixtures/fixtures.json
+++ b/gateway/tests/fixtures/fixtures.json
@@ -60,7 +60,7 @@
     "pk": "6160a2ff-e482-443d-af23-15110b646ae2",
     "fields": {
       "created": "2023-02-01T15:30:43.281796Z",
-      "title": "Docker Image Program",
+      "title": "Docker-Image-Program",
       "image": "icr.io/awesome-namespace/awesome-title",
       "author": 2,
       "env_vars": "{\"PROGRAM_ENV1\": \"VALUE1\", \"PROGRAM_ENV2\": \"VALUE2\"}",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Follow up to https://github.com/Qiskit/qiskit-serverless/pull/1352

Adding provider argument to `get` method.

```python
client = ...

function = client.get("my-func")
function = client.get("default/my-func")
function = client.get(title="my-func", provider="default")
```
