### PR TITLE
Improve error reporting after failed `run`

### DIFF
--- a/client/qiskit_serverless/core/clients/local_client.py
+++ b/client/qiskit_serverless/core/clients/local_client.py
@@ -163,7 +163,25 @@ class LocalClient(BaseClient):
 
     def filtered_logs(self, job_id: str, **kwargs):
         """Return filtered logs."""
-        raise NotImplementedError
+        all_logs = self.logs(job_id=job_id)
+        included = ""
+        include = kwargs.get("include")
+        if include is not None:
+            for line in all_logs.split("\n"):
+                if re.search(include, line) is not None:
+                    included = included + line + "\n"
+        else:
+            included = all_logs
+
+        excluded = ""
+        exclude = kwargs.get("exclude")
+        if exclude is not None:
+            for line in included.split("\n"):
+                if line != "" and re.search(exclude, line) is None:
+                    excluded = excluded + line + "\n"
+        else:
+            excluded = included
+        return excluded
 
     #########################
     ####### Functions #######

--- a/client/qiskit_serverless/core/job.py
+++ b/client/qiskit_serverless/core/job.py
@@ -228,12 +228,12 @@ class Job:
         if self.status() == "ERROR":
             if results:
                 raise QiskitServerlessException(results)
-            else:
-                # If no result returned (common with import errors),
-                # try to match on error trace in logs to point to source of error
-                raise QiskitServerlessException(
-                    self.filtered_logs(include=r"(?i)error|exception")
-                )
+
+            # If no result returned (common with import errors),
+            # try to match on error trace in logs to point to source of error
+            raise QiskitServerlessException(
+                self.filtered_logs(include=r"(?i)error|exception")
+            )
 
         if isinstance(results, str):
             try:

--- a/client/qiskit_serverless/core/job.py
+++ b/client/qiskit_serverless/core/job.py
@@ -183,8 +183,8 @@ class Job:
     def filtered_logs(self, **kwargs) -> str:
         """Returns logs of the job.
         Args:
-            include: rex expression finds match in the log line to be included
-            exclude: rex expression finds match in the log line to be excluded
+            include: regex expression finds matching line in the log to be included
+            exclude: regex expression finds matching line in the log to be excluded
         """
         return self._job_service.filtered_logs(job_id=self.job_id, **kwargs)
 
@@ -226,7 +226,14 @@ class Job:
         results = self._job_service.result(self.job_id)
 
         if self.status() == "ERROR":
-            raise QiskitServerlessException(results)
+            if results:
+                raise QiskitServerlessException(results)
+            else:
+                # If no result returned (common with import errors),
+                # try to match on error trace in logs to point to source of error
+                raise QiskitServerlessException(
+                    self.filtered_logs(include=r"(?i)error|exception")
+                )
 
         if isinstance(results, str):
             try:

--- a/tests/docker/source_files/pattern_with_errors.py
+++ b/tests/docker/source_files/pattern_with_errors.py
@@ -1,0 +1,20 @@
+# source_files/program_with_errors.py
+
+from qiskit_serverless import get_arguments, save_result
+from qiskit.primitives import StatevectorSampler as Sampler
+from .circuit import wrong_circuit_import
+
+# get all arguments passed to this program
+arguments = get_arguments()
+
+# get specific argument that we are interested in
+circuit = arguments.get("circuit")
+
+sampler = Sampler()
+
+quasi_dists = sampler.run([circuit]).result()[0].data.meas.get_counts()
+
+print(f"Quasi distribution: {quasi_dists}")
+
+# saving results of a program
+save_result({"quasi_dists": quasi_dists})

--- a/tests/docker/test_docker.py
+++ b/tests/docker/test_docker.py
@@ -50,9 +50,10 @@ class TestFunctionsDocker:
         assert job.status() == "DONE"
         assert isinstance(job.logs(), str)
 
-    def test_function_with_errors(self, base_client: BaseClient):
+    # local client doesn't make sense here
+    # since it follows a different logging mechanism
+    def test_function_with_errors(self, serverless_client: ServerlessClient):
         """Integration test for faulty function run."""
-
         circuit = QuantumCircuit(2)
         circuit.h(0)
         circuit.cx(0, 1)
@@ -65,12 +66,12 @@ class TestFunctionsDocker:
             working_dir=resources_path,
         )
 
-        runnable_function = base_client.upload(function)
+        runnable_function = serverless_client.upload(function)
 
         assert runnable_function is not None
         assert runnable_function.type == "GENERIC"
 
-        runnable_function = base_client.function(function.title)
+        runnable_function = serverless_client.function(function.title)
 
         assert runnable_function is not None
         assert runnable_function.type == "GENERIC"

--- a/tests/docker/test_docker.py
+++ b/tests/docker/test_docker.py
@@ -78,8 +78,6 @@ class TestFunctionsDocker:
         job = runnable_function.run(circuit=circuit)
 
         assert job is not None
