### PR TITLE
Migrate to bitnami legacy images

### DIFF
--- a/.github/workflows/kubernetes-deploy.yaml
+++ b/.github/workflows/kubernetes-deploy.yaml
@@ -48,6 +48,9 @@ jobs:
             --set gateway.application.debug=1 \
             --set gateway.application.authMockproviderRegistry=test \
             --set gateway.application.dependencies.dynamicDependencies=requirements-test-dynamic-dependencies.txt \
+            --set postgresql.image.repository=bitnamilegacy/postgresql \
+            --set postgresql.volumePermissions.image.repository=bitnamilegacy/os-shell \
+            --set postgresql.metrics.image.repository=bitnamilegacy/postgres-exporter \
             .
           GATEWAY=$(kubectl get pod -l app.kubernetes.io/name=gateway -o name)
           kubectl wait --for=condition=Ready "$GATEWAY" --timeout 5m

--- a/charts/qiskit-serverless/Chart.lock
+++ b/charts/qiskit-serverless/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 9.11.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 13.4.4
+  version: 16.7.27
 - name: kuberay-operator
   repository: https://ray-project.github.io/kuberay-helm
   version: 1.3.2
-digest: sha256:17372e8ea3be16e031b56830dfaf04a85f8d0114c4ca234fedcd2af7677d313f
-generated: "2025-09-17T12:05:48.351655279Z"
+digest: sha256:87ee1e5b7ac9cebda1f2dbd3b484df2bfb9ec5a098bdaf4fd14ea18368d941c7
+generated: "2025-09-18T13:37:48.01118-04:00"

--- a/charts/qiskit-serverless/Chart.yaml
+++ b/charts/qiskit-serverless/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
   - name: postgresql
     condition: postgresqlEnable
-    version: 13.4.4
+    version: 16.7.27
     repository: https://charts.bitnami.com/bitnami
   - name: kuberay-operator
     condition: kuberayOperatorEnable

--- a/docs/deployment/custom_function/local_cluster/deploy.sh
+++ b/docs/deployment/custom_function/local_cluster/deploy.sh
@@ -53,6 +53,9 @@ helm install qs \
 --set ingress.hosts[0].paths[0].pathType=Prefix \
 --set ingress.hosts[0].paths[0].serviceName=gateway \
 --set ingress.hosts[0].paths[0].servicePort=8000 \
+--set postgresql.image.repository=bitnamilegacy/postgresql \
+--set postgresql.volumePermissions.image.repository=bitnamilegacy/os-shell \
+--set postgresql.metrics.image.repository=bitnamilegacy/postgres-exporter \
 .
 
 kubectl wait \


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

As a context from Bitnami team, there was a change in the policy maintaining their docker images that made us to migrate from `bitnami` to `bitnamylegacy` by now for our tests. I need to dig more in-depth to prepare next steps in case these docker images don't receive more updates in the future so this PR works as a temporal patch from that situation.