### PR TITLE
Build ray image with ubi base

### DIFF
--- a/Dockerfile-ray-node
+++ b/Dockerfile-ray-node
@@ -1,7 +1,7 @@
 ARG IMAGE_PY_VERSION=py311
 
 FROM registry.access.redhat.com/ubi9-minimal:9.4-1134
-RUN microdnf install -y python3.11-3.11.7-1.el9_4.1 python3.11-pip-22.3.1-5.el9 python3.11-devel-3.11.7-1.el9_4.1 vim-enhanced-2:8.2.2637-20.el9_1 wget &&\
+RUN microdnf install -y python3.11-3.11.7 python3.11-pip python3.11-devel vim-enhanced wget &&\
     microdnf clean all
 RUN ln -s /usr/bin/python3.11 /usr/local/bin/python3 && \
     ln -s /usr/bin/python3.11 /usr/local/bin/python &&\

--- a/Dockerfile-ray-node
+++ b/Dockerfile-ray-node
@@ -1,48 +1,29 @@
 ARG IMAGE_PY_VERSION=py311
 
-FROM rayproject/ray:2.30.0-$IMAGE_PY_VERSION AS ray-node-amd64
+FROM registry.access.redhat.com/ubi9-minimal:9.4-1134
+RUN microdnf install -y python3.11-3.11.7-1.el9_4.1 python3.11-pip-22.3.1-5.el9 python3.11-devel-3.11.7-1.el9_4.1 vim-enhanced-2:8.2.2637-20.el9_1 wget &&\
+    microdnf clean all
+RUN ln -s /usr/bin/python3.11 /usr/local/bin/python3 && \
+    ln -s /usr/bin/python3.11 /usr/local/bin/python &&\
+    ln -s /usr/bin/pip3.11 /usr/local/bin/pip3 &&\
+    ln -s /usr/bin/pip3.11 /usr/local/bin/pip
+
+# set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
 
 WORKDIR /
 USER 0
-RUN mkdir /data && chown "$RAY_UID":"$RAY_UID" /data
-USER $RAY_UID
-COPY --chown=$RAY_UID:$RAY_UID ./client ./qs
-
+RUN mkdir /data && chown 1000:1000 /data
+USER 0
+COPY client ./qs
 WORKDIR /qs
-# TODO: certifi version pinned to 2024.7.4. More info in #421
-# TODO: pyarrow version pinned to 14.0.1
+
 RUN pip install . --no-cache-dir &&\
     pip install --no-cache-dir pyarrow==14.0.1 &&\
-    pip install --no-cache-dir certifi==2024.7.4
+    pip install --no-cache-dir certifi==2024.7.4 &&\
+    cp -r -n /usr/local/lib64/python3.11/site-packages/symengine /usr/local/lib/python3.11/site-packages &&\
+    cp -r -n /usr/local/lib/python3.11/site-packages/symengine /usr/local/lib64/python3.11/site-packages
 
 WORKDIR /
 RUN rm -r ./qs
-
-FROM rayproject/ray:2.30.0-$IMAGE_PY_VERSION-aarch64 AS ray-node-arm64
-
-WORKDIR /
-USER 0
-RUN mkdir /data && chown "$RAY_UID":"$RAY_UID" /data
-USER $RAY_UID
-RUN apt-get -y update &&\
-    apt-get install --no-install-recommends -y \
-    gcc=4:9.3.0-1ubuntu2 \
-    build-essential=12.8ubuntu1
-COPY --chown=$RAY_UID:$RAY_UID ./client ./qs
-
-WORKDIR /qs
-# TODO: certifi version pinned to 2024.7.4. More info in #421
-# TODO: pyarrow version pinned to 14.0.1
-RUN pip install . --no-cache-dir &&\
-    pip install --no-cache-dir pyarrow==14.0.1 &&\
-    if [ "$TARGETARCH" = "arm64" ] ; \
-        then pip install --no-cache-dir certifi==2024.7.4 ; \
-    fi
-
-WORKDIR /
-USER 0
-RUN rm -r ./qs
-USER $RAY_UID
-
-# hadolint ignore=DL3006
-FROM ray-node-${TARGETARCH} AS final

--- a/Dockerfile-ray-node
+++ b/Dockerfile-ray-node
@@ -19,7 +19,8 @@ USER 0
 COPY client ./qs
 WORKDIR /qs
 
-RUN pip install . --no-cache-dir &&\
+RUN pip install -r requirements.txt &&\
+    pip install . --no-cache-dir &&\
     pip install --no-cache-dir pyarrow==14.0.1 &&\
     pip install --no-cache-dir certifi==2024.7.4 &&\
     cp -r -n /usr/local/lib64/python3.11/site-packages/symengine /usr/local/lib/python3.11/site-packages &&\

