### PR TITLE
Fail job on insufficient resources

### DIFF
--- a/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
+++ b/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
@@ -74,6 +74,8 @@ spec:
             httpGet:
               path: /liveness
               port: http
+            initialDelaySeconds: 60
+            periodSeconds: 20
           readinessProbe:
             httpGet:
               path: /readiness

--- a/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
+++ b/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
@@ -117,6 +117,10 @@ spec:
               value: {{ .Values.application.ray.minReplicas | quote }}
             - name: RAY_CLUSTER_WORKER_MAX_REPLICAS
               value: {{ .Values.application.ray.maxReplicas | quote }}
+            - name: LIMITS_CPU_PER_TASK
+              value: {{ .Values.application.ray.cpu | quote }}
+            - name: LIMITS_MEMORY_PER_TASK
+              value: {{ .Values.application.ray.memory | quote }}
 {{- if .Values.application.superuser.enable }}
             - name: DJANGO_SUPERUSER_USERNAME
               valueFrom:

--- a/gateway/api/management/commands/update_jobs_statuses.py
+++ b/gateway/api/management/commands/update_jobs_statuses.py
@@ -7,7 +7,7 @@ from django.core.management.base import BaseCommand
 
 from api.models import Job
 from api.ray import get_job_handler
-from api.schedule import check_job_timeout, handle_job_status_not_available
+from api.schedule import check_job_timeout, handle_job_status_not_available, fail_job_insufficient_resources
 from api.utils import ray_job_status_to_model_job_status, check_logs
 
 logger = logging.getLogger("commands")
@@ -57,6 +57,14 @@ class Command(BaseCommand):
                 if job_handler:
                     logs = job_handler.logs(job.ray_job_id)
                     job.logs = check_logs(logs, job)
+                    # check if job is resource constrained
+                    no_resources_log = "No available node types can fulfill resource request"
+                    if no_resources_log in logs:
+                        job_status = fail_job_insufficient_resources(job)
+                        job.status = job_status
+                        # cleanup env vars
+                        if job.in_terminal_state():
+                            job.env_vars = "{}"
 
                 try:
                     job.save()

--- a/gateway/api/management/commands/update_jobs_statuses.py
+++ b/gateway/api/management/commands/update_jobs_statuses.py
@@ -56,15 +56,17 @@ class Command(BaseCommand):
 
                 if job_handler:
                     logs = job_handler.logs(job.ray_job_id)
-                    job.logs = check_logs(logs, job)
                     # check if job is resource constrained
-                    no_resources_log = "No available node types can fulfill resource request"
+                    no_resources_log = (
+                        "No available node types can fulfill resource request"
+                    )
                     if no_resources_log in logs:
                         job_status = fail_job_insufficient_resources(job)
                         job.status = job_status
                         # cleanup env vars
                         if job.in_terminal_state():
                             job.env_vars = "{}"
+                    job.logs = check_logs(logs, job)
 
                 try:
                     job.save()

--- a/gateway/api/management/commands/update_jobs_statuses.py
+++ b/gateway/api/management/commands/update_jobs_statuses.py
@@ -61,16 +61,15 @@ class Command(BaseCommand):
                 if job_handler:
                     logs = job_handler.logs(job.ray_job_id)
                     job.logs = check_logs(logs, job)
-                    # check if job is resource constrained
-                    no_resources_log = (
-                        "No available node types can fulfill resource request"
-                    )
-                    if no_resources_log in logs:
-                        job_status = fail_job_insufficient_resources(job)
-                        job.status = job_status
-                        # cleanup env vars
-                        if job.in_terminal_state():
-                            job.env_vars = "{}"
+                # check if job is resource constrained
+                no_resources_log = (
+                    "No available node types can fulfill resource request"
+                )
+                if no_resources_log in logs:
+                    job_status = fail_job_insufficient_resources(job)
+                    job.status = job_status
+                    # cleanup env vars
+                    job.env_vars = "{}"
 
                 try:
                     job.save()

