### PR TITLE
feat: handle 500 errors / improve dev UX

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -36,6 +36,7 @@ services:
     command: gunicorn main.wsgi:application --bind 0.0.0.0:8000 --workers=4
     ports:
       - 8000:8000
+    user: "root"
     environment:
       - DEBUG=1
       - RAY_HOST=http://ray-head:8265
@@ -55,6 +56,11 @@ services:
       - program-artifacts:/usr/src/app/media/
     depends_on:
       - postgres
+    develop:
+      watch:
+        - path: ./gateway
+          action: sync
+          target: /usr/src/app
   scheduler:
     container_name: scheduler
     build:

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -36,7 +36,7 @@ services:
     command: gunicorn main.wsgi:application --bind 0.0.0.0:8000 --workers=4
     ports:
       - 8000:8000
-    user: "root"
+    user: "root" # we use the root user here so the docker-compose watch can sync files into the container
     environment:
       - DEBUG=1
       - RAY_HOST=http://ray-head:8265

--- a/gateway/api/utils.py
+++ b/gateway/api/utils.py
@@ -10,8 +10,10 @@ import re
 import time
 import uuid
 import sys
+import traceback
 import platform
 from typing import Any, Optional, Tuple, Union, Callable, Dict, List
+from django.http import JsonResponse
 
 from cryptography.fernet import Fernet
 from ray.dashboard.modules.job.common import JobStatus
@@ -200,7 +202,7 @@ def generate_cluster_name(username: str) -> str:
         generated cluster name
     """
     pattern = re.compile("[^a-zA-Z0-9-.]")
-    cluster_name = f"c-{re.sub(pattern,'-',username)}-{str(uuid.uuid4())[:8]}"
+    cluster_name = f"c-{re.sub(pattern, '-', username)}-{str(uuid.uuid4())[:8]}"
     return cluster_name
 
 
@@ -471,3 +473,13 @@ def sanitize_file_name(name: str | None):
         return name
     # Remove all characters except alphanumeric, _, ., -
     return re.sub("[^a-zA-Z0-9_\\.\\-]", "", name)
+
+
+def custom_server_error():
+    """Handle 500 error"""
+    response_data = {
+        "error": "internal_server_error",
+        "message": "An unexpected error occurred. Please try again later.",
+    }
+
+    return JsonResponse(response_data, status=500)

--- a/gateway/api/utils.py
+++ b/gateway/api/utils.py
@@ -10,14 +10,13 @@ import re
 import time
 import uuid
 import sys
-import traceback
 import platform
 from typing import Any, Optional, Tuple, Union, Callable, Dict, List
 from django.http import JsonResponse
+from django.conf import settings
 
 from cryptography.fernet import Fernet
 from ray.dashboard.modules.job.common import JobStatus
-from django.conf import settings
 from parsley import makeGrammar
 import objsize
 

--- a/gateway/api/utils.py
+++ b/gateway/api/utils.py
@@ -12,7 +12,6 @@ import uuid
 import sys
 import platform
 from typing import Any, Optional, Tuple, Union, Callable, Dict, List
-from django.http import JsonResponse
 from django.conf import settings
 
 from cryptography.fernet import Fernet

--- a/gateway/api/utils.py
+++ b/gateway/api/utils.py
@@ -201,7 +201,7 @@ def generate_cluster_name(username: str) -> str:
         generated cluster name
     """
     pattern = re.compile("[^a-zA-Z0-9-.]")
-    cluster_name = f"c-{re.sub(pattern, '-', username)}-{str(uuid.uuid4())[:8]}"
+    cluster_name = f"c-{re.sub(pattern,'-',username)}-{str(uuid.uuid4())[:8]}"
     return cluster_name
 
 
@@ -472,13 +472,3 @@ def sanitize_file_name(name: str | None):
         return name
     # Remove all characters except alphanumeric, _, ., -
     return re.sub("[^a-zA-Z0-9_\\.\\-]", "", name)
