### PR TITLE
Improve the logic to manage authentication errors

### DIFF
--- a/gateway/api/authentication.py
+++ b/gateway/api/authentication.py
@@ -35,10 +35,10 @@ class CustomTokenBackend(authentication.BaseAuthentication):
 
         auth_header = request.META.get("HTTP_AUTHORIZATION")
         if auth_header is None:
-            logger.warning(
+            logger.warning("Authorization token was not provided.")
+            raise exceptions.AuthenticationFailed(
                 "Authorization token was not provided."
             )
-            raise exceptions.AuthenticationFailed("Authorization token was not provided.")
         authorization_token = auth_header.split(" ")[-1]
 
         quantum_user = AuthenticationUseCase(
@@ -60,10 +60,10 @@ class MockTokenBackend(authentication.BaseAuthentication):
 
         auth_header = request.META.get("HTTP_AUTHORIZATION")
         if auth_header is None:
-            logger.warning(
+            logger.warning("Authorization token was not provided.")
+            raise exceptions.AuthenticationFailed(
                 "Authorization token was not provided."
             )
-            raise exceptions.AuthenticationFailed("Authorization token was not provided.")
         authorization_token = auth_header.split(" ")[-1]
 
         quantum_user = AuthenticationUseCase(

--- a/gateway/api/authentication.py
+++ b/gateway/api/authentication.py
@@ -3,7 +3,7 @@
 import logging
 from dataclasses import dataclass
 from typing import Optional
-from rest_framework import authentication
+from rest_framework import authentication, exceptions
 
 from api.use_cases.authentication import AuthenticationUseCase
 from api.use_cases.enums.channel import Channel
@@ -36,18 +36,14 @@ class CustomTokenBackend(authentication.BaseAuthentication):
         auth_header = request.META.get("HTTP_AUTHORIZATION")
         if auth_header is None:
             logger.warning(
-                "Problems authenticating: user did not provide authorization token."
+                "Authorization token was not provided."
             )
-            return quantum_user, authorization_token
+            raise exceptions.AuthenticationFailed("Authorization token was not provided.")
         authorization_token = auth_header.split(" ")[-1]
 
         quantum_user = AuthenticationUseCase(
             channel=channel, authorization_token=authorization_token, crn=crn
         ).execute()
-        if quantum_user is None:
-            return quantum_user, CustomAuthentication(
-                channel=channel, token=authorization_token.encode(), instance=crn
-            )
 
         return quantum_user, CustomAuthentication(
             channel=channel, token=authorization_token.encode(), instance=crn
@@ -65,18 +61,14 @@ class MockTokenBackend(authentication.BaseAuthentication):
         auth_header = request.META.get("HTTP_AUTHORIZATION")
         if auth_header is None:
             logger.warning(
-                "Problems authenticating: user did not provide authorization token."
+                "Authorization token was not provided."
             )
-            return quantum_user, authorization_token
+            raise exceptions.AuthenticationFailed("Authorization token was not provided.")
         authorization_token = auth_header.split(" ")[-1]
 
         quantum_user = AuthenticationUseCase(
             channel=channel, authorization_token=authorization_token, crn=None
         ).execute()
-        if quantum_user is None:
-            return quantum_user, CustomAuthentication(
-                channel=channel, token=authorization_token.encode(), instance=None
-            )
 
         return quantum_user, CustomAuthentication(
             channel=channel, token=authorization_token.encode(), instance=None

--- a/gateway/api/authentication.py
+++ b/gateway/api/authentication.py
@@ -49,6 +49,15 @@ class CustomTokenBackend(authentication.BaseAuthentication):
             channel=channel, token=authorization_token.encode(), instance=crn
         )
 
+    def authenticate_header(self, request):
+        """
+        This method is needed to returna 401 when the authentication fails.
+
+        It setups the WWW-Authenticate header with the value Bearer to identify
+        that we are using Bearer <token> as way to authenticate the user.
+        """
+        return "Bearer"
+
 
 class MockTokenBackend(authentication.BaseAuthentication):
     """Custom mock auth backend for tests."""
@@ -73,3 +82,12 @@ class MockTokenBackend(authentication.BaseAuthentication):
         return quantum_user, CustomAuthentication(
             channel=channel, token=authorization_token.encode(), instance=None
         )
+
+    def authenticate_header(self, request):
+        """
+        This method is needed to returna 401 when the authentication fails.
+
+        It setups the WWW-Authenticate header with the value Bearer to identify
+        that we are using Bearer <token> as way to authenticate the user.
+        """
+        return "Bearer"

--- a/gateway/api/services/authentication/ibm_cloud.py
+++ b/gateway/api/services/authentication/ibm_cloud.py
@@ -44,9 +44,7 @@ class IBMCloudService(AuthenticationBase):
             None: in case the authentication failed
         """
         if self.iam_url is None:
-            logger.warning(
-                "IAM URL environment variable was not correctly configured."
-            )
+            logger.warning("IAM URL environment variable was not correctly configured.")
             raise exceptions.AuthenticationFailed("You couldn't be authenticated.")
 
         iam_identity_service = IamIdentityV1(authenticator=self.authenticator)
@@ -57,17 +55,23 @@ class IBMCloudService(AuthenticationBase):
             ).get_result()
         except ApiException as api_exception:
             logger.warning("IBM Cloud authentication error: %s.", api_exception.message)
-            raise exceptions.AuthenticationFailed("You couldn't be authenticated, please review your API Key.")
+            raise exceptions.AuthenticationFailed(
+                "You couldn't be authenticated, please review your API Key."
+            )
 
         self.account_id = user_info.get("account_id")
         if self.account_id is None:
             logger.warning("IBM Cloud didn't return the Account ID for the user.")
-            raise exceptions.AuthenticationFailed("There was a problem in the autentication process with IBM Cloud, please try later.")
-        
+            raise exceptions.AuthenticationFailed(
+                "There was a problem in the autentication process with IBM Cloud, please try later."
+            )
+
         self.iam_id = user_info.get("iam_id")
         if self.iam_id is None:
             logger.warning("IBM Cloud didn't return the IAM ID for the user.")
-            raise exceptions.AuthenticationFailed("There was a problem in the autentication process with IBM Cloud, please try later.")
+            raise exceptions.AuthenticationFailed(
+                "There was a problem in the autentication process with IBM Cloud, please try later."
+            )
 
         logger.debug(
             "User authenticated with account_id[%s] and iam_id[%s]",
@@ -94,16 +98,22 @@ class IBMCloudService(AuthenticationBase):
             ).get_result()
         except ApiException as api_exception:
             logger.warning("IBM Cloud verification error: %s.", api_exception.message)
-            raise exceptions.AuthenticationFailed("There was a problem in the autentication process with IBM Cloud, please review your CRN.")
+            raise exceptions.AuthenticationFailed(
+                "There was a problem in the autentication process with IBM Cloud, please review your CRN."  # pylint: disable=line-too-long
+            )
 
         resource_plan_id = instance.get("resource_plan_id")
         if resource_plan_id is None:
-            logger.warning("IBM Cloud didn't return the Resource plan ID for the resource.")
-            raise exceptions.AuthenticationFailed("There was a problem in the autentication process with IBM Cloud, please try later.")
-        
+            logger.warning(
+                "IBM Cloud didn't return the Resource plan ID for the resource."
+            )
+            raise exceptions.AuthenticationFailed(
+                "There was a problem in the autentication process with IBM Cloud, please try later."
+            )
+
         if resource_plan_id not in settings.RESOURCE_PLANS_ID_ALLOWED:
             logger.warning(
-                "User has no access to the service using IBM Cloud, Resource plan ID [%s] is not a valid plan %s.",
+                "User has no access to the service using IBM Cloud, Resource plan ID [%s] is not a valid plan %s.",  # pylint: disable=line-too-long
                 resource_plan_id,
                 settings.RESOURCE_PLANS_ID_ALLOWED,
             )

--- a/gateway/api/services/authentication/local_authentication.py
+++ b/gateway/api/services/authentication/local_authentication.py
@@ -4,6 +4,7 @@ import logging
 from typing import List
 
 from django.conf import settings
+from rest_framework import exceptions
 
 from api.services.authentication.authentication_base import AuthenticationBase
 
@@ -33,14 +34,14 @@ class LocalAuthenticationService(AuthenticationBase):
             None: in case the authentication failed
         """
         if settings.SETTINGS_AUTH_MOCK_TOKEN is None:
-            logger.warning("Problems authenticating: mock token is not configured.")
-            return None
+            logger.warning("Mock token environment variable is not configured.")
+            raise exceptions.AuthenticationFailed("Mock token environment variable is not configured.")
 
         if self.authorization_token != settings.SETTINGS_AUTH_MOCK_TOKEN:
             logger.warning(
-                "Problems authenticating: authorization token and mock token are different."
+                "Authorization token and mock token are different."
             )
-            return None
+            raise exceptions.AuthenticationFailed("Authorization token is not valid.")
 
         return self.username
 

--- a/gateway/api/services/authentication/local_authentication.py
+++ b/gateway/api/services/authentication/local_authentication.py
@@ -35,12 +35,12 @@ class LocalAuthenticationService(AuthenticationBase):
         """
         if settings.SETTINGS_AUTH_MOCK_TOKEN is None:
             logger.warning("Mock token environment variable is not configured.")
-            raise exceptions.AuthenticationFailed("Mock token environment variable is not configured.")
+            raise exceptions.AuthenticationFailed(
+                "Mock token environment variable is not configured."
+            )
 
         if self.authorization_token != settings.SETTINGS_AUTH_MOCK_TOKEN:
-            logger.warning(
-                "Authorization token and mock token are different."
-            )
+            logger.warning("Authorization token and mock token are different.")
             raise exceptions.AuthenticationFailed("Authorization token is not valid.")
 
         return self.username

--- a/gateway/api/services/authentication/quantum_platform.py
+++ b/gateway/api/services/authentication/quantum_platform.py
@@ -97,9 +97,7 @@ class QuantumPlatformService(AuthenticationBase):
             None: in case the authentication failed
         """
         if self.auth_url is None:
-            logger.warning(
-                "Authentication url is not correctly configured."
-            )
+            logger.warning("Authentication url is not correctly configured.")
             raise exceptions.AuthenticationFailed("You couldn't be authenticated.")
 
         auth_data = safe_request(
@@ -110,20 +108,26 @@ class QuantumPlatformService(AuthenticationBase):
             )
         )
         if auth_data is None:
-            logger.warning(
-                "Quantum Platform returned no data for the specific user. Probably the token is not valid."
+            logger.warning("Authentication data is empty, probably token is not valid.")
+            raise exceptions.AuthenticationFailed(
+                "You couldn't be authenticated, please review your token."
             )
-            raise exceptions.AuthenticationFailed("You couldn't be authenticated, please review your token.")
 
         user_id = auth_data.get("userId")
         if user_id is None:
             logger.warning("Quantum Platform didn't return the id for the user.")
-            raise exceptions.AuthenticationFailed("There was a problem in the autentication process with Quantum Platform, please try later.")
+            raise exceptions.AuthenticationFailed(
+                "There was a problem in the autentication process with Quantum Platform, please try later."  # pylint: disable=line-too-long
+            )
 
         self.access_token = auth_data.get("id")
         if self.access_token is None:
-            logger.warning("Quantum Platform didn't return the access token for the user")
-            raise exceptions.AuthenticationFailed("There was a problem in the autentication process with Quantum Platform, please try later.")
+            logger.warning(
+                "Quantum Platform didn't return the access token for the user"
+            )
+            raise exceptions.AuthenticationFailed(
+                "There was a problem in the autentication process with Quantum Platform, please try later."  # pylint: disable=line-too-long
+            )
 
         return user_id
 
@@ -144,10 +148,10 @@ class QuantumPlatformService(AuthenticationBase):
             )
         )
         if verification_data is None:
-            logger.warning(
-                "Quantum Platform didn't return user data to verify."
+            logger.warning("Quantum Platform didn't return user data to verify.")
+            raise exceptions.AuthenticationFailed(
+                "There was a problem in the autentication process with Quantum Platform, please try later."  # pylint: disable=line-too-long
             )
-            raise exceptions.AuthenticationFailed("There was a problem in the autentication process with Quantum Platform, please try later.")
 
         verifications = []
         verification_fields = settings.SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD.split(";")

--- a/gateway/api/use_cases/authentication.py
+++ b/gateway/api/use_cases/authentication.py
@@ -54,7 +54,9 @@ class AuthenticationUseCase:  # pylint: disable=too-few-public-methods
 
         verified = authentication_service.verify_access()
         if verified is False:
-            exceptions.AuthenticationFailed("Sorry, you don't have access to the service.")
+            raise exceptions.AuthenticationFailed(
+                "Sorry, you don't have access to the service."
+            )
 
         access_groups = authentication_service.get_groups()
         quantum_user = self.user_repository.get_or_create_by_id(user_id=user_id)

--- a/gateway/api/use_cases/authentication.py
+++ b/gateway/api/use_cases/authentication.py
@@ -3,6 +3,7 @@
 import logging
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser
+from rest_framework import exceptions
 
 from api.models import RUN_PROGRAM_PERMISSION, VIEW_PROGRAM_PERMISSION
 from api.repositories.providers import ProviderRepository
@@ -32,14 +33,14 @@ class AuthenticationUseCase:  # pylint: disable=too-few-public-methods
 
     def _get_authentication_service_instance(self) -> AuthenticationBase:
         if self.channel == Channel.IBM_CLOUD:
-            logger.debug("Authentication will be executed with IBM Cloud")
+            logger.debug("Authentication will be executed with IBM Cloud.")
             return IBMCloudService(api_key=self.authorization_token, crn=self.crn)
 
         if self.channel == Channel.IBM_QUANTUM:
-            logger.debug("Authentication will be executed with Quantum Platform")
+            logger.debug("Authentication will be executed with Quantum Platform.")
             return QuantumPlatformService(authorization_token=self.authorization_token)
 
-        logger.debug("Authentication will be executed with Local service")
+        logger.debug("Authentication will be executed with Local service.")
         return LocalAuthenticationService(authorization_token=self.authorization_token)
 
     def execute(self) -> type[AbstractUser] | None:
@@ -50,12 +51,10 @@ class AuthenticationUseCase:  # pylint: disable=too-few-public-methods
         authentication_service = self._get_authentication_service_instance()
 
         user_id = authentication_service.authenticate()
-        if user_id is None:
-            return None
 
         verified = authentication_service.verify_access()
         if verified is False:
-            return None
+            exceptions.AuthenticationFailed("Sorry, you don't have access to the service.")
 
         access_groups = authentication_service.get_groups()
         quantum_user = self.user_repository.get_or_create_by_id(user_id=user_id)

--- a/gateway/tests/api/authentication/custom_token/test_quantum_platform.py
+++ b/gateway/tests/api/authentication/custom_token/test_quantum_platform.py
@@ -3,6 +3,7 @@
 
 from unittest.mock import MagicMock, patch
 import responses
+from rest_framework import exceptions
 from rest_framework.test import APITestCase
 
 from api.authentication import CustomTokenBackend, CustomAuthentication
@@ -110,13 +111,11 @@ class TestQuantumPlatformAuthentication(APITestCase):
             QUANTUM_PLATFORM_API_BASE_URL="http://token_auth_url/api",
             SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD="is_valid;other,WRONG_NESTED_FIELD",
         ):
-            user, authentication = custom_auth.authenticate(request)
-
-            self.assertIsNone(user)
-            self.assertIsInstance(authentication, CustomAuthentication)
-            self.assertEqual(authentication.channel, "ibm_quantum")
-            self.assertEqual(authentication.token, b"AWESOME_TOKEN")
-            self.assertEqual(authentication.instance, None)
+            self.assertRaises(
+                exceptions.AuthenticationFailed,
+                custom_auth.authenticate,
+                request,
+            )
 
         responses.add(
             responses.GET,

--- a/gateway/tests/api/authentication/mock_token/test_mock_token.py
+++ b/gateway/tests/api/authentication/mock_token/test_mock_token.py
@@ -5,6 +5,7 @@ in local environments.
 
 
 from unittest.mock import MagicMock
+from rest_framework import exceptions
 from rest_framework.test import APITestCase
 
 from api.authentication import MockTokenBackend
@@ -50,5 +51,8 @@ class TestMockTokenAuthentication(APITestCase):
         request.META = {"HTTP_AUTHORIZATION": "Bearer my_awesome_token"}
 
         with self.settings(SETTINGS_AUTH_MOCK_TOKEN="other_awesome_token"):
-            user, token = backend.authenticate(request)
-            self.assertIsNone(user)
+            self.assertRaises(
+                exceptions.AuthenticationFailed,
+                backend.authenticate,
+                request,
+            )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR improves the way we are managing 401 from the authentication processes following the recommended steps in: https://www.django-rest-framework.org/api-guide/authentication/#custom-authentication

This means that we will use `AuthenticationFailed` exception to manage the different 401 errors and `authenticate_header` to populate correctly the `WWW-Authenticate` header in those scenarios.