### PR TITLE
Drop python 3.8 from proxy linter job

### DIFF
--- a/.github/workflows/proxy-verify.yaml
+++ b/.github/workflows/proxy-verify.yaml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false # keep running if one leg fails
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

We dropped support for Python 3.8 a while ago, so removing the proxy linter job for that version.

### Details and comments

