### PR TITLE
Migrate from qiskit-ibm-provider to qiskit-ibm-runtime

### DIFF
--- a/client/qiskit_serverless/core/client.py
+++ b/client/qiskit_serverless/core/client.py
@@ -38,7 +38,7 @@ import ray
 import requests
 from ray.dashboard.modules.job.sdk import JobSubmissionClient
 from opentelemetry import trace
-from qiskit_ibm_provider import IBMProvider
+from qiskit_ibm_runtime import QiskitRuntimeService
 
 from qiskit_serverless.core.constants import (
     REQUESTS_TIMEOUT,
@@ -577,7 +577,7 @@ class IBMServerlessClient(ServerlessClient):
             token: IBM quantum token
             name: Name of the account to load
         """
-        token = token or IBMProvider(name=name).active_account().get("token")
+        token = token or QiskitRuntimeService(name=name).active_account().get("token")
         super().__init__(token=token, host=IBM_SERVERLESS_HOST_URL)
 
     @staticmethod
@@ -594,7 +594,7 @@ class IBMServerlessClient(ServerlessClient):
             name: Name of the account to save
             overwrite: ``True`` if the existing account is to be overwritten
         """
-        IBMProvider.save_account(token=token, name=name, overwrite=overwrite)
+        QiskitRuntimeService.save_account(token=token, name=name, overwrite=overwrite)
 
     def get_compute_resources(self) -> List[ComputeResource]:
         raise NotImplementedError(

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -3,8 +3,7 @@ requests>=2.32.2
 importlib-metadata>=5.2.0
 qiskit>=1.0.2
 qiskit-ibm-runtime>=0.21.1
-qiskit-ibm-provider>=0.10.0
-# TODO: make sure ray node and notebook node have the same version of cloudpickle
+# Make sure ray node and notebook node have the same version of cloudpickle
 cloudpickle==2.2.1
 tqdm>=4.66.3
 # opentelemetry


### PR DESCRIPTION
### Summary

Fix deprecation warning from GHA error: https://github.com/Qiskit/qiskit-serverless/actions/runs/9548356596/job/26315353152?pr=1374

We are migrating from qiskit-ibm-provider to qiskit-ibm-runtime packages.