### PR TITLE
Filter job end-points

### DIFF
--- a/.github/workflows/kubernetes-deploy.yaml
+++ b/.github/workflows/kubernetes-deploy.yaml
@@ -54,7 +54,7 @@ jobs:
             --set gateway.application.limits.keepClusterOnComplete=false \
             .
           GATEWAY=$(kubectl get pod -l app.kubernetes.io/name=gateway -o name)
-          kubectl wait --for=condition=Ready "$GATEWAY" --timeout 7m
+          kubectl wait --for=condition=Ready "$GATEWAY" --timeout 9m
       - name: setup python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/kubernetes-deploy.yaml
+++ b/.github/workflows/kubernetes-deploy.yaml
@@ -54,7 +54,7 @@ jobs:
             --set gateway.application.limits.keepClusterOnComplete=false \
             .
           GATEWAY=$(kubectl get pod -l app.kubernetes.io/name=gateway -o name)
-          kubectl wait --for=condition=Ready "$GATEWAY" --timeout 9m
+          kubectl wait --for=condition=Ready "$GATEWAY" --timeout 5m
       - name: setup python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/kubernetes-deploy.yaml
+++ b/.github/workflows/kubernetes-deploy.yaml
@@ -54,7 +54,7 @@ jobs:
             --set gateway.application.limits.keepClusterOnComplete=false \
             .
           GATEWAY=$(kubectl get pod -l app.kubernetes.io/name=gateway -o name)
-          kubectl wait --for=condition=Ready "$GATEWAY" --timeout 5m
+          kubectl wait --for=condition=Ready "$GATEWAY" --timeout 7m
       - name: setup python
         uses: actions/setup-python@v4
         with:

--- a/gateway/api/v1/views.py
+++ b/gateway/api/v1/views.py
@@ -14,7 +14,7 @@ from api.permissions import IsOwner
 from . import serializers as v1_serializers
 
 
-class ProgramViewSet(views.ProgramViewSet):  # pylint: disable=too-many-ancestors
+class ProgramViewSet(views.ProgramViewSet):
     """
     Quantum function view set first version. Use ProgramSerializer V1.
     """
@@ -65,7 +65,7 @@ class ProgramViewSet(views.ProgramViewSet):  # pylint: disable=too-many-ancestor
         return super().run(request)
 
 
-class JobViewSet(views.JobViewSet):  # pylint: disable=too-many-ancestors
+class JobViewSet(views.JobViewSet):
     """
     Job view set first version. Use JobSerializer V1.
     """

--- a/gateway/api/v1/views.py
+++ b/gateway/api/v1/views.py
@@ -5,10 +5,11 @@ Views api for V1.
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import permissions, status
 from rest_framework.decorators import action
+from rest_framework.pagination import LimitOffsetPagination
 
 
 from api import views
-from api.models import Job, RuntimeJob
+from api.models import RuntimeJob
 from api.permissions import IsOwner
 from . import serializers as v1_serializers
 
@@ -39,14 +40,14 @@ class ProgramViewSet(views.ProgramViewSet):  # pylint: disable=too-many-ancestor
         return v1_serializers.RunJobSerializer(*args, **kwargs)
 
     @swagger_auto_schema(
-        operation_description="List author Qiskit Patterns",
+        operation_description="List author Qiskit Functions",
         responses={status.HTTP_200_OK: v1_serializers.ProgramSerializer(many=True)},
     )
     def list(self, request):
         return super().list(request)
 
     @swagger_auto_schema(
-        operation_description="Upload a Qiskit Pattern",
+        operation_description="Upload a Qiskit Function",
         request_body=v1_serializers.UploadProgramSerializer,
         responses={status.HTTP_200_OK: v1_serializers.UploadProgramSerializer},
     )
@@ -55,7 +56,7 @@ class ProgramViewSet(views.ProgramViewSet):  # pylint: disable=too-many-ancestor
         return super().upload(request)
 
     @swagger_auto_schema(
-        operation_description="Run an existing Qiskit Pattern",
+        operation_description="Run an existing Qiskit Function",
         request_body=v1_serializers.RunProgramSerializer,
         responses={status.HTTP_200_OK: v1_serializers.RunJobSerializer},
     )
@@ -69,12 +70,36 @@ class JobViewSet(views.JobViewSet):  # pylint: disable=too-many-ancestors
     Job view set first version. Use JobSerializer V1.
     """
 
-    queryset = Job.objects.all()
     serializer_class = v1_serializers.JobSerializer
+    pagination_class = LimitOffsetPagination
     permission_classes = [permissions.IsAuthenticated, IsOwner]
 
     def get_serializer_class(self):
         return v1_serializers.JobSerializer
+
+    @swagger_auto_schema(
+        operation_description="Get author Job",
+        responses={status.HTTP_200_OK: v1_serializers.JobSerializer(many=False)},
+    )
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk)
+
+    @swagger_auto_schema(
+        operation_description="List author Jobs",
+        responses={status.HTTP_200_OK: v1_serializers.JobSerializer(many=True)},
+    )
+    def list(self, request):
+        return super().list(request)
+
+    @swagger_auto_schema(
+        operation_description="Save the result of a job",
+        responses={status.HTTP_200_OK: v1_serializers.JobSerializer(many=False)},
+    )
+    @action(methods=["POST"], detail=True)
+    def result(self, request, pk=None):
+        return super().result(request, pk)
+
+    ### We are not returning serializers in the rest of the end-points
 
 
 class FilesViewSet(views.FilesViewSet):

--- a/gateway/api/views.py
+++ b/gateway/api/views.py
@@ -63,7 +63,7 @@ if bool(int(os.environ.get("OTEL_ENABLED", "0"))):
     trace._set_tracer_provider(provider, log=False)  # pylint: disable=protected-access
 
 
-class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ancestors
+class ProgramViewSet(viewsets.GenericViewSet):
     """
     Program ViewSet configuration using GenericViewSet.
     """
@@ -325,7 +325,7 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
         return Response(job_serializer.data)
 
 
-class JobViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ancestors
+class JobViewSet(viewsets.GenericViewSet):
     """
     Job ViewSet configuration using GenericViewSet.
     """

--- a/gateway/tests/api/test_job.py
+++ b/gateway/tests/api/test_job.py
@@ -50,6 +50,16 @@ class TestJobApi(APITestCase):
         self.assertEqual(jobs_response.data.get("status"), "SUCCEEDED")
         self.assertEqual(jobs_response.data.get("result"), '{"somekey":1}')
 
+    def test_not_authorized_job_detail(self):
+        """Tests job detail fails trying to access to other user job."""
+        self._authorize()
+
+        jobs_response = self.client.get(
+            reverse("v1:jobs-detail", args=["1a7947f9-6ae8-4e3d-ac1e-e7d608deec84"]),
+            format="json",
+        )
+        self.assertEqual(jobs_response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_job_save_result(self):
         """Tests job results save."""
         self._authorize()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Part of #1270 , this PR pretends to clean-up some end-points from `Jobs` to only those ones that we are currently using.

### Details

End-Points removed:
- POST /jobs/: it's not possible to create jobs directly from the end-point
- PUT /jobs/{id}: I think we are not updating jobs from PUT call
- PATCH /jobs/{id}: I think we are not updating jobs from PATCH call
- DELETE /jobs/{id}: we are not removing jobs using DELETE call