--- a/gateway/api/management/commands/update_jobs_statuses.py
+++ b/gateway/api/management/commands/update_jobs_statuses.py
@@ -24,6 +24,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         # update job statuses
+        #pylint: disable=too-many-branches
         updated_jobs_counter = 0
         jobs = Job.objects.filter(status__in=Job.RUNNING_STATES)
         for job in jobs:

--- a/gateway/api/management/commands/update_jobs_statuses.py
+++ b/gateway/api/management/commands/update_jobs_statuses.py
@@ -10,7 +10,7 @@ from api.ray import get_job_handler
 from api.schedule import (
     check_job_timeout,
     handle_job_status_not_available,
-    fail_job_insufficient_resources
+    fail_job_insufficient_resources,
 )
 from api.utils import ray_job_status_to_model_job_status, check_logs
 

--- a/gateway/api/management/commands/update_jobs_statuses.py
+++ b/gateway/api/management/commands/update_jobs_statuses.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         # update job statuses
-        #pylint: disable=too-many-branches
+        # pylint: disable=too-many-branches
         updated_jobs_counter = 0
         jobs = Job.objects.filter(status__in=Job.RUNNING_STATES)
         for job in jobs:

--- a/gateway/api/management/commands/update_jobs_statuses.py
+++ b/gateway/api/management/commands/update_jobs_statuses.py
@@ -7,7 +7,11 @@ from django.core.management.base import BaseCommand
 
 from api.models import Job
 from api.ray import get_job_handler
-from api.schedule import check_job_timeout, handle_job_status_not_available, fail_job_insufficient_resources
+from api.schedule import (
+    check_job_timeout,
+    handle_job_status_not_available,
+    fail_job_insufficient_resources
+)
 from api.utils import ray_job_status_to_model_job_status, check_logs
 
 logger = logging.getLogger("commands")
@@ -56,6 +60,7 @@ class Command(BaseCommand):
 
                 if job_handler:
                     logs = job_handler.logs(job.ray_job_id)
