### PR TITLE
Group qiskit serverless images in image registry

### DIFF
--- a/.github/workflows/docker-verify.yaml
+++ b/.github/workflows/docker-verify.yaml
@@ -55,22 +55,22 @@ jobs:
       matrix:
         image:
           [
-            "qiskit-serverless-gateway:latest",
-            "qiskit-serverless-proxy:latest",
-            "qiskit-serverless-ray-node:latest-py39",
-            "qiskit-serverless-ray-node:latest-py310",
+            "qiskit-serverless/gateway:latest",
+            "qiskit-serverless/proxy:latest",
+            "qiskit-serverless/ray-node:latest-py39",
+            "qiskit-serverless/ray-node:latest-py310",
           ]
         include:
-          - image: "qiskit-serverless-gateway:latest"
+          - image: "qiskit-serverless/gateway:latest"
             dockerfile: "./gateway/Dockerfile"
             pyversion: "3.10"
-          - image: "qiskit-serverless-proxy:latest"
+          - image: "qiskit-serverless/proxy:latest"
             dockerfile: "./proxy/Dockerfile"
             pyversion: "3.10"
-          - image: "qiskit-serverless-ray-node:latest-py39"
+          - image: "qiskit-serverless/ray-node:latest-py39"
             dockerfile: "Dockerfile-ray-node"
             pyversion: "py39"
-          - image: "qiskit-serverless-ray-node:latest-py310"
+          - image: "qiskit-serverless/ray-node:latest-py310"
             dockerfile: "Dockerfile-ray-node"
             pyversion: "py310"
     runs-on: ubuntu-latest

--- a/.github/workflows/icr-image-build-and-push.yaml
+++ b/.github/workflows/icr-image-build-and-push.yaml
@@ -15,19 +15,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - imagename: qiskit-serverless-ray-node
+          - imagename: qiskit-serverless/ray-node
             pythonversion: py39
             dockerfile: Dockerfile-ray-node
             platforms: linux/amd64
-          - imagename: qiskit-serverless-ray-node
+          - imagename: qiskit-serverless/ray-node
             pythonversion: py310
             dockerfile: Dockerfile-ray-node
             platforms: linux/amd64,linux/arm64
-          - imagename: qiskit-serverless-gateway
+          - imagename: qiskit-serverless/gateway
             pythonversion: ''
             dockerfile: ./gateway/Dockerfile
             platforms: linux/amd64,linux/arm64
-          - imagename: qiskit-serverless-proxy
+          - imagename: qiskit-serverless/proxy
             pythonversion: ''
             dockerfile: ./proxy/Dockerfile
             platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release-pull-request.yaml
+++ b/.github/workflows/release-pull-request.yaml
@@ -11,22 +11,22 @@ jobs:
       matrix:
         image:
           [
-            "qiskit-serverless-gateway:latest",
-            "qiskit-serverless-ray-node:latest-py39",
-            "qiskit-serverless-ray-node:latest-py310",
-            "qiskit-serverless-proxy:latest"
+            "qiskit-serverless/gateway:latest",
+            "qiskit-serverless/ray-node:latest-py39",
+            "qiskit-serverless/ray-node:latest-py310",
+            "qiskit-serverless/proxy:latest"
           ]
         include:
-          - image: "qiskit-serverless-gateway:latest"
+          - image: "qiskit-serverless/gateway:latest"
             dockerfile: "./gateway/Dockerfile"
             pyversion: "3.10"
-          - image: "qiskit-serverless-ray-node:latest-py39"
+          - image: "qiskit-serverless/ray-node:latest-py39"
             dockerfile: "Dockerfile-ray-node"
             pyversion: "py39"
-          - image: "qiskit-serverless-ray-node:latest-py310"
+          - image: "qiskit-serverless/ray-node:latest-py310"
             dockerfile: "Dockerfile-ray-node"
             pyversion: "py310"
-          - image: "qiskit-serverless-proxy:latest-py310"
+          - image: "qiskit-serverless/proxy:latest-py310"
             dockerfile: "./proxy/Dockerfile"
             pyversion: "py310"
     runs-on: ubuntu-latest

--- a/.github/workflows/update-component-versions.yaml
+++ b/.github/workflows/update-component-versions.yaml
@@ -35,7 +35,7 @@ jobs:
           sed -i "s/version: ${OLDNUM}/version: ${NEWNUM}/" charts/qiskit-serverless/charts/gateway/Chart.yaml
           sed -i "s/appVersion: \"${OLDNUM}\"/appVersion: \"${NEWNUM}\"/" charts/qiskit-serverless/charts/gateway/Chart.yaml
           sed -i "s/ray-node:${OLDNUM}/ray-node:${NEWNUM}/" charts/qiskit-serverless/charts/gateway/values.yaml
-          sed -i "s/qiskit-serverless-proxy:${OLDNUM}/qiskit-serverless-proxy:${NEWNUM}/" charts/qiskit-serverless/charts/gateway/values.yaml
+          sed -i "s/qiskit-serverless/proxy:${OLDNUM}/qiskit-serverless/proxy:${NEWNUM}/" charts/qiskit-serverless/charts/gateway/values.yaml
           sed -i "s/tag: \"${OLDNUM}\"/tag: \"${NEWNUM}\"/" charts/qiskit-serverless/values.yaml
           sed -i "s/tag: \"${OLDNUM}-py39\"/tag: \"${NEWNUM}-py39\"/" charts/qiskit-serverless/values.yaml
           sed -i "s/ray-node:${OLDNUM}/ray-node:${NEWNUM}/" charts/qiskit-serverless/values.yaml

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ else
 	arch="amd64"
 endif
 