--- a/Dockerfile-ray-node
+++ b/Dockerfile-ray-node
@@ -9,8 +9,8 @@ RUN ln -s /usr/bin/python3.11 /usr/local/bin/python3 && \
     ln -s /usr/bin/pip3.11 /usr/local/bin/pip
 
 # set environment variables
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
 
 WORKDIR /
 USER 0

--- a/Dockerfile-ray-node
+++ b/Dockerfile-ray-node
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi9-minimal:9.4-1134
-RUN microdnf install -y python3.11-3.11.7 python3.11-pip python3.11-devel vim-enhanced wget &&\
+RUN microdnf install -y python3.11 python3.11-pip python3.11-devel vim-enhanced wget &&\
     microdnf clean all
 RUN ln -s /usr/bin/python3.11 /usr/local/bin/python3 && \
     ln -s /usr/bin/python3.11 /usr/local/bin/python &&\

--- a/Dockerfile-ray-node
+++ b/Dockerfile-ray-node
@@ -1,5 +1,3 @@
-ARG IMAGE_PY_VERSION=py311
-
 FROM registry.access.redhat.com/ubi9-minimal:9.4-1134
 RUN microdnf install -y python3.11-3.11.7 python3.11-pip python3.11-devel vim-enhanced wget &&\
     microdnf clean all

--- a/Dockerfile-ray-node-community
+++ b/Dockerfile-ray-node-community
@@ -1,0 +1,48 @@
+ARG IMAGE_PY_VERSION=py311
+
+FROM rayproject/ray:2.30.0-$IMAGE_PY_VERSION AS ray-node-amd64
+
+WORKDIR /
+USER 0
+RUN mkdir /data && chown "$RAY_UID":"$RAY_UID" /data
+USER $RAY_UID
+COPY --chown=$RAY_UID:$RAY_UID ./client ./qs
+
+WORKDIR /qs
+# TODO: certifi version pinned to 2024.7.4. More info in #421
+# TODO: pyarrow version pinned to 14.0.1
+RUN pip install . --no-cache-dir &&\
+    pip install --no-cache-dir pyarrow==14.0.1 &&\
+    pip install --no-cache-dir certifi==2024.7.4
+
+WORKDIR /
+RUN rm -r ./qs
+
+FROM rayproject/ray:2.30.0-$IMAGE_PY_VERSION-aarch64 AS ray-node-arm64
+
+WORKDIR /
+USER 0
+RUN mkdir /data && chown "$RAY_UID":"$RAY_UID" /data
+USER $RAY_UID
+RUN apt-get -y update &&\
+    apt-get install --no-install-recommends -y \
+    gcc=4:9.3.0-1ubuntu2 \
+    build-essential=12.8ubuntu1
+COPY --chown=$RAY_UID:$RAY_UID ./client ./qs
+
+WORKDIR /qs
+# TODO: certifi version pinned to 2024.7.4. More info in #421
+# TODO: pyarrow version pinned to 14.0.1
+RUN pip install . --no-cache-dir &&\
+    pip install --no-cache-dir pyarrow==14.0.1 &&\
+    if [ "$TARGETARCH" = "arm64" ] ; \
+        then pip install --no-cache-dir certifi==2024.7.4 ; \
+    fi
+
+WORKDIR /
+USER 0
+RUN rm -r ./qs
+USER $RAY_UID
+
+# hadolint ignore=DL3006
+FROM ray-node-${TARGETARCH} AS final

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -14,3 +14,4 @@ s3fs>=2023.6.0
 opentelemetry.instrumentation.requests>=0.40b0
 ipywidgets>=8.1.2
 ipython>=8.10.0
+numpy>=1.26.4,<2

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi9-minimal:9.4-1134
-RUN microdnf install -y python3.11-3.11.7-1.el9_4.1 python3.11-pip-22.3.1-5.el9 python3.11-devel-3.11.7-1.el9_4.1 vim-enhanced-2:8.2.2637-20.el9_1 &&\
+RUN microdnf install -y python3.11 python3.11-pip python3.11-devel vim-enhanced &&\
     microdnf clean all
 RUN ln -s /usr/bin/python3.11 /usr/local/bin/python3 && \
     ln -s /usr/bin/python3.11 /usr/local/bin/python &&\


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Build the ray image using a UBI base 

### Details and comments

This currently only tests x86, as I have no way to test an ARM image. Per Aki, the UBI base images work on Apple Silicon.

I've also left the old dockerfile (using the community Ray image as a base), in case that's helpful.

This also pins numpy to v1.x, as v2 causes a number of issues
