### PR TITLE
Fix build stage name

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -2,11 +2,11 @@ ARG MICRO_IMAGE_DIR=/ubi-micro-img
 
 # BASE image using UBI 9 micro where the
 # application and requirements will be installed
-FROM registry.access.redhat.com/ubi9-micro:9.4-15 AS BASE
+FROM registry.access.redhat.com/ubi9-micro:9.4-15 AS base
 
 # BUILD image using UBI 9 where the dependencies that
 # require installing with a package manager will be installed
-FROM registry.access.redhat.com/ubi9:9.4-1214.1726694543 AS BUILD
+FROM registry.access.redhat.com/ubi9:9.4-1214.1726694543 AS build
 ARG MICRO_IMAGE_DIR
 
 # Copy the BASE image into the BUILD image
@@ -24,7 +24,7 @@ RUN dnf install --installroot ${MICRO_IMAGE_DIR} --nodocs -y \
 
 # APP image from `scratch` which will be the final image
 # and remaining application requirements will be installed
-FROM scratch AS APP
+FROM scratch AS app
 ARG MICRO_IMAGE_DIR
 # hadolint ignore=DL3045
 COPY --from=BUILD ${MICRO_IMAGE_DIR}/ .


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR should remove the warnings generated at build time in the gateway image:

```
#1 WARN: StageNameCasing: Stage name 'BASE' should be lowercase (line 5)
#1 WARN: StageNameCasing: Stage name 'BUILD' should be lowercase (line 9)
#1 WARN: StageNameCasing: Stage name 'APP' should be lowercase (line 27)
```
