### PR TITLE
Remove setuptools from docker image

### DIFF
--- a/Dockerfile-ray-node
+++ b/Dockerfile-ray-node
@@ -21,7 +21,7 @@ RUN mkdir /function_data && chown 1000:1000 /function_data
 COPY client ./qs
 WORKDIR /qs
 
-# Need versions of pip/setuptools more recent than provided by UBI image
+# Need versions of pip more recent than provided by UBI image
 RUN python3.11 -m ensurepip --upgrade
 
 RUN pip install --upgrade --no-cache-dir pip>=24.2

--- a/Dockerfile-ray-node
+++ b/Dockerfile-ray-node
@@ -24,8 +24,7 @@ WORKDIR /qs
 # Need versions of pip/setuptools more recent than provided by UBI image
 RUN python3.11 -m ensurepip --upgrade
 
-RUN pip install --upgrade --no-cache-dir pip>=24.2 &&\
-    pip install --upgrade --no-cache-dir setuptools>=72.1.0
+RUN pip install --upgrade --no-cache-dir pip>=24.2
 
 RUN pip install -r requirements.txt --no-cache-dir &&\
     pip install . --no-cache-dir &&\


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Initially we are only using setuptools in `requirements-dev` and is a dependency that should not be needed in the docker image installation. 