### PR TITLE
Adjust qiskit-ibm-runtime version to 0.40

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -2,7 +2,7 @@ ray[default]>=2.30, <3
 requests>=2.32.2, <3
 importlib-metadata>=5.2.0, <9
 qiskit[qpy-compat]>=1.4, <3
-qiskit-ibm-runtime>=0.29.0, <1
+qiskit-ibm-runtime~=0.40.1
 # Make sure ray node and notebook node have the same version of cloudpickle
 cloudpickle==2.2.1
 tqdm>=4.66.3, <5

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -19,7 +19,7 @@ drf-yasg>=1.21.10, <2
 # Django dependency, but we need a newer version (IBMQ#246)
 sqlparse>=0.5.0, <1
 qiskit[qpy-compat]>=1.4, <3
-qiskit-ibm-runtime>=0.29.0, <1
+qiskit-ibm-runtime~=0.40.1
 tzdata>=2024.1
 django-cors-headers>=4.4.0, <5
 whitenoise>=6.7.0, <7


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Latest `qiskit-ibm-runtime` version is not compatible so we will adjust the current version and work in the compatibility later on.
