### PR TITLE
Client: fix for Function post init

### DIFF
--- a/client/qiskit_serverless/core/function.py
+++ b/client/qiskit_serverless/core/function.py
@@ -68,7 +68,7 @@ class QiskitFunction:  # pylint: disable=too-many-instance-attributes
             title_split = self.title.split("/")
             if len(title_split) > 2:
                 raise ValueError("Invalid title: it can only contain one slash.")
-            if self.provider != title_split[0]:
+            if self.provider != title_split[0] and self.provider is not None:
                 raise ValueError(
                     "Invalid provider: you provided two different "
                     + f"providers [{self.provider}] and [{title_split[0]}]."


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix for Function post init.

### Details and comments

With current implementation `list` and `widget` method calls failed if user had function named `bla-bla/my-function` before introduction of `provider` field. 
