### PR TITLE
feat: improve instances many to many in backoffice

### DIFF
--- a/gateway/api/admin.py
+++ b/gateway/api/admin.py
@@ -23,6 +23,7 @@ class ProgramAdmin(admin.ModelAdmin):
     search_fields = ["title", "author__username"]
     list_filter = ["provider", "type"]
     exclude = ["env_vars"]
+    filter_horizontal = ["instances"]
 
 
 @admin.register(ComputeResource)


### PR DESCRIPTION
### Summary

This PR improves the "Instances" field in the form located at `/backoffice/api/program/add/`.

It uses the `filter_horizontal` described [here](https://stackoverflow.com/questions/5385933/a-better-django-admin-manytomany-field-widget)

### Screenshot

![image](https://github.com/user-attachments/assets/ec435db5-82a3-49d9-a01f-86011e9be872)


