### PR TITLE
Provide support for large job arguments

### DIFF
--- a/client/qiskit_serverless/core/client.py
+++ b/client/qiskit_serverless/core/client.py
@@ -167,7 +167,7 @@ class BaseClient(JsonSerializable):
         >>> )
     """
 
-    def __init__(
+    def __init__(  # pylint:  disable=too-many-positional-arguments
         self,
         name: str,
         host: Optional[str] = None,
@@ -386,7 +386,7 @@ class ServerlessClient(BaseClient):
         >>> )
     """
 
-    def __init__(
+    def __init__(  # pylint:  disable=too-many-positional-arguments
         self,
         name: Optional[str] = None,
         host: Optional[str] = None,

--- a/client/qiskit_serverless/serializers/program_serializers.py
+++ b/client/qiskit_serverless/serializers/program_serializers.py
@@ -33,8 +33,6 @@ from qiskit.primitives import SamplerResult, EstimatorResult
 from qiskit_ibm_runtime import QiskitRuntimeService
 from qiskit_ibm_runtime.utils.json import RuntimeDecoder, RuntimeEncoder
 
-from qiskit_serverless.core.constants import ENV_JOB_ARGUMENTS
-
 
 class QiskitObjectsEncoder(RuntimeEncoder):
     """Json encoder for Qiskit objects."""
@@ -83,6 +81,8 @@ def get_arguments() -> Dict[str, Any]:
     """
     arguments = "{}"
     if os.path.isfile("arguments.serverless"):
-        with open("arguments.serverless", "r") as f:
+        with open(
+                "arguments.serverless", "r", encoding="utf-8"
+        ) as f:
             arguments = f.read()
     return json.loads(arguments, cls=QiskitObjectsDecoder)

--- a/client/qiskit_serverless/serializers/program_serializers.py
+++ b/client/qiskit_serverless/serializers/program_serializers.py
@@ -81,8 +81,6 @@ def get_arguments() -> Dict[str, Any]:
     """
     arguments = "{}"
     if os.path.isfile("arguments.serverless"):
-        with open(
-                "arguments.serverless", "r", encoding="utf-8"
-        ) as f:
+        with open("arguments.serverless", "r", encoding="utf-8") as f:
             arguments = f.read()
     return json.loads(arguments, cls=QiskitObjectsDecoder)

--- a/client/qiskit_serverless/serializers/program_serializers.py
+++ b/client/qiskit_serverless/serializers/program_serializers.py
@@ -81,4 +81,8 @@ def get_arguments() -> Dict[str, Any]:
     Returns:
         Dictionary of arguments.
     """
-    return json.loads(os.environ.get(ENV_JOB_ARGUMENTS, "{}"), cls=QiskitObjectsDecoder)
+    arguments = "{}"
+    if os.path.isfile("arguments.serverless"):
+        with open("arguments.serverless", "r") as f:
+            arguments = f.read()
+    return json.loads(arguments, cls=QiskitObjectsDecoder)

--- a/client/qiskit_serverless/utils/runtime_service_client.py
+++ b/client/qiskit_serverless/utils/runtime_service_client.py
@@ -93,7 +93,7 @@ class ServerlessRuntimeService(QiskitRuntimeService):
         QiskitRuntimeService (QiskitRuntimeService): Qiskit runtime service object.
     """
 
-    def run(
+    def run(  # pylint:  disable=too-many-positional-arguments
         self,
         program_id: str,
         inputs: Dict,
@@ -105,7 +105,8 @@ class ServerlessRuntimeService(QiskitRuntimeService):
         session_id: Optional[str] = None,
         start_session: Optional[bool] = False,
     ) -> Union[RuntimeJob, RuntimeJobV2]:
-        runtime_job = super().run(
+        """Run a serverless Runtime service job."""
+        runtime_job = super()._run(
             program_id,
             inputs,
             options,

--- a/client/tests/serializers/test_program_serializers.py
+++ b/client/tests/serializers/test_program_serializers.py
@@ -12,14 +12,12 @@
 
 """QiskitPattern serializers tests."""
 import json
-import os
 from unittest import TestCase, skip
 
 import numpy as np
 from qiskit.circuit.random import random_circuit
 from qiskit_ibm_runtime import QiskitRuntimeService
 
-from qiskit_serverless.core.constants import ENV_JOB_ARGUMENTS
 from qiskit_serverless.serializers.program_serializers import (
     QiskitObjectsDecoder,
     QiskitObjectsEncoder,

--- a/client/tests/serializers/test_program_serializers.py
+++ b/client/tests/serializers/test_program_serializers.py
@@ -61,8 +61,8 @@ class TestArgParsing(TestCase):
         circuit = random_circuit(4, 2)
         array = np.array([[42.0], [0.0]])
 
-        os.environ[ENV_JOB_ARGUMENTS] = json.dumps(
-            {"circuit": circuit, "array": array}, cls=QiskitObjectsEncoder
-        )
+        with open("arguments.serverless", "w", encoding="utf-8") as f:
+            json.dump({"circuit": circuit, "array": array}, f, cls=QiskitObjectsEncoder)
+
         parsed_arguments = get_arguments()
         self.assertEqual(list(parsed_arguments.keys()), ["circuit", "array"])

--- a/gateway/api/ray.py
+++ b/gateway/api/ray.py
@@ -123,8 +123,8 @@ class JobHandler:
                 logger.debug("uploading arguments for job %s", job.id)
                 with open(
                     working_directory_for_upload + "/arguments.serverless",
-                        "w",
-                        encoding="utf-8",
+                    "w",
+                    encoding="utf-8",
                 ) as f:
                     f.write(job.arguments)
 

--- a/gateway/api/ray.py
+++ b/gateway/api/ray.py
@@ -118,6 +118,12 @@ class JobHandler:
             # get entrypoint
             entrypoint = f"python {program.entrypoint}"
 
+            # upload arguments to working directory
+            if job.arguments:
+                logger.debug("uploading arguments for job %s", job.id)
+                with open(working_directory_for_upload + "/arguments.serverless", "w") as f:
+                    f.write(job.arguments)
+
             # set tracing
             carrier = {}
             TraceContextTextMapPropagator().inject(carrier)

--- a/gateway/api/ray.py
+++ b/gateway/api/ray.py
@@ -122,7 +122,9 @@ class JobHandler:
             if job.arguments:
                 logger.debug("uploading arguments for job %s", job.id)
                 with open(
-                    working_directory_for_upload + "/arguments.serverless", "w", encoding="utf-8"
+                    working_directory_for_upload + "/arguments.serverless",
+                        "w",
+                        encoding="utf-8",
                 ) as f:
                     f.write(job.arguments)
 

--- a/gateway/api/ray.py
+++ b/gateway/api/ray.py
@@ -122,7 +122,7 @@ class JobHandler:
             if job.arguments:
                 logger.debug("uploading arguments for job %s", job.id)
                 with open(
-                        working_directory_for_upload + "/arguments.serverless", "w"
+                    working_directory_for_upload + "/arguments.serverless", "w", encoding="utf-8"
                 ) as f:
                     f.write(job.arguments)
 

--- a/gateway/api/ray.py
+++ b/gateway/api/ray.py
@@ -119,14 +119,17 @@ class JobHandler:
             entrypoint = f"python {program.entrypoint}"
 
             # upload arguments to working directory
-            if job.arguments:
-                logger.debug("uploading arguments for job %s", job.id)
-                with open(
-                    working_directory_for_upload + "/arguments.serverless",
-                    "w",
-                    encoding="utf-8",
-                ) as f:
+            # if no arguments, write an empty dict to the arguments file
+            with open(
+                working_directory_for_upload + "/arguments.serverless",
+                "w",
+                encoding="utf-8",
+            ) as f:
+                if job.arguments:
+                    logger.debug("uploading arguments for job %s", job.id)
                     f.write(job.arguments)
+                else:
+                    f.write({})
 
             # set tracing
             carrier = {}

--- a/gateway/api/ray.py
+++ b/gateway/api/ray.py
@@ -121,7 +121,9 @@ class JobHandler:
             # upload arguments to working directory
             if job.arguments:
                 logger.debug("uploading arguments for job %s", job.id)
-                with open(working_directory_for_upload + "/arguments.serverless", "w") as f:
+                with open(
+                        working_directory_for_upload + "/arguments.serverless", "w"
+                ) as f:
                     f.write(job.arguments)
 
             # set tracing

--- a/gateway/api/serializers.py
+++ b/gateway/api/serializers.py
@@ -13,6 +13,7 @@ from django.conf import settings
 from django.contrib.auth.models import Group, Permission
 from django.db.models import Q
 from rest_framework import serializers
+import objsize
 
 from api.utils import build_env_variables, encrypt_env_vars
 from .models import (

--- a/gateway/api/serializers.py
+++ b/gateway/api/serializers.py
@@ -13,7 +13,6 @@ from django.conf import settings
 from django.contrib.auth.models import Group, Permission
 from django.db.models import Q
 from rest_framework import serializers
-import objsize
 
 from api.utils import build_env_variables, encrypt_env_vars
 from .models import (

--- a/gateway/api/serializers.py
+++ b/gateway/api/serializers.py
@@ -223,7 +223,7 @@ class RunJobSerializer(serializers.ModelSerializer):
             config=config,
         )
 
-        env = encrypt_env_vars(build_env_variables(token, job))
+        env = encrypt_env_vars(build_env_variables(token, job, arguments))
         try:
             env["traceparent"] = carrier["traceparent"]
         except KeyError:

--- a/gateway/api/serializers.py
+++ b/gateway/api/serializers.py
@@ -223,7 +223,7 @@ class RunJobSerializer(serializers.ModelSerializer):
             config=config,
         )
 
-        env = encrypt_env_vars(build_env_variables(token, job, arguments))
+        env = encrypt_env_vars(build_env_variables(token, job))
         try:
             env["traceparent"] = carrier["traceparent"]
         except KeyError:

--- a/gateway/api/utils.py
+++ b/gateway/api/utils.py
@@ -112,7 +112,7 @@ def decrypt_string(string: str) -> str:
     return fernet.decrypt(string.encode("utf-8")).decode("utf-8")
 
 
-def build_env_variables(token, job: Job) -> Dict[str, str]:
+def build_env_variables(token, job: Job, args: str = None) -> Dict[str, str]:
     """Builds env variables for job.
 
     Args:
@@ -123,6 +123,11 @@ def build_env_variables(token, job: Job) -> Dict[str, str]:
         env variables dict
     """
     extra = {}
+    arguments = "{}"
+    # only set arguments if size is <1MB
+    if args and sys.getsizeof(args) < 1000000:
+        arguments = args
+
     if settings.SETTINGS_AUTH_MECHANISM != "default":
         extra = {
             "QISKIT_IBM_TOKEN": str(token),
@@ -134,6 +139,7 @@ def build_env_variables(token, job: Job) -> Dict[str, str]:
             "ENV_JOB_GATEWAY_TOKEN": str(token),
             "ENV_JOB_GATEWAY_HOST": str(settings.SITE_HOST),
             "ENV_JOB_ID_GATEWAY": str(job.id),
+            "ENV_JOB_ARGUMENTS": arguments,
         },
         **extra,
     }

--- a/gateway/api/utils.py
+++ b/gateway/api/utils.py
@@ -112,13 +112,12 @@ def decrypt_string(string: str) -> str:
     return fernet.decrypt(string.encode("utf-8")).decode("utf-8")
 
 
-def build_env_variables(token, job: Job, arguments: str) -> Dict[str, str]:
+def build_env_variables(token, job: Job) -> Dict[str, str]:
     """Builds env variables for job.
 
     Args:
         token: django request token decoded
         job: job
-        arguments: program arguments
 
     Returns:
         env variables dict

--- a/gateway/api/utils.py
+++ b/gateway/api/utils.py
@@ -126,7 +126,7 @@ def build_env_variables(token, job: Job, args: str = None) -> Dict[str, str]:
     extra = {}
     # only set arguments envvar if not too big
     # remove this after sufficient time for users to upgrade client
-    arguments = "ERROR: arguments are too big. upgrade your client"
+    arguments = "{}"
     if args:
         if objsize.get_deep_size(args) < 100000:
             logger.debug("passing arguments as envvar for job %s", job.id)

--- a/gateway/api/utils.py
+++ b/gateway/api/utils.py
@@ -131,7 +131,7 @@ def build_env_variables(token, job: Job, args: str = None) -> Dict[str, str]:
         else:
             logger.warn(
                 "arguments for job [%s] are > 1MB and will not be written to env var",
-                job.id
+                job.id,
             )
 
     if settings.SETTINGS_AUTH_MECHANISM != "default":

--- a/gateway/api/utils.py
+++ b/gateway/api/utils.py
@@ -126,14 +126,14 @@ def build_env_variables(token, job: Job, args: str = None) -> Dict[str, str]:
     extra = {}
     # only set arguments envvar if not too big
     # remove this after sufficient time for users to upgrade client
-    arguments = "{}"
+    arguments = "ERROR: arguments are too big. upgrade your client"
     if args:
         if objsize.get_deep_size(args) < 100000:
-            logger.debug("passing arguments as envvar for job [%s]", job.id)
+            logger.debug("passing arguments as envvar for job %s", job.id)
             arguments = args
         else:
             logger.warning(
-                "arguments for job [%s] are too large and will not be written to env var",
+                "arguments for job %s are too large and will not be written to env var",
                 job.id,
             )
 

--- a/gateway/api/utils.py
+++ b/gateway/api/utils.py
@@ -129,7 +129,7 @@ def build_env_variables(token, job: Job, args: str = None) -> Dict[str, str]:
         if sys.getsizeof(args) < 1000000:
             arguments = args
         else:
-            logger.warn(
+            logger.warning(
                 "arguments for job [%s] are > 1MB and will not be written to env var",
                 job.id,
             )

--- a/gateway/api/utils.py
+++ b/gateway/api/utils.py
@@ -123,10 +123,13 @@ def build_env_variables(token, job: Job, args: str = None) -> Dict[str, str]:
         env variables dict
     """
     extra = {}
-    arguments = "{}"
     # only set arguments if size is <1MB
-    if args and sys.getsizeof(args) < 1000000:
-        arguments = args
+    arguments = "{}"
+    if args:
+        if sys.getsizeof(args) < 1000000:
+            arguments = args
+        else:
+            logger.warn("arguments for job [%s] are > 1MB and will not be written to env var", job.id)
 
     if settings.SETTINGS_AUTH_MECHANISM != "default":
         extra = {

--- a/gateway/api/utils.py
+++ b/gateway/api/utils.py
@@ -129,7 +129,10 @@ def build_env_variables(token, job: Job, args: str = None) -> Dict[str, str]:
         if sys.getsizeof(args) < 1000000:
             arguments = args
         else:
-            logger.warn("arguments for job [%s] are > 1MB and will not be written to env var", job.id)
+            logger.warn(
+                "arguments for job [%s] are > 1MB and will not be written to env var",
+                job.id
+            )
 
     if settings.SETTINGS_AUTH_MECHANISM != "default":
         extra = {

--- a/gateway/api/utils.py
+++ b/gateway/api/utils.py
@@ -135,7 +135,6 @@ def build_env_variables(token, job: Job, arguments: str) -> Dict[str, str]:
             "ENV_JOB_GATEWAY_TOKEN": str(token),
             "ENV_JOB_GATEWAY_HOST": str(settings.SITE_HOST),
             "ENV_JOB_ID_GATEWAY": str(job.id),
-            "ENV_JOB_ARGUMENTS": arguments,
         },
         **extra,
     }

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -23,3 +23,4 @@ tzdata>=2024.1
 django-cors-headers>=4.4.0, <5
 parsley>=1.3, <2
 whitenoise>=6.7.0, <7
+objsize>=0.7.0

--- a/gateway/tests/api/test_utils.py
+++ b/gateway/tests/api/test_utils.py
@@ -31,7 +31,7 @@ class TestUtils(APITestCase):
                 "ENV_JOB_GATEWAY_TOKEN": "42",
                 "ENV_JOB_GATEWAY_HOST": "http://localhost:8000",
                 "ENV_JOB_ID_GATEWAY": "42",
-                "ENV_JOB_ARGUMENTS": "ERROR: arguments are too big. upgrade your client",
+                "ENV_JOB_ARGUMENTS": "{}",
             },
         )
 
@@ -43,7 +43,7 @@ class TestUtils(APITestCase):
                 "ENV_JOB_GATEWAY_TOKEN": "42",
                 "ENV_JOB_GATEWAY_HOST": "http://localhost:8000",
                 "ENV_JOB_ID_GATEWAY": "42",
-                "ENV_JOB_ARGUMENTS": "ERROR: arguments are too big. upgrade your client",
+                "ENV_JOB_ARGUMENTS": "{}",
                 "QISKIT_IBM_TOKEN": "42",
                 "QISKIT_IBM_CHANNEL": "ibm_quantum",
                 "QISKIT_IBM_URL": "https://auth.quantum-computing.ibm.com/api",

--- a/gateway/tests/api/test_utils.py
+++ b/gateway/tests/api/test_utils.py
@@ -37,9 +37,7 @@ class TestUtils(APITestCase):
         with self.settings(
             SETTINGS_AUTH_MECHANISM="custom_token", SECRET_KEY="super-secret"
         ):
-            env_vars_with_qiskit_runtime = build_env_variables(
-                token=token, job=job
-            )
+            env_vars_with_qiskit_runtime = build_env_variables(token=token, job=job)
             expecting = {
                 "ENV_JOB_GATEWAY_TOKEN": "42",
                 "ENV_JOB_GATEWAY_HOST": "http://localhost:8000",

--- a/gateway/tests/api/test_utils.py
+++ b/gateway/tests/api/test_utils.py
@@ -24,14 +24,13 @@ class TestUtils(APITestCase):
         token = "42"
         job = MagicMock()
         job.id = "42"
-        env_vars = build_env_variables(token=token, job=job, arguments={"answer": 42})
+        env_vars = build_env_variables(token=token, job=job)
         self.assertEqual(
             env_vars,
             {
                 "ENV_JOB_GATEWAY_TOKEN": "42",
                 "ENV_JOB_GATEWAY_HOST": "http://localhost:8000",
                 "ENV_JOB_ID_GATEWAY": "42",
-                "ENV_JOB_ARGUMENTS": {"answer": 42},
             },
         )
 
@@ -39,13 +38,12 @@ class TestUtils(APITestCase):
             SETTINGS_AUTH_MECHANISM="custom_token", SECRET_KEY="super-secret"
         ):
             env_vars_with_qiskit_runtime = build_env_variables(
-                token=token, job=job, arguments={"answer": 42}
+                token=token, job=job
             )
             expecting = {
                 "ENV_JOB_GATEWAY_TOKEN": "42",
                 "ENV_JOB_GATEWAY_HOST": "http://localhost:8000",
                 "ENV_JOB_ID_GATEWAY": "42",
-                "ENV_JOB_ARGUMENTS": {"answer": 42},
                 "QISKIT_IBM_TOKEN": "42",
                 "QISKIT_IBM_CHANNEL": "ibm_quantum",
                 "QISKIT_IBM_URL": "https://auth.quantum-computing.ibm.com/api",

--- a/gateway/tests/api/test_utils.py
+++ b/gateway/tests/api/test_utils.py
@@ -31,7 +31,7 @@ class TestUtils(APITestCase):
                 "ENV_JOB_GATEWAY_TOKEN": "42",
                 "ENV_JOB_GATEWAY_HOST": "http://localhost:8000",
                 "ENV_JOB_ID_GATEWAY": "42",
-                "ENV_JOB_ARGUMENTS": "{}",
+                "ENV_JOB_ARGUMENTS": "ERROR: arguments are too big. upgrade your client",
             },
         )
 
@@ -43,7 +43,7 @@ class TestUtils(APITestCase):
                 "ENV_JOB_GATEWAY_TOKEN": "42",
                 "ENV_JOB_GATEWAY_HOST": "http://localhost:8000",
                 "ENV_JOB_ID_GATEWAY": "42",
-                "ENV_JOB_ARGUMENTS": "{}",
+                "ENV_JOB_ARGUMENTS": "ERROR: arguments are too big. upgrade your client",
                 "QISKIT_IBM_TOKEN": "42",
                 "QISKIT_IBM_CHANNEL": "ibm_quantum",
                 "QISKIT_IBM_URL": "https://auth.quantum-computing.ibm.com/api",

--- a/gateway/tests/api/test_utils.py
+++ b/gateway/tests/api/test_utils.py
@@ -31,6 +31,7 @@ class TestUtils(APITestCase):
                 "ENV_JOB_GATEWAY_TOKEN": "42",
                 "ENV_JOB_GATEWAY_HOST": "http://localhost:8000",
                 "ENV_JOB_ID_GATEWAY": "42",
+                "ENV_JOB_ARGUMENTS": "{}",
             },
         )
 

