### PR TITLE
Change static files serving to whitenoise plugin

### DIFF
--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -85,6 +85,7 @@ MIDDLEWARE = [
     "allow_cidr.middleware.AllowCIDRMiddleware",
     "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -198,6 +199,13 @@ AUTHENTICATION_BACKENDS = [
     # `allauth` specific authentication methods, such as login by e-mail
     "allauth.account.auth_backends.AuthenticationBackend",
 ]
+
+STORAGES = {
+    "staticfiles": {
+        # allow whitenoise compression and cache
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/4.1/topics/i18n/

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -65,6 +65,7 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
+    "whitenoise.runserver_nostatic",
     "django.contrib.staticfiles",
     "django.contrib.sites",
     "django_prometheus",
@@ -199,13 +200,6 @@ AUTHENTICATION_BACKENDS = [
     # `allauth` specific authentication methods, such as login by e-mail
     "allauth.account.auth_backends.AuthenticationBackend",
 ]
-
-STORAGES = {
-    "staticfiles": {
-        # allow whitenoise compression and cache
-        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
-    },
-}
 
 # Internationalization
 # https://docs.djangoproject.com/en/4.1/topics/i18n/

--- a/gateway/main/urls.py
+++ b/gateway/main/urls.py
@@ -16,7 +16,6 @@ Including another URLconf
 
 from django.conf import settings
 from django.conf.urls.static import static
-from django.views.static import serve
 from django.contrib import admin
 from django.urls import path, include, re_path
 from rest_framework import routers, permissions

--- a/gateway/main/urls.py
+++ b/gateway/main/urls.py
@@ -49,7 +49,6 @@ urlpatterns = [
     path("", include("django_prometheus.urls")),
     path("backoffice/", admin.site.urls),
     re_path(r"^api/v1/", include(("api.v1.urls", "api"), namespace="v1")),
-    re_path(r"^static/(?P<path>.*)$", serve, {"document_root": settings.STATIC_ROOT}),
 ]
 
 if settings.DEBUG:

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -22,3 +22,4 @@ qiskit-ibm-runtime>=0.29.0
 tzdata>=2024.1
 django-cors-headers>=4.4.0, <5
 parsley>=1.3, <2
+whitenoise>=6.7.0, <7


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Right now we have some limitations in the way we are serving static files because Django doesn't serve them by default. I use a plugin to implement better static files sharing.

### Details and comments

Using [whitenoise for django](https://whitenoise.readthedocs.io/en/stable/django.html) plugin to manage static files.
