### PR TITLE
Improve cluster name support

### DIFF
--- a/gateway/api/utils.py
+++ b/gateway/api/utils.py
@@ -233,8 +233,14 @@ def generate_cluster_name(username: str) -> str:
     Returns:
         generated cluster name
     """
-    pattern = re.compile("[^a-zA-Z0-9-.]")
-    cluster_name = f"c-{re.sub(pattern, '-', username)}-{str(uuid.uuid4())[:8]}"
+    # Force capital letters to be lowercase
+    lowercase_username = username.lower()
+
+    # Substitue any not valid character by "-"
+    pattern = re.compile("[^a-z0-9-]")
+    cluster_name = (
+        f"c-{re.sub(pattern, '-', lowercase_username)}-{str(uuid.uuid4())[:8]}"
+    )
     return cluster_name
 
 

--- a/gateway/tests/api/utils/test_cluster_name_generator.py
+++ b/gateway/tests/api/utils/test_cluster_name_generator.py
@@ -1,0 +1,23 @@
+"""Tests to verify the cluster name generator."""
+
+from rest_framework.test import APITestCase
+
+from api.utils import generate_cluster_name
+
+
+class TestClusterNameGenerator(APITestCase):
+    """Test suite to validate the cluster name generator."""
+
+    def test_quantum_user_generation(self):
+        """This test verifies the cluster name generation for IQP users."""
+        username = "6bc1230a4g12340012345003"
+
+        cluster_name = generate_cluster_name(username=username)
+        assert cluster_name.startswith("c-6bc1230a4g12340012345003-")
+
+    def test_ibm_cloud_user_generation(self):
+        """This test verifies the cluster name generation for IBM Cloud users."""
+        username = "IBMid-123001ABCD"
+
+        cluster_name = generate_cluster_name(username=username)
+        assert cluster_name.startswith("c-ibmid-123001abcd-")

--- a/gateway/tests/api/utils/test_cluster_name_generator.py
+++ b/gateway/tests/api/utils/test_cluster_name_generator.py
@@ -13,11 +13,17 @@ class TestClusterNameGenerator(APITestCase):
         username = "6bc1230a4g12340012345003"
 
         cluster_name = generate_cluster_name(username=username)
-        assert cluster_name.startswith("c-6bc1230a4g12340012345003-")
+        self.assertTrue(cluster_name.startswith("c-6bc1230a4g12340012345003-"))
 
     def test_ibm_cloud_user_generation(self):
         """This test verifies the cluster name generation for IBM Cloud users."""
         username = "IBMid-123001ABCD"
 
         cluster_name = generate_cluster_name(username=username)
-        assert cluster_name.startswith("c-ibmid-123001abcd-")
+        self.assertTrue(cluster_name.startswith("c-ibmid-123001abcd-"))
+
+    def test_weird_user_generation(self):
+        """This test verifies the cluster name generation for a weird usern name."""
+        username = "WE.IRD_?|-name"
+        cluster_name = generate_cluster_name(username=username)
+        self.assertTrue(cluster_name.startswith("c-we-ird----name-"))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes a problem we had with the generation of the cluster name as we were allowing characters that should not be allowed in the kubernetes environment as `.` or capital letters.