### PR TITLE
Upload end point

### DIFF
--- a/gateway/api/services/file_storage.py
+++ b/gateway/api/services/file_storage.py
@@ -10,6 +10,7 @@ from typing import Optional, Tuple
 from wsgiref.util import FileWrapper
 
 from django.conf import settings
+from django.core.files import File
 
 from utils import sanitize_file_path
 
@@ -171,3 +172,26 @@ class FileStorage:  # pylint: disable=too-few-public-methods
             file_size = os.path.getsize(path_to_file)
 
             return file_wrapper, file_type, file_size
+
+    def upload_file(self, file: File) -> str:
+        """
+        This method upload a file to the specific path:
+            - Only files with supported extensions are available to download
+            - It returns only a file from a user or a provider file storage
+
+        Args:
+            file (django.File): the file to store in the specific path
+
+        Returns:
+            str: the path where the file was stored
+        """
+
+        file_name = sanitize_file_path(file.name)
+        basename = os.path.basename(file_name)
+        path_to_file = sanitize_file_path(os.path.join(self.file_path, basename))
+
+        with open(path_to_file, "wb+") as destination:
+            for chunk in file.chunks():
+                destination.write(chunk)
+
+        return path_to_file

--- a/gateway/api/services/file_storage.py
+++ b/gateway/api/services/file_storage.py
@@ -148,6 +148,9 @@ class FileStorage:  # pylint: disable=too-few-public-methods
             - Only files with supported extensions are available to download
             - It returns only a file from a user or a provider file storage
 
+        Args:
+            file_name (str): the name of the file to download
+
         Returns:
             FileWrapper: the file itself
             str: with the type of the file
@@ -195,7 +198,7 @@ class FileStorage:  # pylint: disable=too-few-public-methods
                 destination.write(chunk)
 
         return path_to_file
