### PR TITLE
Improve HTTP server configuration

### DIFF
--- a/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
+++ b/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
@@ -65,7 +65,16 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: [ "gunicorn", "main.wsgi:application", "--bind", "0.0.0.0:{{ .Values.service.port }}", "--workers=4" ]
+          args: [ 
+            "gunicorn", 
+            {{ .Values.application.httpServer.serverModel }}, 
+            "--bind", "0.0.0.0:{{ .Values.service.port }}", 
+            "--workers={{ .Values.application.httpServer.workers }}",
+            "--threads={{ .Values.application.httpServer.threads }}", 
+            "--max-requests={{ .Values.application.httpServer.threads }}",
+            "--max-requests-jitter={{ .Values.application.httpServer.jitter }}",
+            "--timeout={{ .Values.application.httpServer.timeout }}"
+            ]
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/qiskit-serverless/charts/gateway/values.yaml
+++ b/charts/qiskit-serverless/charts/gateway/values.yaml
@@ -6,7 +6,14 @@ replicaCount: 1
 useCertManager: false
 
 application:
-#  command: [ "gunicorn", "gateway.wsgi:application", "--bind", "0.0.0.0:8000", "--workers=3" ]
+  # Gunicorn configuration
+  httpServer:
+    serverModel: "main.wsgi:application"
+    workers: 1
+    threads: 1
+    maxRequests: 1200
+    jitter: 50
+    timeout: 25
   debug: 0
   siteHost: "http://127.0.0.1:8000"
   rayHost: "http://ray:8265/"

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -33,7 +33,7 @@ services:
     build:
       context: ./
       dockerfile: gateway/Dockerfile
-    command: gunicorn main.wsgi:application --bind 0.0.0.0:8000 --workers=4
+    command: gunicorn main.wsgi:application --bind 0.0.0.0:8000 --workers=1 --threads=1 --max-requests=1200 --max-requests-jitter=50 --timeout=25
     ports:
       - 8000:8000
     user: "root" # we use the root user here so the docker-compose watch can sync files into the container

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
   gateway:
     container_name: gateway
     image: icr.io/quantum-public/qiskit-serverless/gateway:${VERSION:-0.21.1}
-    command: gunicorn main.wsgi:application --bind 0.0.0.0:8000 --workers=4
+    command: gunicorn main.wsgi:application --bind 0.0.0.0:8000 --workers=1 --threads=1 --max-requests=1200 --max-requests-jitter=50 --timeout=25
     ports:
       - 8000:8000
     environment:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR introduces several improvements in our current HTTP Server configuration after reading carefully the documentation: https://docs.gunicorn.org/en/stable/settings.html

The main improvement that I was trying to accomplish was to be able to apply different configurations depending of the environment through `values.yaml`. I added also the typical parameters that users usually modify to increase stability: workers, threads, max_requests, max_requests_jitter and timeout.

Being able to configure `workers` is very important because different environments have different resources so we could increase or decrease this number depending of the environment where we are deploying in order: `2-4 x $(NUM_CORES)`

Also the combination of `max_requests` and `max_requests_jitter` is important to configure because they configure the thresholds used to restart the different workers to prevent memory leaks (this could be easily one of the problems we were having in the system).