### PR TITLE
Deprecate get_jobs method

### DIFF
--- a/client/qiskit_serverless/core/function.py
+++ b/client/qiskit_serverless/core/function.py
@@ -27,6 +27,7 @@ Qiskit Serverless function
     QiskitFunction
 """
 import dataclasses
+import warnings
 from dataclasses import dataclass
 from typing import Optional, Dict, List, Any, Tuple
 
@@ -118,14 +119,31 @@ class QiskitFunction:  # pylint: disable=too-many-instance-attributes
             config=config,
         )
 
-    def jobs(self):
-        """Run function
+    def get_jobs(self):
+        """List of jobs created in this function.
 
         Raises:
             QiskitServerlessException: validation exception
 
         Returns:
-            Job ids : job executed this function
+            [Job] : list of jobs
+        """
+        warnings.warn(
+            "`get_jobs` method has been deprecated. "
+            "And will be removed in future releases. "
+            "Please, use `jobs` instead.",
+            DeprecationWarning,
+        )
+        return self.jobs()
+
+    def jobs(self):
+        """List of jobs created in this function.
+
+        Raises:
+            QiskitServerlessException: validation exception
+
+        Returns:
+            [Job] : list of jobs
         """
         from qiskit_serverless.core.job import (  # pylint: disable=import-outside-toplevel
             Job,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR continues the work from #1480 introducing a deprecation warning in `get_jobs` instead of remove it.