-    
+
     def remove_file(self, file_name: str) -> bool:
         """
         This method remove a file in the path of file_name

--- a/gateway/api/v1/views/files.py
+++ b/gateway/api/v1/views/files.py
@@ -143,18 +143,65 @@ class FilesViewSet(views.FilesViewSet):
         return super().delete(request)
 
     @swagger_auto_schema(
-        operation_description="Upload selected file",
+        operation_description="Upload a file into the user directory",
         request_body=openapi.Schema(
             type=openapi.TYPE_OBJECT,
             properties={
-                "file": openapi.Schema(type=openapi.TYPE_FILE, description="file name"),
-                "provider": openapi.Schema(
-                    type=openapi.TYPE_STRING, description="provider name"
-                ),
+                "file": openapi.Schema(
+                    type=openapi.TYPE_FILE, description="File to be uploaded"
+                )
             },
             required=["file"],
         ),
+        manual_parameters=[
+            openapi.Parameter(
+                "function",
+                openapi.IN_QUERY,
+                description="Qiskit Function title",
+                type=openapi.TYPE_STRING,
+                required=True,
+            ),
+            openapi.Parameter(
+                "provider",
+                openapi.IN_QUERY,
+                description="Provider name",
+                type=openapi.TYPE_STRING,
+                required=False,
+            ),
+        ],
     )
     @action(methods=["POST"], detail=False)
     def upload(self, request):
         return super().upload(request)
+
+    @swagger_auto_schema(
+        operation_description="Upload a file into the provider directory",
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                "file": openapi.Schema(
+                    type=openapi.TYPE_FILE, description="File to be uploaded"
+                )
+            },
+            required=["file"],
+        ),
+        manual_parameters=[
+            openapi.Parameter(
+                "function",
+                openapi.IN_QUERY,
+                description="Qiskit Function title",
+                type=openapi.TYPE_STRING,
+                required=True,
+            ),
+            openapi.Parameter(
+                "provider",
+                openapi.IN_QUERY,
+                description="Provider name",
+                type=openapi.TYPE_STRING,
+                required=True,
+            ),
+        ],
+    )
+    @action(methods=["POST"], detail=False, url_path="provider/upload")
+    def provider_upload(self, request):
+        return super().provider_upload(request)

--- a/gateway/api/views/files.py
+++ b/gateway/api/views/files.py
@@ -6,7 +6,6 @@ Version views inherit from the different views.
 import logging
 import os
 
-from django.conf import settings
 from django.http import StreamingHttpResponse
 
 # pylint: disable=duplicate-code
@@ -23,7 +22,6 @@ from rest_framework.response import Response
 from api.services.file_storage import SUPPORTED_FILE_EXTENSIONS, FileStorage, WorkingDir
 from api.utils import sanitize_file_name, sanitize_name
 from api.models import Provider, Program
-from utils import sanitize_file_path
 
 # pylint: disable=duplicate-code
 logger = logging.getLogger("gateway")

--- a/gateway/tests/api/test_v1_files.py
+++ b/gateway/tests/api/test_v1_files.py
@@ -1,7 +1,7 @@
 """Tests files api."""
 
 import os
-from urllib.parse import quote_plus
+from urllib.parse import urlencode
 
 from django.urls import reverse
 from rest_framework import status
@@ -381,18 +381,22 @@ class TestFilesApi(APITestCase):
         media_root = os.path.normpath(os.path.join(os.getcwd(), media_root))
 
         with self.settings(MEDIA_ROOT=media_root):
-            user = models.User.objects.get(username="test_user")
+            function = "personal-program"
+            user = models.User.objects.get(username="test_user_2")
             self.client.force_authenticate(user=user)
             url = reverse("v1:files-upload")
+
             with open("README.md") as f:
+                query_params = {"function": function}
                 response = self.client.post(
-                    url,
-                    data={"file": f},
+                    f"{url}?{urlencode(query_params)}",
+                    {"file": f},
                     format="multipart",
                 )
+
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
-                self.assertTrue(os.path.join(media_root, "test_user", "README.md"))
-                os.remove(os.path.join(media_root, "test_user", "README.md"))
+                self.assertTrue(os.path.join(media_root, "test_user_2", "README.md"))
+                os.remove(os.path.join(media_root, "test_user_2", "README.md"))
 
     def test_provider_file_upload(self):
         """Tests uploading existing file."""
@@ -405,18 +409,25 @@ class TestFilesApi(APITestCase):
         media_root = os.path.normpath(os.path.join(os.getcwd(), media_root))
 
         with self.settings(MEDIA_ROOT=media_root):
+            provider = "default"
+            function = "Program"
             user = models.User.objects.get(username="test_user_2")
             self.client.force_authenticate(user=user)
-            url = reverse("v1:files-upload")
+            url = reverse("v1:files-provider-upload")
+
             with open("README.md") as f:
+                query_params = {"function": function, "provider": provider}
                 response = self.client.post(
-                    url,
-                    data={"file": f, "provider": "default"},
+                    f"{url}?{urlencode(query_params)}",
+                    {"file": f},
                     format="multipart",
                 )
+
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
-                self.assertTrue(os.path.join(media_root, "test_user", "README.md"))
-                os.remove(os.path.join(media_root, "default", "README.md"))
+                self.assertTrue(
+                    os.path.join(media_root, "default", "Program", "README.md")
+                )
+                os.remove(os.path.join(media_root, "default", "Program", "README.md"))
 
     def test_escape_directory(self):
         """Tests directory escape / injection."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Following the work done in #1529 this PR refactors the `upload` end-point. The process followed was very similar:

This PR enables `files/upload` and `files/provider/upload` end-points to be able to upload the files to the user and provider directory.

### Details and comments

- `files/upload` end-point was separated in two:
  -  `files/upload` now contains the paths: `username/` and `username/provider/function`. Following the previous development, with the purpose to separate paths where to upload the files from functions from the user's root folder.
  - `files/provider/upload` to manage the path `provider/function` so now each function will have its own folder in the provider directory to upload the files.