### PR TITLE
Fix authentication for catalog end-points

### DIFF
--- a/gateway/api/authentication.py
+++ b/gateway/api/authentication.py
@@ -25,10 +25,8 @@ class CustomTokenBackend(authentication.BaseAuthentication):
 
         auth_header = request.META.get("HTTP_AUTHORIZATION")
         if auth_header is None:
-            logger.warning("Authorization token was not provided.")
-            raise exceptions.AuthenticationFailed(
-                "Authorization token was not provided."
-            )
+            logger.debug("Authorization token was not provided. Only public access allowed.")
+            return None, None
         authorization_token = auth_header.split(" ")[-1]
 
         quantum_user = AuthenticationUseCase(
@@ -59,10 +57,8 @@ class MockTokenBackend(authentication.BaseAuthentication):
 
         auth_header = request.META.get("HTTP_AUTHORIZATION")
         if auth_header is None:
-            logger.warning("Authorization token was not provided.")
-            raise exceptions.AuthenticationFailed(
-                "Authorization token was not provided."
-            )
+            logger.debug("Authorization token was not provided. Only public access allowed.")
+            return None, None
         authorization_token = auth_header.split(" ")[-1]
 
         quantum_user = AuthenticationUseCase(

--- a/gateway/api/authentication.py
+++ b/gateway/api/authentication.py
@@ -1,7 +1,7 @@
 """Custom Authentication DRF Backends to authenticate the user."""
 
 import logging
-from rest_framework import authentication, exceptions
+from rest_framework import authentication
 
 from api.domain.authentication.custom_authentication import CustomAuthentication
 from api.use_cases.authentication import AuthenticationUseCase
@@ -25,7 +25,9 @@ class CustomTokenBackend(authentication.BaseAuthentication):
 
         auth_header = request.META.get("HTTP_AUTHORIZATION")
         if auth_header is None:
-            logger.debug("Authorization token was not provided. Only public access allowed.")
+            logger.debug(
+                "Authorization token was not provided. Only public access allowed."
+            )
             return None, None
         authorization_token = auth_header.split(" ")[-1]
 
@@ -57,7 +59,9 @@ class MockTokenBackend(authentication.BaseAuthentication):
 
         auth_header = request.META.get("HTTP_AUTHORIZATION")
         if auth_header is None:
-            logger.debug("Authorization token was not provided. Only public access allowed.")
+            logger.debug(
+                "Authorization token was not provided. Only public access allowed."
+            )
             return None, None
         authorization_token = auth_header.split(" ")[-1]
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR fix the authentication process for catalog end-points allowing the access for that people that wants to check the catalog. These end-points are public and may not requiere the bearer token or access verification.