### PR TITLE
Add `is_running_in_serverless()` function

### DIFF
--- a/client/qiskit_serverless/__init__.py
+++ b/client/qiskit_serverless/__init__.py
@@ -34,7 +34,7 @@ from .core import (
     LocalClient,
     save_result,
     Configuration,
-    is_running_as_serverless_program,
+    is_running_in_serverless,
 )
 from .exception import QiskitServerlessException
 from .core.function import QiskitPattern, QiskitFunction

--- a/client/qiskit_serverless/__init__.py
+++ b/client/qiskit_serverless/__init__.py
@@ -34,6 +34,7 @@ from .core import (
     LocalClient,
     save_result,
     Configuration,
+    is_running_as_serverless_program,
 )
 from .exception import QiskitServerlessException
 from .core.function import QiskitPattern, QiskitFunction

--- a/client/qiskit_serverless/core/__init__.py
+++ b/client/qiskit_serverless/core/__init__.py
@@ -44,7 +44,7 @@ Core abstractions
     get
     put
     get_refs_by_status
-    is_running_as_serverless_program
+    is_running_in_serverless
 
 """
 
@@ -58,7 +58,7 @@ from .job import (
     Job,
     save_result,
     Configuration,
-    is_running_as_serverless_program,
+    is_running_in_serverless,
 )
 from .function import QiskitPattern, QiskitFunction
 from .decorators import (

--- a/client/qiskit_serverless/core/__init__.py
+++ b/client/qiskit_serverless/core/__init__.py
@@ -44,6 +44,7 @@ Core abstractions
     get
     put
     get_refs_by_status
+    is_running_as_serverless_program
 
 """
 
@@ -57,6 +58,7 @@ from .job import (
     Job,
     save_result,
     Configuration,
+    is_running_as_serverless_program,
 )
 from .function import QiskitPattern, QiskitFunction
 from .decorators import (

--- a/client/qiskit_serverless/core/job.py
+++ b/client/qiskit_serverless/core/job.py
@@ -279,3 +279,8 @@ def _map_status_to_serverless(status: str) -> str:
         return status_map[status]
     except KeyError:
         return status
+
+
+def is_running_as_serverless_program() -> bool:
+    """Return ``True`` if running as a Qiskit serverless program, ``False`` otherwise."""
+    return "ENV_JOB_ID_GATEWAY" in os.environ

--- a/client/qiskit_serverless/core/job.py
+++ b/client/qiskit_serverless/core/job.py
@@ -281,6 +281,6 @@ def _map_status_to_serverless(status: str) -> str:
         return status
 
 
-def is_running_as_serverless_program() -> bool:
+def is_running_in_serverless() -> bool:
     """Return ``True`` if running as a Qiskit serverless program, ``False`` otherwise."""
     return "ENV_JOB_ID_GATEWAY" in os.environ

--- a/client/tests/core/test_job.py
+++ b/client/tests/core/test_job.py
@@ -16,7 +16,7 @@ from qiskit_serverless.core.constants import (
     ENV_JOB_ID_GATEWAY,
     ENV_JOB_GATEWAY_TOKEN,
 )
-from qiskit_serverless.core.job import is_running_as_serverless_program, save_result
+from qiskit_serverless.core.job import is_running_in_serverless, save_result
 
 
 # pylint: disable=redefined-outer-name
@@ -78,13 +78,13 @@ class TestJob:
 
 
 class TestRunningAsServerlessProgram:
-    """Test ``is_running_as_serverless_program()``."""
+    """Test ``is_running_in_serverless()``."""
 
     def test_not_running_as_serverless_program(self):
-        """Test ``is_running_as_serverless_program()`` outside a serverless program."""
-        assert is_running_as_serverless_program() is False
+        """Test ``is_running_in_serverless()`` outside a serverless program."""
+        assert is_running_in_serverless() is False
 
     def test_running_as_serverless_program(self, job_env_variables):
-        """Test ``is_running_as_serverless_program()`` in a mocked serverless program."""
+        """Test ``is_running_in_serverless()`` in a mocked serverless program."""
         _ = job_env_variables
-        assert is_running_as_serverless_program() is True
+        assert is_running_in_serverless() is True

--- a/client/tests/core/test_job.py
+++ b/client/tests/core/test_job.py
@@ -2,10 +2,10 @@
 
 # pylint: disable=too-few-public-methods
 import os
-from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
+import pytest
 import requests_mock
 
 from qiskit.circuit.random import random_circuit
@@ -16,7 +16,19 @@ from qiskit_serverless.core.constants import (
     ENV_JOB_ID_GATEWAY,
     ENV_JOB_GATEWAY_TOKEN,
 )
-from qiskit_serverless.core.job import save_result
+from qiskit_serverless.core.job import is_running_as_serverless_program, save_result
+
+
+# pylint: disable=redefined-outer-name
+@pytest.fixture()
+def job_env_variables(monkeypatch):
+    """Fixture to set mock job environment variables."""
+    # Inspired by https://stackoverflow.com/a/77256931/1558890
+    with patch.dict(os.environ, clear=True):
+        monkeypatch.setenv(ENV_JOB_GATEWAY_HOST, "https://awesome-tests.com/")
+        monkeypatch.setenv(ENV_JOB_ID_GATEWAY, "42")
+        monkeypatch.setenv(ENV_JOB_GATEWAY_TOKEN, "awesome-token")
+        yield  # Restore the environment after the test runs
 
 
 class ResponseMock:
@@ -26,15 +38,12 @@ class ResponseMock:
     text = "{}"
 
 
-class TestJob(TestCase):
+class TestJob:
     """TestJob."""
 
-    def test_save_result(self):
+    def test_save_result(self, job_env_variables):
         """Tests job save result."""
-
-        os.environ[ENV_JOB_GATEWAY_HOST] = "https://awesome-tests.com/"
-        os.environ[ENV_JOB_ID_GATEWAY] = "42"
-        os.environ[ENV_JOB_GATEWAY_TOKEN] = "awesome-token"
+        _ = job_env_variables
 
         url = (
             f"{os.environ.get(ENV_JOB_GATEWAY_HOST)}/"
@@ -48,7 +57,7 @@ class TestJob(TestCase):
                     "quantum_circuit": random_circuit(3, 2),
                 }
             )
-            self.assertTrue(result)
+            assert result is True
 
     @patch("requests.get", Mock(return_value=ResponseMock()))
     def test_filtered_logs(self):
@@ -66,3 +75,16 @@ class TestJob(TestCase):
         assert "This is the line 1\n" == client.filtered_logs(
             "id", include="This is the l.+", exclude="the.+a.+l"
         )
+
+
+class TestRunningAsServerlessProgram:
+    """Test ``is_running_as_serverless_program()``."""
+
+    def test_not_running_as_serverless_program(self):
+        """Test ``is_running_as_serverless_program()`` outside a serverless program."""
+        assert is_running_as_serverless_program() is False
+
+    def test_running_as_serverless_program(self, job_env_variables):
+        """Test ``is_running_as_serverless_program()`` in a mocked serverless program."""
+        _ = job_env_variables
+        assert is_running_as_serverless_program() is True


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This adds a function so that the user can easily detect whether the program is running under Qiskit serverless. In some instances, a person may want to be able to branch on whether that is the case.

### Details and comments

I am not necessarily attached to this name.

For the tests, I improved them by making the environment variable handling be temporary and in a fixture.  This meant a slight migration to pytest style (from unittest style), and silencing a pylint warning.