### PR TITLE
Fix job failing and marking it error

### DIFF
--- a/gateway/api/schedule.py
+++ b/gateway/api/schedule.py
@@ -80,6 +80,7 @@ def execute_job(job: Job) -> Job:
                 kill_ray_cluster(compute_resource.title)
                 compute_resource.delete()
                 job.status = Job.FAILED
+                job.compute_resource = None
                 job.logs += "\nCompute resource was not found."
 
         span.set_attribute("job.status", job.status)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fix the issue with the following log
```
ERROR 2024-08-13 17:27:08,672 schedule.py:72 : Exception was caught during scheduling job on user [66951c66b73cf04d4329e63d] resource.
Resource [c-66951c66b73cf04d4329e63d-906827e1] was in DB records, but address is not reachable.
Cleaning up db record and setting job [6e7d3cb0-4a62-446f-af75-106e99ccc9ba] to failed
Traceback (most recent call last):
  File "/usr/src/app/manage.py", line 47, in <module>
    main()
  File "/usr/src/app/manage.py", line 43, in main
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.11/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.11/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.11/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/api/management/commands/schedule_queued_jobs.py", line 86, in handle
    job.save()
  File "/usr/local/lib/python3.11/site-packages/django/db/models/base.py", line 778, in save
    self._prepare_related_fields_for_save(operation_name="save")
  File "/usr/local/lib/python3.11/site-packages/django/db/models/base.py", line 1093, in _prepare_related_fields_for_save
    raise ValueError(
ValueError: save() prohibited to prevent data loss due to unsaved related object 'compute_resource'.
```

### Details and comments

