### PR TITLE
Fix path for arguments

### DIFF
--- a/gateway/.gitignore
+++ b/gateway/.gitignore
@@ -137,4 +137,4 @@ GitHub.sublime-settings
 !.vscode/extensions.json
 .history
 
-tests/resources/fake_media/*/arguments/*
+tests/resources/fake_media/*

--- a/gateway/api/ray.py
+++ b/gateway/api/ray.py
@@ -114,7 +114,12 @@ class JobHandler:
                 )
 
             # upload arguments to working directory
-            storage = ArgumentsStorage(job.author.username)
+            provider_name = None
+            if job.program.provider is not None:
+                provider_name = job.program.provider.name
+            storage = ArgumentsStorage(
+                job.author.username, program.title, provider_name
+            )
             arguments = storage.get(job.id) or job.arguments
             arguments_file = os.path.join(
                 working_directory_for_upload, "arguments.serverless"

--- a/gateway/api/serializers.py
+++ b/gateway/api/serializers.py
@@ -273,6 +273,8 @@ class RunJobSerializer(serializers.ModelSerializer):
         logger.info("Creating Job with RunExistingJobSerializer")
         status = Job.QUEUED
         program = validated_data.get("program")
+        function_title = validated_data.get("function_title")
+        provider_name = validated_data.get("provider_name", None)
         arguments = validated_data.get("arguments", "{}")
         author = validated_data.get("author")
         config = validated_data.get("config", None)
@@ -302,7 +304,9 @@ class RunJobSerializer(serializers.ModelSerializer):
             )
         )
 
-        arguments_storage = ArgumentsStorage(author.username)
+        arguments_storage = ArgumentsStorage(
+            author.username, function_title, provider_name
+        )
         arguments_storage.save(job.id, arguments)
 
         try:

--- a/gateway/api/services/arguments_storage.py
+++ b/gateway/api/services/arguments_storage.py
@@ -15,10 +15,24 @@ class ArgumentsStorage:
     ARGUMENTS_FILE_EXTENSION = ".json"
     ENCODING = "utf-8"
 
-    def __init__(self, username: str):
-        self.user_arguments_directory = os.path.join(
-            settings.MEDIA_ROOT, username, "arguments"
-        )
+    def __init__(
+        self, username: str, function_title: str, provider_name: Optional[str]
+    ):
+        # We need to use the same path as the FileStorage here
+        # because it is attached the volume in the docker image
+        if provider_name is None:
+            self.user_arguments_directory = os.path.join(
+                settings.MEDIA_ROOT, username, "arguments"
+            )
+        else:
+            self.user_arguments_directory = os.path.join(
+                settings.MEDIA_ROOT,
+                username,
+                provider_name,
+                function_title,
+                "arguments",
+            )
+
         os.makedirs(self.user_arguments_directory, exist_ok=True)
 
     def _get_arguments_path(self, job_id: str) -> str:

--- a/gateway/api/views/programs.py
+++ b/gateway/api/views/programs.py
@@ -248,7 +248,12 @@ class ProgramViewSet(viewsets.GenericViewSet):
             channel = request.auth.channel
             token = request.auth.token.decode()
             instance = request.auth.instance
-        job_data = {"arguments": arguments, "program": function.id}
+        job_data = {
+            "arguments": arguments,
+            "program": function.id,
+            "function_title": function.title,
+            "provider_name": provider_name,
+        }
         job_serializer = self.get_serializer_run_job(data=job_data)
         if not job_serializer.is_valid():
             logger.error(

--- a/gateway/api/views/programs.py
+++ b/gateway/api/views/programs.py
@@ -250,9 +250,7 @@ class ProgramViewSet(viewsets.GenericViewSet):
             instance = request.auth.instance
         job_data = {
             "arguments": arguments,
-            "program": function.id,
-            "function_title": function.title,
-            "provider_name": provider_name,
+            "program": function.id
         }
         job_serializer = self.get_serializer_run_job(data=job_data)
         if not job_serializer.is_valid():
@@ -268,6 +266,8 @@ class ProgramViewSet(viewsets.GenericViewSet):
             token=token,
             config=jobconfig,
             instance=instance,
+            function_title=function.title,
+            provider_name=provider_name,
         )
         logger.info("Returning Job [%s] created.", job.id)
 

--- a/gateway/api/views/programs.py
+++ b/gateway/api/views/programs.py
@@ -248,10 +248,7 @@ class ProgramViewSet(viewsets.GenericViewSet):
             channel = request.auth.channel
             token = request.auth.token.decode()
             instance = request.auth.instance
-        job_data = {
-            "arguments": arguments,
-            "program": function.id
-        }
+        job_data = {"arguments": arguments, "program": function.id}
         job_serializer = self.get_serializer_run_job(data=job_data)
         if not job_serializer.is_valid():
             logger.error(

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -146,7 +146,7 @@ class TestProgramApi(APITestCase):
             self.assertEqual(job.config.workers, None)
             self.assertEqual(job.config.auto_scaling, True)
 
-            arguments_storage = ArgumentsStorage(user.username)
+            arguments_storage = ArgumentsStorage(user.username, "Program", None)
             stored_arguments = arguments_storage.get(job.id)
 
             self.assertEqual(stored_arguments, arguments)

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -151,6 +151,57 @@ class TestProgramApi(APITestCase):
 
             self.assertEqual(stored_arguments, arguments)
 
+    def test_provider_run(self):
+        """Tests run existing authorized."""
+
+        media_root = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "..",
+            "resources",
+            "fake_media",
+        )
+        media_root = os.path.normpath(os.path.join(os.getcwd(), media_root))
+
+        with self.settings(MEDIA_ROOT=media_root):
+            user = models.User.objects.get(username="test_user_2")
+            self.client.force_authenticate(user=user)
+
+            arguments = json.dumps({"MY_ARGUMENT_KEY": "MY_ARGUMENT_VALUE"})
+            programs_response = self.client.post(
+                "/api/v1/programs/run/",
+                data={
+                    "title": "Docker-Image-Program",
+                    "provider": "default",
+                    "arguments": arguments,
+                    "config": {
+                        "workers": None,
+                        "min_workers": 1,
+                        "max_workers": 5,
+                        "auto_scaling": True,
+                    },
+                },
+                format="json",
+            )
+            job_id = programs_response.data.get("id")
+            job = Job.objects.get(id=job_id)
+            env_vars = json.loads(job.env_vars)
+
+            self.assertEqual(job.status, Job.QUEUED)
+            self.assertEqual(job.trial, False)
+            self.assertEqual(env_vars["PROGRAM_ENV1"], "VALUE1")
+            self.assertEqual(env_vars["PROGRAM_ENV2"], "VALUE2")
+            self.assertEqual(job.config.min_workers, 1)
+            self.assertEqual(job.config.max_workers, 5)
+            self.assertEqual(job.config.workers, None)
+            self.assertEqual(job.config.auto_scaling, True)
+
+            arguments_storage = ArgumentsStorage(
+                user.username, "Docker-Image-Program", "default"
+            )
+            stored_arguments = arguments_storage.get(job.id)
+
+            self.assertEqual(stored_arguments, arguments)
+
     def test_run_locked(self):
         """Tests run disabled program."""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #1671 we did a complex migration moving arguments from database to object storage. This PR fixes a bug related with the building logic for the path as it was not taking into account those Functions with a Provider assigned.

The fix adds this new path as a part of the build path logic to separate folder between Functions:
- /username/arguments
- /username/provider/function/arguments