### PR TITLE
Update default value of `QISKIT_IBM_URL`

### DIFF
--- a/gateway/api/utils.py
+++ b/gateway/api/utils.py
@@ -163,6 +163,7 @@ def build_env_variables(  # pylint: disable=too-many-positional-arguments
             extra = {
                 "QISKIT_IBM_INSTANCE": str(instance),
             }
+        # pylint: disable=fixme
         # TODO: remove this path once iqp classic is sunset for all users
         if channel.value == Channel.IBM_QUANTUM.value:
             url = "https://auth.quantum.ibm.com/api"

--- a/gateway/api/utils.py
+++ b/gateway/api/utils.py
@@ -163,12 +163,16 @@ def build_env_variables(  # pylint: disable=too-many-positional-arguments
             extra = {
                 "QISKIT_IBM_INSTANCE": str(instance),
             }
-
+        # TODO: remove this path once iqp classic is sunset for all users
+        if channel.value == Channel.IBM_QUANTUM.value:
+            url = "https://auth.quantum.ibm.com/api"
+        else:
+            url = settings.QISKIT_IBM_URL
         extra.update(
             {
                 "QISKIT_IBM_TOKEN": str(token),
                 "QISKIT_IBM_CHANNEL": channel.value,
-                "QISKIT_IBM_URL": settings.QISKIT_IBM_URL,
+                "QISKIT_IBM_URL": url,
             }
         )
 

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -389,9 +389,7 @@ GATEWAY_DYNAMIC_DEPENDENCIES = str(
 )
 
 # authentication base url for qiskit runtime
-QISKIT_IBM_URL = os.environ.get(
-    "QISKIT_IBM_URL", "https://cloud.ibm.com"
-)
+QISKIT_IBM_URL = os.environ.get("QISKIT_IBM_URL", "https://cloud.ibm.com")
 
 # quantum api
 IQP_QCON_API_BASE_URL = os.environ.get("IQP_QCON_API_BASE_URL", None)

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -388,9 +388,9 @@ GATEWAY_DYNAMIC_DEPENDENCIES = str(
     )
 )
 
-# qiskit runtime
+# authentication base url for qiskit runtime
 QISKIT_IBM_URL = os.environ.get(
-    "QISKIT_IBM_URL", "https://auth.quantum-computing.ibm.com/api"
+    "QISKIT_IBM_URL", "https://cloud.ibm.com"
 )
 
 # quantum api

--- a/gateway/tests/api/test_utils.py
+++ b/gateway/tests/api/test_utils.py
@@ -50,7 +50,7 @@ class TestUtils(APITestCase):
                     "ENV_ACCESS_TRIAL": "False",
                     "QISKIT_IBM_TOKEN": "an_awesome_token",
                     "QISKIT_IBM_CHANNEL": "ibm_quantum",
-                    "QISKIT_IBM_URL": "https://auth.quantum-computing.ibm.com/api",
+                    "QISKIT_IBM_URL": "https://auth.quantum.ibm.com/api",
                 },
             )
 
@@ -87,7 +87,7 @@ class TestUtils(APITestCase):
                     "QISKIT_IBM_TOKEN": "an_awesome_api_key",
                     "QISKIT_IBM_CHANNEL": "ibm_quantum_platform",
                     "QISKIT_IBM_INSTANCE": "an_awesome_crn",
-                    "QISKIT_IBM_URL": "https://auth.quantum-computing.ibm.com/api",
+                    "QISKIT_IBM_URL": "https://cloud.ibm.com",
                 },
             )
 
@@ -122,7 +122,7 @@ class TestUtils(APITestCase):
                     "ENV_ACCESS_TRIAL": "False",
                     "QISKIT_IBM_TOKEN": "mock_token",
                     "QISKIT_IBM_CHANNEL": "local",
-                    "QISKIT_IBM_URL": "https://auth.quantum-computing.ibm.com/api",
+                    "QISKIT_IBM_URL": "https://cloud.ibm.com",
                 },
             )
 
@@ -157,7 +157,7 @@ class TestUtils(APITestCase):
                     "ENV_ACCESS_TRIAL": "True",
                     "QISKIT_IBM_TOKEN": "mock_token",
                     "QISKIT_IBM_CHANNEL": "local",
-                    "QISKIT_IBM_URL": "https://auth.quantum-computing.ibm.com/api",
+                    "QISKIT_IBM_URL": "https://cloud.ibm.com",
                 },
             )
 
@@ -179,7 +179,7 @@ class TestUtils(APITestCase):
                 "ENV_JOB_ARGUMENTS": {"answer": 42},
                 "QISKIT_IBM_TOKEN": "42",
                 "QISKIT_IBM_CHANNEL": "ibm_quantum",
-                "QISKIT_IBM_URL": "https://auth.quantum-computing.ibm.com/api",
+                "QISKIT_IBM_URL": "https://cloud.ibm.com",
             }
             encrypted_env_vars = encrypt_env_vars(env_vars_with_qiskit_runtime)
             self.assertFalse(encrypted_env_vars["QISKIT_IBM_TOKEN"] == "42")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
When using a non-default authentication path (local or mock), the fallback value of the runtime authentication URL was hardcoded to the `ibm_quantum` channel endpoint. This PR changes the default to the `ibm_quantum_platform` endpoint, and adds a channel check before applying the default to also support the `ibm_quantum` path.


### Details and comments

