### PR TITLE
Issue 593 | Client: deprecate stop in favor of cancel

### DIFF
--- a/client/qiskit_serverless/core/job.py
+++ b/client/qiskit_serverless/core/job.py
@@ -667,6 +667,16 @@ class Job:
 
     def stop(self, service: Optional[QiskitRuntimeService] = None):
         """Stops the job from running."""
+        warnings.warn(
+            "`stop` method has been deprecated. "
+            "And will be removed in future releases. "
+            "Please, use `cancel` instead.",
+            DeprecationWarning,
+        )
+        return self.cancel(service)
+
+    def cancel(self, service: Optional[QiskitRuntimeService] = None):
+        """Cancels the job."""
         return self._job_client.stop(self.job_id, service=service)
 
     def logs(self) -> str:

--- a/client/tests/core/test_pattern.py
+++ b/client/tests/core/test_pattern.py
@@ -54,4 +54,4 @@ def test_program():
         assert "42" in recovered_job.logs()
         assert recovered_job.in_terminal_state()
         assert recovered_job.status() == "DONE"
-        assert isinstance(job.stop(), bool)
+        assert isinstance(job.cancel(), bool)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Deprecate `Job.stop` in favor of `Job.cancel`