-
-
-def custom_server_error():
-    """Handle 500 error"""
-    response_data = {
-        "error": "internal_server_error",
-        "message": "An unexpected error occurred. Please try again later.",
-    }
-
-    return JsonResponse(response_data, status=500)

--- a/gateway/api/views/jobs.py
+++ b/gateway/api/views/jobs.py
@@ -152,7 +152,6 @@ class JobViewSet(viewsets.GenericViewSet):
         tracer = trace.get_tracer("gateway.tracer")
         ctx = TraceContextTextMapPropagator().extract(carrier=request.headers)
         with tracer.start_as_current_span("gateway.job.list", context=ctx):
-            raise Exception("Errorrr")
             queryset = self.get_queryset()
 
             page = self.paginate_queryset(queryset)

--- a/gateway/api/views/jobs.py
+++ b/gateway/api/views/jobs.py
@@ -152,6 +152,7 @@ class JobViewSet(viewsets.GenericViewSet):
         tracer = trace.get_tracer("gateway.tracer")
         ctx = TraceContextTextMapPropagator().extract(carrier=request.headers)
         with tracer.start_as_current_span("gateway.job.list", context=ctx):
+            raise Exception("Errorrr")
             queryset = self.get_queryset()
 
             page = self.paginate_queryset(queryset)

--- a/gateway/main/urls.py
+++ b/gateway/main/urls.py
@@ -24,7 +24,7 @@ from drf_yasg import openapi
 import probes.views
 import version.views
 
-handler500 = 'rest_framework.exceptions.server_error'
+handler500 = "rest_framework.exceptions.server_error"
 
 schema = get_schema_view(  # pylint: disable=invalid-name
     openapi.Info(

--- a/gateway/main/urls.py
+++ b/gateway/main/urls.py
@@ -64,9 +64,7 @@ urlpatterns += [
         schema.with_ui("swagger", cache_timeout=0),
         name="schema-swagger-ui",
     ),
-    re_path(r"^redoc/$", schema.with_ui("redoc",
-            cache_timeout=0), name="schema-redoc"),
+    re_path(r"^redoc/$", schema.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
 ]
 if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL,
-                          document_root=settings.MEDIA_ROOT)
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/gateway/main/urls.py
+++ b/gateway/main/urls.py
@@ -23,9 +23,8 @@ from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 import probes.views
 import version.views
-from api.utils import custom_server_error
 
-handler500 = custom_server_error
+handler500 = 'rest_framework.exceptions.server_error'
 
 schema = get_schema_view(  # pylint: disable=invalid-name
     openapi.Info(

--- a/gateway/main/urls.py
+++ b/gateway/main/urls.py
@@ -23,6 +23,9 @@ from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 import probes.views
 import version.views
+from api.utils import custom_server_error
+
+handler500 = custom_server_error
 
 schema = get_schema_view(  # pylint: disable=invalid-name
     openapi.Info(
@@ -61,7 +64,9 @@ urlpatterns += [
         schema.with_ui("swagger", cache_timeout=0),
         name="schema-swagger-ui",
     ),
-    re_path(r"^redoc/$", schema.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
+    re_path(r"^redoc/$", schema.with_ui("redoc",
+            cache_timeout=0), name="schema-redoc"),
 ]
 if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    urlpatterns += static(settings.MEDIA_URL,
+                          document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR:
- handles 500 errors to return them as JSON instead of HTML
- Modify docker-compose-dev.yaml to hot reload gateway changes

### Details and comments

To test the change:
1. set `DEBUG=0` in `services.dateway.environment` inside `docker-compose-dev.yaml`.
2. run `docker-compose -f docker-compose-dev.yaml watch`.
3. raise an Error somewhere in the code.
4. Make an http request to the code with the previous error (you should receive the error in json format).
5. Remove the Error raise and make the http request again. You should see the change sync and the response without errors.