--- a/gateway/tests/api/test_utils.py
+++ b/gateway/tests/api/test_utils.py
@@ -42,6 +42,7 @@ class TestUtils(APITestCase):
                 "ENV_JOB_GATEWAY_TOKEN": "42",
                 "ENV_JOB_GATEWAY_HOST": "http://localhost:8000",
                 "ENV_JOB_ID_GATEWAY": "42",
+                "ENV_JOB_ARGUMENTS": "{}",
                 "QISKIT_IBM_TOKEN": "42",
                 "QISKIT_IBM_CHANNEL": "ibm_quantum",
                 "QISKIT_IBM_URL": "https://auth.quantum-computing.ibm.com/api",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Provide support for passing large arguments (>1MB) for programs / functions. Utility-scale circuits, for example.

### Details and comments

We used to use the Ray environmental variable `ENV_JOB_ARGUMENTS` to pass arguments to programs at runtime. While this is fine for small arguments, Ray wasn't able to handle larger ones (like circuits at utlity scale using 100+ qubits), which resulted in the job being stuck in the pending / initializing phase.

So instead of trying to pass arguments by environmental variable, this PR updates the submission flow to write arguments to a file (`arguments.serverless`, overwriting any existing file) in the working directory so it will be included when the job is sent to the Ray cluster. 

Since this is happening in the gateway, it won't run into the `MAX_ARTIFACT_FILE_SIZE_MB` limitation, which is checked in the client _before_ arguments would be added.





