### PR TITLE
Change tox testenv:black envdir

### DIFF
--- a/client/tox.ini
+++ b/client/tox.ini
@@ -24,7 +24,6 @@ commands =
   python -m pytest -v
 
 [testenv:lint]
-envdir = .tox/lint
 skip_install = true
 commands =
   black --diff --check .
@@ -32,7 +31,6 @@ commands =
   mypy --install-types --non-interactive .
 
 [testenv:black]
-envdir = .tox/black
 skip_install = true
 commands = black .
 

--- a/client/tox.ini
+++ b/client/tox.ini
@@ -32,7 +32,7 @@ commands =
   mypy --install-types --non-interactive .
 
 [testenv:black]
-envdir = .tox/lint
+envdir = .tox/black
 skip_install = true
 commands = black .
 


### PR DESCRIPTION
### Summary

I realized that if i run `tox -eblack && tox -elint` dependencies are installed twice everytime i execute it.
If we change the `envdir` of black, we have the dependecies duplicated in both directories but they are installed only the first time so it is much faster.

Is there any better option @IceKhan13 ?