+                    job.logs = check_logs(logs, job)
                     # check if job is resource constrained
                     no_resources_log = (
                         "No available node types can fulfill resource request"
@@ -66,7 +71,6 @@ class Command(BaseCommand):
                         # cleanup env vars
                         if job.in_terminal_state():
                             job.env_vars = "{}"
-                    job.logs = check_logs(logs, job)
 
                 try:
                     job.save()

--- a/gateway/api/management/commands/update_jobs_statuses.py
+++ b/gateway/api/management/commands/update_jobs_statuses.py
@@ -62,15 +62,15 @@ class Command(BaseCommand):
                 if job_handler:
                     logs = job_handler.logs(job.ray_job_id)
                     job.logs = check_logs(logs, job)
-                # check if job is resource constrained
-                no_resources_log = (
-                    "No available node types can fulfill resource request"
-                )
-                if no_resources_log in logs:
-                    job_status = fail_job_insufficient_resources(job)
-                    job.status = job_status
-                    # cleanup env vars
-                    job.env_vars = "{}"
+                    # check if job is resource constrained
+                    no_resources_log = (
+                        "No available node types can fulfill resource request"
+                    )
+                    if no_resources_log in job.logs:
+                        job_status = fail_job_insufficient_resources(job)
+                        job.status = job_status
+                        # cleanup env vars
+                        job.env_vars = "{}"
 
                 try:
                     job.save()

--- a/gateway/api/schedule.py
+++ b/gateway/api/schedule.py
@@ -184,10 +184,11 @@ def fail_job_insufficient_resources(job: Job):
         job.compute_resource = None
 
     job_status = Job.FAILED
-    job.logs = ("Insufficient resources available to the run job in this "
-                "configuration.\nMax resources allowed are "
-                f"{settings.LIMITS_CPU_PER_TASK} CPUs and "
-                f"{settings.LIMITS_MEMORY_PER_TASK} GB of RAM per job."
-                )
+    job.logs = (
+        "Insufficient resources available to the run job in this "
+        "configuration.\nMax resources allowed are "
+        f"{settings.LIMITS_CPU_PER_TASK} CPUs and "
+        f"{settings.LIMITS_MEMORY_PER_TASK} GB of RAM per job."
+    )
 
     return job_status

--- a/gateway/api/schedule.py
+++ b/gateway/api/schedule.py
@@ -184,5 +184,4 @@ def fail_job_insufficient_resources(job: Job):
         job.compute_resource = None
 
     job_status = Job.FAILED
-    job.logs += f"{job.logs}\nInsufficient resources to run job."
     return job_status

--- a/gateway/api/schedule.py
+++ b/gateway/api/schedule.py
@@ -184,5 +184,10 @@ def fail_job_insufficient_resources(job: Job):
         job.compute_resource = None
 
     job_status = Job.FAILED
-    job.logs = "Insufficient resources available to the run job in this configuration."
+    job.logs = ("Insufficient resources available to the run job in this "
+                "configuration.\nMax resources allowed are "
+                f"{settings.LIMITS_CPU_PER_TASK} CPUs and "
+                f"{settings.LIMITS_MEMORY_PER_TASK} GB of RAM per job."
+                )
+
     return job_status

--- a/gateway/api/schedule.py
+++ b/gateway/api/schedule.py
@@ -168,3 +168,21 @@ def handle_job_status_not_available(job: Job, job_status):
         job_status = Job.FAILED
         job.logs += f"{job.logs}\nSomething went wrong during updating job status."
     return job_status
+
+
+def fail_job_insufficient_resources(job: Job):
+    """Fail job if insufficient resources are available."""
+    if config.RAY_CLUSTER_NO_DELETE_ON_COMPLETE:
+        logger.debug(
+            "RAY_CLUSTER_NO_DELETE_ON_COMPLETE is enabled, "
+            + "so cluster [%s] will not be removed",
+            job.compute_resource.title,
+        )
+    else:
+        kill_ray_cluster(job.compute_resource.title)
+        job.compute_resource.delete()
+        job.compute_resource = None
+
+    job_status = Job.FAILED
+    job.logs += f"{job.logs}\nInsufficient resources to run job."
+    return job_status

--- a/gateway/api/schedule.py
+++ b/gateway/api/schedule.py
@@ -184,4 +184,5 @@ def fail_job_insufficient_resources(job: Job):
         job.compute_resource = None
 
     job_status = Job.FAILED
+    job.logs = "Insufficient resources available to the run job in this configuration."
     return job_status

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -306,6 +306,8 @@ SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD = os.environ.get(
 # resources limitations
 LIMITS_JOBS_PER_USER = int(os.environ.get("LIMITS_JOBS_PER_USER", "2"))
 LIMITS_MAX_CLUSTERS = int(os.environ.get("LIMITS_MAX_CLUSTERS", "6"))
+LIMITS_CPU_PER_TASK = int(os.environ.get("LIMITS_CPU_PER_TASK", "4"))
+LIMITS_MEMORY_PER_TASK = int(os.environ.get("LIMITS_MEMORY_PER_TASK", "8"))
 
 # ray cluster management
 RAY_KUBERAY_NAMESPACE = os.environ.get("RAY_KUBERAY_NAMESPACE", "qiskit-serverless")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #1379 
Ray will wait indefinitely if a job has insufficient resources, so we need to explicitly fail jobs that don't have enough resources to run.

### Details and comments

When a user uses `distribute_task` within their functions, they may request more resources than they have available, which will result in something like this in the logs:

```
2024-06-24 14:23:25,045	INFO worker.py:1405 -- Using address 10.244.0.16:6379 set in the environment variable RAY_ADDRESS
2024-06-24 14:23:25,045	INFO worker.py:1540 -- Connecting to existing Ray cluster at address: 10.244.0.16:6379...
2024-06-24 14:23:25,056	INFO worker.py:1715 -- Connected to Ray cluster. View the dashboard at 10.244.0.16:8265 
(autoscaler +2s) Tip: use `ray status` to view detailed cluster status. To disable these messages, set RAY_SCHEDULER_EVENTS=0.
(autoscaler +2s) Error: No available node types can fulfill resource request {'CPU': 4.0, 'memory': 1.0}. Add suitable node types to this cluster to resolve this issue.
```

In this PR we look for the `No available node types can fulfill resource request` line in the logs and then fail the job if we find it. 