-        assert job.status() == "ERROR"
-        assert isinstance(job.logs(), str)
         expected_message = (
             "ImportError: attempted relative import with no known parent package"
         )
@@ -89,7 +87,10 @@ class TestFunctionsDocker:
             return details_index > 0
 
         with raises(QiskitServerlessException, check=exceptionCheck):
-            job.run()
+            job.result()
+
+        assert job.status() == "ERROR"
+        assert isinstance(job.logs(), str)
 
     def test_function_with_arguments(self, base_client: BaseClient):
         """Integration test for Functions with arguments."""

--- a/tests/docker/test_docker.py
+++ b/tests/docker/test_docker.py
@@ -82,15 +82,16 @@ class TestFunctionsDocker:
             "ImportError: attempted relative import with no known parent package"
         )
 
-        def exceptionCheck(e: QiskitServerlessException):
-            details_index = str(e).find(expected_message)
-            return details_index > 0
-
-        with raises(QiskitServerlessException, check=exceptionCheck):
+        with raises(QiskitServerlessException) as exc_info:
             job.result()
+
+        print(str(exc_info.value))
+        assert expected_message in str(exc_info.value)
 
         assert job.status() == "ERROR"
         assert isinstance(job.logs(), str)
+
+        print(str(exc_info.value))
 
     def test_function_with_arguments(self, base_client: BaseClient):
         """Integration test for Functions with arguments."""

--- a/tests/docker/test_docker.py
+++ b/tests/docker/test_docker.py
@@ -83,10 +83,13 @@ class TestFunctionsDocker:
         expected_message = (
             "ImportError: attempted relative import with no known parent package"
         )
-        with self.assertRaises(QiskitServerlessException) as context:
-            job.run()
 
-        self.assertEqual(str(context.exception), expected_message)
+        def exceptionCheck(e: QiskitServerlessException):
+            details_index = str(e).find(expected_message)
+            return details_index > 0
+
+        with raises(QiskitServerlessException, check=exceptionCheck):
+            job.run()
 
     def test_function_with_arguments(self, base_client: BaseClient):
         """Integration test for Functions with arguments."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The current implementation of the `Job` class relies on the function entrypoint implementation to properly handle error reporting and return the error trace as part of the result if something goes wrong. In practice, this is rarely happening, resulting in most function failures to show up as empty `QiskitServerlesException`s. The function logs however often store useful information about the error trace.

This PR adds a mechanism that scans the logs for an exception and returns that line in the case that `result` is `None`. So instead of 

```
QiskitServerlessException                 Traceback (most recent call last)
Cell In[8], line 1
----> 1 result = job.result()
      2 print(result)

File ~/qiskit_workspace/.venv_benchmark/lib/python3.11/site-packages/qiskit_serverless/core/job.py:229, in Job.result(self, wait, cadence, verbose, maxwait)
    226 results = self._job_service.result(self.job_id)
    228 if self.status() == "ERROR":
--> 229     raise QiskitServerlessException(results)
    231 if isinstance(results, str):
    232     try:

QiskitServerlessException: {}
```

Users would see a more actionable message, such as:

```
---------------------------------------------------------------------------
QiskitServerlessException                 Traceback (most recent call last)
Cell In[8], line 1
----> 1 result = job.result()
      2 print(result)

File ~/qiskit_workspace/qiskit-serverless/client/qiskit_serverless/core/job.py:238, in Job.result(self, wait, cadence, verbose, maxwait)
    234         raise QiskitServerlessException(results)
    235     else:
    236         # If no result returned (common with import errors), 
    237         # try to match on error trace in logs to point to source of error
--> 238         raise QiskitServerlessException(self.filtered_logs(include=r'(?i)error|exception'))
    240 if isinstance(results, str):
    241     try:

QiskitServerlessException: ModuleNotFoundError: No module named 'circuit_function.utils'; 'circuit_function' is not a package
```

### Details and comments

1. If the function developers don't add any logging capabilities, this improvement will not change that. For example, some functions simply return `"No available logs. Contact the provider"`. But this feature is still helpful for custom function development, where we don't have any issues reporting logs.

2. I am considering adding the full error trace instead of just the exception, although this is anyways available in the logs, it might help to see something like:

```
INFO job_manager.py:531 -- Runtime env is setting up.\nTraceback (most recent call last):\n  File "/tmp/ray/session_2025-07-15_11-14-11_975056_1/runtime_resources/working_dir_files/_ray_pkg_545018ec1c39fc2c/circuit_function/circuit_function.py", line 21, in <module>\n    from circuit_function.utils import (\n  File "/tmp/ray/session_2025-07-15_11-14-11_975056_1/runtime_resources/working_dir_files/_ray_pkg_545018ec1c39fc2c/circuit_function/circuit_function.py", line 21, in <module>\n    from circuit_function.utils import (\nModuleNotFoundError: No module named \'circuit_function.utils\'; \'circuit_function\' is not a package\n'
```

Again, this would only be visible if the developers choose to log these error traces.