-rayNodeImageName=$(repository)/qiskit-serverless-ray-node
-gatewayImageName=$(repository)/qiskit-serverless-gateway
-proxyImageName=$(repository)/qiskit-serverless-proxy
+rayNodeImageName=$(repository)/qiskit-serverless/ray-node
+gatewayImageName=$(repository)/qiskit-serverless/gateway
+proxyImageName=$(repository)/qiskit-serverless/proxy
 
 # =============
 # Docker images

--- a/charts/qiskit-serverless/charts/gateway/values.yaml
+++ b/charts/qiskit-serverless/charts/gateway/values.yaml
@@ -17,9 +17,9 @@ application:
   superuser:
     enable: true
   ray:
-    nodeImage: "icr.io/quantum-public/qiskit-serverless-ray-node:0.12.0-py39"
-    nodeImage_py39: "icr.io/quantum-public/qiskit-serverless-ray-node:0.12.0-py39"
-    nodeImage_py310: "icr.io/quantum-public/qiskit-serverless-ray-node:0.12.0-py310"
+    nodeImage: "icr.io/quantum-public/qiskit-serverless/ray-node:0.12.0-py39"
+    nodeImage_py39: "icr.io/quantum-public/qiskit-serverless/ray-node:0.12.0-py39"
+    nodeImage_py310: "icr.io/quantum-public/qiskit-serverless/ray-node:0.12.0-py310"
     cpu: 2
     memory: 2
     replicas: 1
@@ -27,7 +27,7 @@ application:
     maxReplicas: 4
     opensslImage: registry.access.redhat.com/ubi8/openssl:8.8-9
     kubectlImage: alpine/k8s:1.29.2@sha256:a51aa37f0a34ff827c7f2f9cb7f6fbb8f0e290fa625341be14c2fcc4b1880f60
-    proxyImage: "icr.io/quantum-public/qiskit-serverless-proxy:0.9.0"
+    proxyImage: "icr.io/quantum-public/qiskit-serverless/proxy:0.9.0"
     scrapeWithPrometheus: true
     openTelemetry: false
     openTelemetryCollector:
@@ -90,7 +90,7 @@ secrets:
       email: admin@examplemail.io
 
 image:
-  repository: icr.io/quantum-public/qiskit-serverless-gateway
+  repository: icr.io/quantum-public/qiskit-serverless/gateway
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"

--- a/charts/qiskit-serverless/values.yaml
+++ b/charts/qiskit-serverless/values.yaml
@@ -45,7 +45,7 @@ gateway:
   useCertManager: false
 
   image:
-    repository: "icr.io/quantum-public/qiskit-serverless-gateway"
+    repository: "icr.io/quantum-public/qiskit-serverless/gateway"
     pullPolicy: IfNotPresent
     tag: "0.12.0"
   application:
@@ -59,7 +59,7 @@ gateway:
       type: ClusterIP
       port: 8000
     ray:
-      nodeImage: "icr.io/quantum-public/qiskit-serverless-ray-node:0.12.0-py310"
+      nodeImage: "icr.io/quantum-public/qiskit-serverless/ray-node:0.12.0-py310"
       opensslImage: registry.access.redhat.com/ubi8/openssl:8.8-9
       kubectlImage: alpine/k8s:1.29.2@sha256:a51aa37f0a34ff827c7f2f9cb7f6fbb8f0e290fa625341be14c2fcc4b1880f60
     limits:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@
 services:
   ray-head:
     container_name: ray-head
-    image: icr.io/quantum-public/qiskit-serverless-ray-node:${VERSION:-0.12.0}-py310
+    image: icr.io/quantum-public/qiskit-serverless/ray-node:${VERSION:-0.12.0}-py310
     entrypoint: [
       "ray", "start", "--head", "--port=6379",
       "--dashboard-host=0.0.0.0", "--block"
@@ -27,7 +27,7 @@ services:
       always
   gateway:
     container_name: gateway
-    image: icr.io/quantum-public/qiskit-serverless-gateway:${VERSION:-0.12.0}
+    image: icr.io/quantum-public/qiskit-serverless/gateway:${VERSION:-0.12.0}
     command: gunicorn main.wsgi:application --bind 0.0.0.0:8000 --workers=4
     ports:
       - 8000:8000
@@ -52,7 +52,7 @@ services:
       - postgres
   scheduler:
     container_name: scheduler
-    image: icr.io/quantum-public/qiskit-serverless-gateway:${VERSION:-0.12.0}
+    image: icr.io/quantum-public/qiskit-serverless/gateway:${VERSION:-0.12.0}
     entrypoint: "./scripts/scheduler.sh"
     environment:
       - DEBUG=0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This moves all the qiskit-serverless images under a top-level group, which will make image management easier in the future (as per infra team request). For example:

`qiskit-serverless-gateway:latest` --> `qiskit-serverless/gateway:latest`

### Details and comments


