### PR TITLE
Add support of symbolic links as entrypoint of function.

### DIFF
--- a/client/qiskit_serverless/core/job.py
+++ b/client/qiskit_serverless/core/job.py
@@ -882,7 +882,7 @@ def _upload_with_artifact(
         )
 
     try:
-        with tarfile.open(artifact_file_path, "w") as tar:
+        with tarfile.open(artifact_file_path, "w", dereference=True) as tar:
             for filename in os.listdir(program.working_dir):
                 fpath = os.path.join(program.working_dir, filename)
                 tar.add(fpath, arcname=filename)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

If the entrypoint specified in Function is not a regular file but a symbolic link to a python file, the upload to the cluster will be incomplete and execution of the entrypoint will fail. This PR provides support to run with symbolic links/hardlinks in addition to real file.

### Details and comments

Creates `source_files` directory and put the following 2 files. One is real file, another is symbolic linked file.

```
source_files/
    pattern_with_arguments.py@ -> ../basic/source_files/pattern_with_arguments.py
```

And then, creates an instance of QiskitFunction with `pattern_with_parallel_workflow.py` as entrypoint.

```
function = QiskitFunction(
    title="test",
    entrypoint="pattern_with_parallel_workflow.py",
    working_dir="./source_files/",
)
```

Above invocation and subsequent upload() are succeeded, but the following error is occurred when running this function.

```
2024-10-11 12:48:18,794	INFO job_manager.py:531 -- Runtime env is setting up.
python: can't open file '/tmp/ray/session_2024-10-11_12-05-19_925458_1/runtime_resources/working_dir_files/_ray_pkg_e8408231f4c60cc4/pattern_with_parallel_workflow.py': [Errno 2] No such file or directory
```

This is because of [this implementation](https://github.com/Qiskit/qiskit-serverless/blob/cf655f26d93c7447c567d7b862872b553cdcc94d/client/qiskit_serverless/core/job.py#L885).  

Symbolic link target(=content) will not be included in the archive file. As result, it will not be available in the cluster side.
[TarFile](https://docs.python.org/3/library/tarfile.html#tarfile.TarFile) provides the solution for this case. The content of the target files can be added to the archive if `dereference=True`. 

` with tarfile.open(artifact_file_path, "w", dereference=True) as tar:`

This PR will change above 1 line to support both regular file and symbolic/hard links.