### PR TITLE
Increase result cadence

### DIFF
--- a/client/qiskit_serverless/core/job.py
+++ b/client/qiskit_serverless/core/job.py
@@ -163,7 +163,7 @@ class Job:
         """Returns the execution error message."""
         return self._job_service.result(self.job_id) if self.status() == "ERROR" else ""
 
-    def result(self, wait=True, cadence=5, verbose=False, maxwait=0):
+    def result(self, wait=True, cadence=30, verbose=False, maxwait=0):
         """Return results of the job.
         Args:
             wait: flag denoting whether to wait for the


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

From current experience jobs are taking several hours to finish so checking the result of a `Job` every 5 seconds has no much sense. This PR increase the time reducing the number of requests we send to every 30 seconds until the job finishes if the user wants to wait for it.
