### PR TITLE
Fix incompatibility with old authentication processes

### DIFF
--- a/gateway/api/authentication.py
+++ b/gateway/api/authentication.py
@@ -36,10 +36,14 @@ class CustomTokenBackend(authentication.BaseAuthentication):
 
         crn = request.META.get("HTTP_SERVICE_CRN", None)
         channel_header = request.META.get("HTTP_SERVICE_CHANNEL", None)
-        if channel_header is None:
-            # this is to maintain compatibility for older versions
-            # that are not being managing channel
+        # This is to maintain compatibility for older versions:
+        #   - IQP use case: Catalog(token=""")
+        #   - IBM cloud use case: Catalog(channel=", token="", crn="")
+        # Originally we were not sending the channel in <=0.24.0 versions
+        if channel_header is None and crn is None:
             channel_header = Channel.IBM_QUANTUM.value
+        if channel_header is None and crn is not None:
+            channel_header = Channel.IBM_QUANTUM_PLATFORM.value
         try:
             channel = Channel(channel_header)
         except ValueError as error:

--- a/gateway/api/authentication.py
+++ b/gateway/api/authentication.py
@@ -11,6 +11,7 @@ from api.domain.authentication.channel import Channel
 logger = logging.getLogger("gateway.authentication")
 PUBLIC_ENDPOINTS = ["catalog", "swagger"]
 
+
 # This logic needs to be reviewed as it can be simplified
 # maybe with isAuthenticatedOrReadOnly permission
 def is_public_endpoint(path: str) -> bool:
@@ -37,11 +38,11 @@ class CustomTokenBackend(authentication.BaseAuthentication):
         crn = request.META.get("HTTP_SERVICE_CRN", None)
         channel_header = request.META.get("HTTP_SERVICE_CHANNEL", None)
         # This is to maintain backwards compatibility with previous user patterns.
-        # In qiskit-serverless <=0.24.0 , the channel input was not provided to the 
+        # In qiskit-serverless <=0.24.0 , the channel input was not provided to the
         # authenticator, but inferred from other inputs:
         #   - IQP use case: Catalog(token=""")
         #   - IBM cloud use case: Catalog(channel=", token="", crn="")
-        
+
         if channel_header is None and crn is None:
             channel_header = Channel.IBM_QUANTUM.value
         if channel_header is None and crn is not None:

--- a/gateway/api/authentication.py
+++ b/gateway/api/authentication.py
@@ -36,10 +36,12 @@ class CustomTokenBackend(authentication.BaseAuthentication):
 
         crn = request.META.get("HTTP_SERVICE_CRN", None)
         channel_header = request.META.get("HTTP_SERVICE_CHANNEL", None)
-        # This is to maintain compatibility for older versions:
+        # This is to maintain backwards compatibility with previous user patterns.
+        # In qiskit-serverless <=0.24.0 , the channel input was not provided to the 
+        # authenticator, but inferred from other inputs:
         #   - IQP use case: Catalog(token=""")
         #   - IBM cloud use case: Catalog(channel=", token="", crn="")
-        # Originally we were not sending the channel in <=0.24.0 versions
+        
         if channel_header is None and crn is None:
             channel_header = Channel.IBM_QUANTUM.value
         if channel_header is None and crn is not None:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Due to the changes in the https://github.com/Qiskit/qiskit-serverless/pull/1666 I detected an incompatibility problem in the old authentication process.

This last PR was basically sending the channel as a way to be able to send the `instance` with `ibm_quantum`. All the tests passed because we were testing that the new functionality was working with the same interface as we had until now but we didn't do any regression test. That's when I detected that in the next use case:
```python
QiskitFunctionsCatalog(channel="ibm_quantum_platform", token="YOUR_TOKEN", instance="YOUR_CRN")
```

We were not sending the channel in previous versions and due to the new logic we were assigning in the backend `ibm_quantum` to this authentication process. This PR should fix that problem as we are validating that if the user is not sending a channel and it's sending the CRN we assume it's an old version and we maintain that logic to support compatibility with previous versions.