### PR TITLE
Don't add local gateway/media directory to container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -44,3 +44,4 @@ static
 stats
 *.sqlite3
 tests
+gateway/media


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #1473

The `gateway/media` directory is currently ignored by git. If the user happens to have created that directory locally for some reason (running tests?) then the docker build fails.

This patch implements a simple fix to remove the local media diretory, if it exists, from the container image prior to the normal build steps.


### Details and comments

