### PR TITLE
Include qpy-compat option from Qsikit 2.1.0

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,7 +1,7 @@
 ray[default]>=2.30, <3
 requests>=2.32.2, <3
 importlib-metadata>=5.2.0, <9
-qiskit>=1.4, <3
+qiskit[qpy-compat]>=1.4, <3
 qiskit-ibm-runtime>=0.29.0, <1
 # Make sure ray node and notebook node have the same version of cloudpickle
 cloudpickle==2.2.1

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -18,6 +18,7 @@ django-concurrency>=2.5, <3
 drf-yasg>=1.21.10, <2
 # Django dependency, but we need a newer version (IBMQ#246)
 sqlparse>=0.5.0, <1
+qiskit[qpy-compat]>=1.4, <3
 qiskit-ibm-runtime>=0.29.0, <1
 tzdata>=2024.1
 django-cors-headers>=4.4.0, <5


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

[Qiskit 2.1.0](https://github.com/Qiskit/qiskit/releases/tag/2.1.0) changed the way they were managing `symengine` package. From previous versions they made that `symengine` was not needed anymore but that only works for versions greater than 2.1.0.

For versions lower than 2.1.0 we need to change the way we are installing qiskit adding the option `qpy-compat`.