### PR TITLE
migrate links from qiskit-extensions to qiskit

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,4 +17,4 @@ authors:
 title: "Qiskit Serverless"
 version: 0.0.3
 date-released: 2023-02-14
-url: "https://github.com/Qiskit-Extensions/qiskit-serverless"
+url: "https://github.com/Qiskit/qiskit-serverless"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ There are tons of useful resources about Git [out there](https://try.github.io/)
 
 ## Opening issues
 
-You can [open 3 types of issues](https://github.com/Qiskit-Extensions/qiskit-serverless/issues/new/choose):
+You can [open 3 types of issues](https://github.com/Qiskit/qiskit-serverless/issues/new/choose):
 
 * Bug reports: for reporting a misfunction. Provide steps to reproduce and expected behaviour.
 * Enhancement request: to suggest improvements to the current code.
@@ -109,10 +109,10 @@ nerdctl images
 ### Deciding what to work on
 
 To give our collaborators an idea of where the team needs help, we use the
-[help wanted](https://github.com/Qiskit-Extensions/qiskit-serverless/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
+[help wanted](https://github.com/Qiskit/qiskit-serverless/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
 label – this is appropriate for all contributors. In addition, for those who are relatively new to the open-source
 workflow or our codebase, feel free to view issues tagged with the
-[good first issue](https://github.com/Qiskit-Extensions/qiskit-serverless/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+[good first issue](https://github.com/Qiskit/qiskit-serverless/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
 label.
 
 
@@ -131,7 +131,7 @@ track this repository. A typical Git setup after
 # After forking the repository in GitHub
 git clone https://github.com/<your_username>/qiskit-serverless.git
 cd qiskit-serverless
-git remote add upstream https://github.com/Qiskit-Extensions/qiskit-serverless.git
+git remote add upstream https://github.com/Qiskit/qiskit-serverless.git
 git remote set-url --push upstream no_push
 git remote update upstream
 git checkout main

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Stability](https://img.shields.io/badge/stability-alpha-f4d03f.svg)](https://github.com/Qiskit-Extensions/qiskit-serverless/releases)
+[![Stability](https://img.shields.io/badge/stability-alpha-f4d03f.svg)](https://github.com/Qiskit/qiskit-serverless/releases)
 [![License](https://img.shields.io/github/license/qiskit-community/quantum-prototype-template?label=License)](https://github.com/qiskit-community/quantum-prototype-template/blob/main/LICENSE.txt)
 [![Code style: Black](https://img.shields.io/badge/Code%20style-Black-000.svg)](https://github.com/psf/black)
 [![Python](https://img.shields.io/badge/Python-3.9%20%7C%203.10-informational)](https://www.python.org/)
@@ -45,7 +45,7 @@ For user convenience, this section assumes that users will deploy the infrastruc
       ```
    1. Clone the Qiskit Serverless repository
       ```shell
-      git clone https://github.com/Qiskit-Extensions/qiskit-serverless.git
+      git clone https://github.com/Qiskit/qiskit-serverless.git
       ```
    1. Run QiskitServerless infrastructure
       Execute Docker Compose using the following commands.
@@ -75,10 +75,10 @@ For user convenience, this section assumes that users will deploy the infrastruc
    This will open the Jupyter Lab environment in your web browser.
 1. Write your first example Qiskit Pattern.
    In the JupyterLab, create a new file, `pattern.py`, in the `work` directory. You can include any arbitrary Python code in your program, or you can use the
-   [example Python file in this tutorial](https://github.com/Qiskit-Extensions/qiskit-serverless/blob/main/docs/getting_started/basic/01_running_program.ipynb).
+   [example Python file in this tutorial](https://github.com/Qiskit/qiskit-serverless/blob/main/docs/getting_started/basic/01_running_program.ipynb).
 
 1. Run the program
-   In the JupyterLab, create a new notebook in the same directory as your program, and execute [the tutorial code](https://github.com/Qiskit-Extensions/qiskit-serverless/blob/main/docs/getting_started/basic/01_running_program.ipynb).
+   In the JupyterLab, create a new notebook in the same directory as your program, and execute [the tutorial code](https://github.com/Qiskit/qiskit-serverless/blob/main/docs/getting_started/basic/01_running_program.ipynb).
 
    You can check the job status and get the result.
 
@@ -96,19 +96,19 @@ For user convenience, this section assumes that users will deploy the infrastruc
 
    That's all!
 
-For more detailed examples and explanations refer to the [Guide](https://qiskit-extensions.github.io/qiskit-serverless/index.html):
+For more detailed examples and explanations refer to the [Guide](https://qiskit.github.io/qiskit-serverless/index.html):
 
-1. [Getting Started](https://qiskit-extensions.github.io/qiskit-serverless/getting_started/index.html#)
-1. [Example Qiskit Patterns](https://qiskit-extensions.github.io/qiskit-serverless/examples/index.html)
-1. [Infrastructure](https://qiskit-extensions.github.io/qiskit-serverless/deployment/index.html)
-1. [Migrating from Qiskit Runtime programs](https://qiskit-extensions.github.io/qiskit-serverless/migration/index.html)
+1. [Getting Started](https://qiskit.github.io/qiskit-serverless/getting_started/index.html#)
+1. [Example Qiskit Patterns](https://qiskit.github.io/qiskit-serverless/examples/index.html)
+1. [Infrastructure](https://qiskit.github.io/qiskit-serverless/deployment/index.html)
+1. [Migrating from Qiskit Runtime programs](https://qiskit.github.io/qiskit-serverless/migration/index.html)
 
 ----------------------------------------------------------------------------------------------------
 
 ### How to Give Feedback
 
 We encourage your feedback! You can share your thoughts with us by:
-- Opening an [issue](https://github.com/Qiskit-Extensions/qiskit-serverless/issues) in the repository
+- Opening an [issue](https://github.com/Qiskit/qiskit-serverless/issues) in the repository
 
 
 ----------------------------------------------------------------------------------------------------

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 To report vulnerabilities, you can privately report a potential security issue
 via the Github security vulnerabilities feature. This can be done here:
 
-https://github.com/Qiskit-Extensions/qiskit-serverless/security/advisories
+https://github.com/Qiskit/qiskit-serverless/security/advisories
 
 Please do **not** open a public issue about a potential security vulnerability.
 

--- a/client/README.md
+++ b/client/README.md
@@ -1,5 +1,5 @@
-[![Stability](https://img.shields.io/badge/stability-alpha-f4d03f.svg)](https://github.com/Qiskit-Extensions/qiskit-serverless/releases)
-[![Client verify process](https://github.com/Qiskit-Extensions/qiskit-serverless/actions/workflows/client-verify.yaml/badge.svg)](https://github.com/Qiskit-Extensions/qiskit-serverless/actions/workflows/client-verify.yaml)
+[![Stability](https://img.shields.io/badge/stability-alpha-f4d03f.svg)](https://github.com/Qiskit/qiskit-serverless/releases)
+[![Client verify process](https://github.com/Qiskit/qiskit-serverless/actions/workflows/client-verify.yaml/badge.svg)](https://github.com/Qiskit/qiskit-serverless/actions/workflows/client-verify.yaml)
 [![License](https://img.shields.io/github/license/qiskit-community/quantum-prototype-template?label=License)](https://github.com/qiskit-community/quantum-prototype-template/blob/main/LICENSE.txt)
 [![Code style: Black](https://img.shields.io/badge/Code%20style-Black-000.svg)](https://github.com/psf/black)
 [![Python](https://img.shields.io/badge/Python-3.9%20%7C%203.10-informational)](https://www.python.org/)
@@ -7,7 +7,7 @@
 
 # Qiskit Serverless client
 
-![diagram](https://raw.githubusercontent.com/Qiskit-Extensions/qiskit-serverless/main/docs/images/qs_diagram.png)
+![diagram](https://raw.githubusercontent.com/Qiskit/qiskit-serverless/main/docs/images/qs_diagram.png)
 
 # Installation
 
@@ -17,7 +17,7 @@ pip install qiskit_serverless
 
 ## Documentation
 
-Full docs can be found at https://qiskit-extensions.github.io/qiskit-serverless/
+Full docs can be found at https://qiskit.github.io/qiskit-serverless/
 
 ## Usage
 

--- a/docs/deployment/cloud.rst
+++ b/docs/deployment/cloud.rst
@@ -86,7 +86,7 @@ and run the next commands:
 .. code-block::
    :caption: run this commands with the release version like 0.12.0 in x.y.z (2 places)
 
-        $ helm -n <INSERT_YOUR_NAMESPACE> install qiskit-serverless --create-namespace https://github.com/Qiskit-Extensions/qiskit-serverless/releases/download/vx.y.z/qiskit-serverless-x.y.z.tgz
+        $ helm -n <INSERT_YOUR_NAMESPACE> install qiskit-serverless --create-namespace https://github.com/Qiskit/qiskit-serverless/releases/download/vx.y.z/qiskit-serverless-x.y.z.tgz
 
 This will deploy the required components to your cluster.
 
@@ -111,7 +111,7 @@ Now that we have the desired services, we can expose their ports:
 Now you may access your cluster services from localhost.
 
 For development this is more than enough, but if you are considering deploying it remotely you will need to
-configure the various ``ingress`` properties in `values.yaml <https://github.com/Qiskit-Extensions/qiskit-serverless/blob/main/charts/qiskit-serverless/values.yaml>`_
+configure the various ``ingress`` properties in `values.yaml <https://github.com/Qiskit/qiskit-serverless/blob/main/charts/qiskit-serverless/values.yaml>`_
 with the configuration of your domain and provider.
 
 * **Important**: ``nginx-ingress-controller`` is disabled by default because third party providers should provide its own Ingress controller. To use it locally you need to activate it too.
@@ -121,4 +121,4 @@ Optionally, you can install an observability package to handle logging and monit
 .. code-block::
    :caption: run this commands with the release version like 0.12.0 in x.y.z (2 places) using the same namespace as in the previous helm command
 
-        $ helm -n <INSERT_YOUR_NAMESPACE> install qs-observability  https://github.com/Qiskit-Extensions/qiskit-serverless/releases/download/vx.y.z/qs-observability-x.y.z.tgz
+        $ helm -n <INSERT_YOUR_NAMESPACE> install qs-observability  https://github.com/Qiskit/qiskit-serverless/releases/download/vx.y.z/qs-observability-x.y.z.tgz

--- a/docs/deployment/local.rst
+++ b/docs/deployment/local.rst
@@ -29,7 +29,7 @@ on your local machine straightforward. The first thing we will do is clone the r
    :caption: Clone the Qiskit Serverless repository.
 
       cd /path/to/workspace/
-      git clone git@github.com:Qiskit-Extensions/qiskit-serverless.git
+      git clone git@github.com:Qiskit/qiskit-serverless.git
 
 Step 2: Set up Docker
 

--- a/docs/getting_started/basic/01_running_program.ipynb
+++ b/docs/getting_started/basic/01_running_program.ipynb
@@ -65,7 +65,7 @@
    "id": "7ac24f62-8487-47fb-9805-66f2192953d4",
    "metadata": {},
    "source": [
-    "> &#x26A0; This provider is set up with default credentials to a test cluster intended to run on your machine. For information on setting up infrastructure on your local machine, check out the guide on [local infrastructure setup](https://qiskit-extensions.github.io/qiskit-serverless/deployment/local.html)."
+    "> &#x26A0; This provider is set up with default credentials to a test cluster intended to run on your machine. For information on setting up infrastructure on your local machine, check out the guide on [local infrastructure setup](https://qiskit.github.io/qiskit-serverless/deployment/local.html)."
    ]
   },
   {
@@ -206,7 +206,7 @@
    "id": "39ee31d2-3553-4e19-bcb9-4cccd0df0e4c",
    "metadata": {},
    "source": [
-    "[Job](https://qiskit-extensions.github.io/qiskit-serverless/stubs/qiskit_serverless.core.Job.html#qiskit_serverless.core.Job) instances have a `status()` method to check status of pattern execution."
+    "[Job](https://qiskit.github.io/qiskit-serverless/stubs/qiskit_serverless.core.Job.html#qiskit_serverless.core.Job) instances have a `status()` method to check status of pattern execution."
    ]
   },
   {

--- a/docs/getting_started/basic/02_arguments_and_results.ipynb
+++ b/docs/getting_started/basic/02_arguments_and_results.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "Let's create another file with our pattern [./source_files/pattern_with_arguments.py](./source_files/pattern_with_arguments.py). \n",
     "\n",
-    "Instead of having the circuit defined inside the pattern (like we did in first example), we will pass it as an argument. We will also save the results, so we can access them later by calling [save_result](https://qiskit-extensions.github.io/qiskit-serverless/stubs/qiskit_serverless.core.save_result.html#qiskit_serverless.core.save_result).\n",
+    "Instead of having the circuit defined inside the pattern (like we did in first example), we will pass it as an argument. We will also save the results, so we can access them later by calling [save_result](https://qiskit.github.io/qiskit-serverless/stubs/qiskit_serverless.core.save_result.html#qiskit_serverless.core.save_result).\n",
     "\n",
     "Here is the pattern:\n",
     "\n",
@@ -39,7 +39,7 @@
     "})\n",
     "```\n",
     "\n",
-    "As you can see, the circuit construction is not inside the pattern anymore. Instead, we parse the arguments by calling the [get_arguments](https://qiskit-extensions.github.io/qiskit-serverless/stubs/qiskit_serverless.serializers.get_arguments.html#qiskit_serverless.serializers.get_arguments) function."
+    "As you can see, the circuit construction is not inside the pattern anymore. Instead, we parse the arguments by calling the [get_arguments](https://qiskit.github.io/qiskit-serverless/stubs/qiskit_serverless.serializers.get_arguments.html#qiskit_serverless.serializers.get_arguments) function."
    ]
   },
   {
@@ -101,7 +101,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> &#x26A0; This provider is set up with default credentials to a test cluster intended to run on your machine. For information on setting up infrastructure on your local machine, check out the guide on [local infrastructure setup](https://qiskit-extensions.github.io/qiskit-serverless/deployment/local.html)."
+    "> &#x26A0; This provider is set up with default credentials to a test cluster intended to run on your machine. For information on setting up infrastructure on your local machine, check out the guide on [local infrastructure setup](https://qiskit.github.io/qiskit-serverless/deployment/local.html)."
    ]
   },
   {

--- a/docs/getting_started/basic/03_dependencies.ipynb
+++ b/docs/getting_started/basic/03_dependencies.ipynb
@@ -69,7 +69,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> &#x26A0; This provider is set up with default credentials to a test cluster intended to run on your machine. For information on setting up infrastructure on your local machine, check out the guide on [local infrastructure setup](https://qiskit-extensions.github.io/qiskit-serverless/deployment/local.html)."
+    "> &#x26A0; This provider is set up with default credentials to a test cluster intended to run on your machine. For information on setting up infrastructure on your local machine, check out the guide on [local infrastructure setup](https://qiskit.github.io/qiskit-serverless/deployment/local.html)."
    ]
   },
   {

--- a/docs/getting_started/basic/04_distributed_workloads.ipynb
+++ b/docs/getting_started/basic/04_distributed_workloads.ipynb
@@ -46,19 +46,19 @@
     "\n",
     "There are a lot of new concepts introduced in this pattern, so let's go over them in more detail:\n",
     "\n",
-    "The [distribute_task](https://qiskit-extensions.github.io/qiskit-serverless/stubs/qiskit_serverless.core.distribute_task.html#qiskit_serverless.core.distribute_task) decorator converts a function into a distributed task. This means that the function will be executed on compute resources asynchronously and in parallel to the main context of the pattern.\n",
+    "The [distribute_task](https://qiskit.github.io/qiskit-serverless/stubs/qiskit_serverless.core.distribute_task.html#qiskit_serverless.core.distribute_task) decorator converts a function into a distributed task. This means that the function will be executed on compute resources asynchronously and in parallel to the main context of the pattern.\n",
     "\n",
-    "When you call a converted function, it will return a reference to the function execution instead of the result. In order to get the result back, you need to call the [get](https://qiskit-extensions.github.io/qiskit-serverless/stubs/qiskit_serverless.core.get.html#qiskit_serverless.core.get) function on the function reference. `get` will wait until the function is finished and return the result of the function execution.\n",
+    "When you call a converted function, it will return a reference to the function execution instead of the result. In order to get the result back, you need to call the [get](https://qiskit.github.io/qiskit-serverless/stubs/qiskit_serverless.core.get.html#qiskit_serverless.core.get) function on the function reference. `get` will wait until the function is finished and return the result of the function execution.\n",
     "\n",
     "In the pattern above, we have applied the `distribute_task` decorator to the `distributed_sample` function. This function takes a `QuantumCircuit` as input and returns the quasi distribution for that circuit.\n",
     "\n",
-    "After we have defined the `distributed_sample` function, we read the circuits from the pattern arguments using the [get_arguments](https://qiskit-extensions.github.io/qiskit-serverless/stubs/qiskit_serverless.serializers.get_arguments.html#qiskit_serverless.serializers.get_arguments) function. We then call the `distributed_sample` function for each of the circuits, which creates a reference to each of the function executions.\n",
+    "After we have defined the `distributed_sample` function, we read the circuits from the pattern arguments using the [get_arguments](https://qiskit.github.io/qiskit-serverless/stubs/qiskit_serverless.serializers.get_arguments.html#qiskit_serverless.serializers.get_arguments) function. We then call the `distributed_sample` function for each of the circuits, which creates a reference to each of the function executions.\n",
     "\n",
     "These function executions will run in parallel on compute resources, and we get task references as the return type. We store these task references in the `sample_task_references` list.\n",
     "\n",
     "After we have created the task references for each of the function executions, we need to collect the results from these tasks. We do this by calling the `get` function on the list of task references, which waits until all the tasks have completed and returns the results.\n",
     "\n",
-    "Once we have the results, we can save them using the [save_result](https://qiskit-extensions.github.io/qiskit-serverless/stubs/qiskit_serverless.core.save_result.html#qiskit_serverless.core.save_result) function.\n",
+    "Once we have the results, we can save them using the [save_result](https://qiskit.github.io/qiskit-serverless/stubs/qiskit_serverless.core.save_result.html#qiskit_serverless.core.save_result) function.\n",
     "\n",
     "Essentially, this pattern reads the circuits from the pattern arguments, executes the `distributed_sample` function on each circuit in parallel, collects the results from the function executions, and saves the results."
    ]
@@ -67,7 +67,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> &#x26A0; This provider is set up with default credentials to a test cluster intended to run on your machine. For information on setting up infrastructure on your local machine, check out the guide on [local infrastructure setup](https://qiskit-extensions.github.io/qiskit-serverless/deployment/local.html)."
+    "> &#x26A0; This provider is set up with default credentials to a test cluster intended to run on your machine. For information on setting up infrastructure on your local machine, check out the guide on [local infrastructure setup](https://qiskit.github.io/qiskit-serverless/deployment/local.html)."
    ]
   },
   {

--- a/docs/getting_started/basic/05_retrieving_past_results.ipynb
+++ b/docs/getting_started/basic/05_retrieving_past_results.ipynb
@@ -15,9 +15,9 @@
    "id": "37322958-a029-46bb-bc46-82b7ded329b5",
    "metadata": {},
    "source": [
-    "First, create [ServerlessProvider](https://qiskit-extensions.github.io/qiskit-serverless/stubs/qiskit_serverless.core.Provider.html#qiskit_serverless.core.ServerlessProvider) instance.\n",
+    "First, create [ServerlessProvider](https://qiskit.github.io/qiskit-serverless/stubs/qiskit_serverless.core.Provider.html#qiskit_serverless.core.ServerlessProvider) instance.\n",
     "\n",
-    "> &#x26A0; This provider is set up with default credentials to a test cluster intended to run on your machine. For information on setting up infrastructure on your local machine, check out the guide on [local infrastructure setup](https://qiskit-extensions.github.io/qiskit-serverless/deployment/local.html)."
+    "> &#x26A0; This provider is set up with default credentials to a test cluster intended to run on your machine. For information on setting up infrastructure on your local machine, check out the guide on [local infrastructure setup](https://qiskit.github.io/qiskit-serverless/deployment/local.html)."
    ]
   },
   {
@@ -114,7 +114,7 @@
    "id": "675f9b7a-7d44-43e3-baea-0289cf29e573",
    "metadata": {},
    "source": [
-    "Call the blocking comand, [Job](https://qiskit-extensions.github.io/qiskit-serverless/stubs/qiskit_serverless.core.Job.html#qiskit_serverless.core.Job)``.result()``, to ensure the results are ready in the following cells."
+    "Call the blocking comand, [Job](https://qiskit.github.io/qiskit-serverless/stubs/qiskit_serverless.core.Job.html#qiskit_serverless.core.Job)``.result()``, to ensure the results are ready in the following cells."
    ]
   },
   {
@@ -191,7 +191,7 @@
    "id": "24942f00-680e-4cea-b0e7-bc75b19565fe",
    "metadata": {},
    "source": [
-    "To inspect the logs from a pattern, access them from the [Job](https://qiskit-extensions.github.io/qiskit-serverless/stubs/qiskit_serverless.core.Job.html#qiskit_serverless.core.Job) instance."
+    "To inspect the logs from a pattern, access them from the [Job](https://qiskit.github.io/qiskit-serverless/stubs/qiskit_serverless.core.Job.html#qiskit_serverless.core.Job) instance."
    ]
   },
   {

--- a/docs/getting_started/experimental/file_download.ipynb
+++ b/docs/getting_started/experimental/file_download.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "> &#x26A0; This interface is experimental, therefore it is subjected to breaking changes.\n",
     "\n",
-    "> &#x26A0; This provider is set up with default credentials to a test cluster intended to run on your machine. For information on setting up infrastructure on your local machine, check out the guide on [local infrastructure setup](https://qiskit-extensions.github.io/qiskit-serverless/deployment/local.html)."
+    "> &#x26A0; This provider is set up with default credentials to a test cluster intended to run on your machine. For information on setting up infrastructure on your local machine, check out the guide on [local infrastructure setup](https://qiskit.github.io/qiskit-serverless/deployment/local.html)."
    ]
   },
   {

--- a/docs/getting_started/experimental/manage_data_directory.ipynb
+++ b/docs/getting_started/experimental/manage_data_directory.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "> &#x26A0; This interface is experimental, therefore it is subjected to breaking changes.\n",
     "\n",
-    "> &#x26A0; This provider is set up with default credentials to a test cluster intended to run on your machine. For information on setting up infrastructure on your local machine, check out the guide on [local infrastructure setup](https://qiskit-extensions.github.io/qiskit-serverless/deployment/local.html)."
+    "> &#x26A0; This provider is set up with default credentials to a test cluster intended to run on your machine. For information on setting up infrastructure on your local machine, check out the guide on [local infrastructure setup](https://qiskit.github.io/qiskit-serverless/deployment/local.html)."
    ]
   },
   {

--- a/docs/getting_started/experimental/running_programs_using_decorators.ipynb
+++ b/docs/getting_started/experimental/running_programs_using_decorators.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "> &#x26A0; This interface is experimental, therefore it is subjected to breaking changes.\n",
     "\n",
-    "> &#x26A0; This provider is set up with default credentials to a test cluster intended to run on your machine. For information on setting up infrastructure on your local machine, check out the guide on [local infrastructure setup](https://qiskit-extensions.github.io/qiskit-serverless/deployment/local.html)."
+    "> &#x26A0; This provider is set up with default credentials to a test cluster intended to run on your machine. For information on setting up infrastructure on your local machine, check out the guide on [local infrastructure setup](https://qiskit.github.io/qiskit-serverless/deployment/local.html)."
    ]
   },
   {
@@ -60,7 +60,7 @@
     "## Hello, Qiskit!\n",
     "\n",
     "Let's create simpliest pattern by writing a funtion `hello_qiskit` and annotating it with `@distribute_qiskit_function` decorator. \n",
-    "The ``distribute_qiskit_function`` decorator accepts a [BaseProvider](https://qiskit-extensions.github.io/qiskit-serverless/stubs/qiskit_serverless.core.BaseProvider.html) instance for the ``provider`` argument. Other arguments are `dependencies` to specify extra packages to install during execution and `working_dir` to specify working directory that will be shiped for remote execution if needed."
+    "The ``distribute_qiskit_function`` decorator accepts a [BaseProvider](https://qiskit.github.io/qiskit-serverless/stubs/qiskit_serverless.core.BaseProvider.html) instance for the ``provider`` argument. Other arguments are `dependencies` to specify extra packages to install during execution and `working_dir` to specify working directory that will be shiped for remote execution if needed."
    ]
   },
   {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ system and receive the results when they are ready.
 
 ------------
 
-The source code to the project is available `on GitHub <https://github.com/Qiskit-Extensions/qiskit-serverless>`_.
+The source code to the project is available `on GitHub <https://github.com/Qiskit/qiskit-serverless>`_.
 
 .. Hiding - Indices and tables
    :ref:`genindex`


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

updates links in documentation to point to `github.com/Qiskit/qiskit-serverless/*` and `qiskit.github.io/*` instead of `github.com/Qiskit-Extensions/qiskit-serverless/*` and `qiskit-extensions.github.io/*`

### Details and comments

while links to `github.com/Qiskit-Extensions/qiskit-serverless/*` currently redirect to the correct location, right now all the links to `qiskit-extensions.github.io/*` are returning 404s, e.g. https://qiskit-extensions.github.io/qiskit-serverless/getting_started/index.html# 
