### PR TITLE
🏗️ Fix conflict naming between serializers

### DIFF
--- a/gateway/api/v1/views/jobs_new/list.py
+++ b/gateway/api/v1/views/jobs_new/list.py
@@ -29,7 +29,7 @@ from api.v1.views.serializer_utils import SanitizedCharField
 from api.views.enums.type_filter import TypeFilter
 
 
-class InputSerializer(serializers.Serializer):
+class ListInputSerializer(serializers.Serializer):
     """
     Validates and sanitizes query parameters for the jobs list endpoint.
     """
@@ -56,7 +56,7 @@ class InputSerializer(serializers.Serializer):
         return JobFilters(**validated_data)
 
 
-class ProgramSummarySerializer(serializers.ModelSerializer):
+class ListProgramSummarySerializer(serializers.ModelSerializer):
     """
     Summary fields for the related program.
     """
@@ -66,12 +66,12 @@ class ProgramSummarySerializer(serializers.ModelSerializer):
         fields = ["id", "title", "provider"]
 
 
-class JobSerializerWithoutResult(serializers.ModelSerializer):
+class ListJobSerializerWithoutResult(serializers.ModelSerializer):
     """
     Minimal job representation for listings.
     """
 
-    program = ProgramSummarySerializer(many=False)
+    program = ListProgramSummarySerializer(many=False)
 
     class Meta:
         model = Job
@@ -98,7 +98,7 @@ def serialize_output(
     Returns:
         A dictionary with pagination metadata and serialized items.
     """
-    serializer = JobSerializerWithoutResult(jobs, many=True)
+    serializer = ListJobSerializerWithoutResult(jobs, many=True)
     return create_paginated_response(
         data=serializer.data,
         total_count=total_count,
@@ -167,7 +167,7 @@ def serialize_output(
         ),
     ],
     responses={
-        status.HTTP_200_OK: JobSerializerWithoutResult(many=True),
+        status.HTTP_200_OK: ListJobSerializerWithoutResult(many=True),
         **standard_error_responses(
             not_found_example="Qiskit Function XXX doesn't exist.",
         ),
@@ -193,7 +193,7 @@ def get_jobs(request: Request) -> Response:
     Returns:
         A paginated list of jobs matching the filters.
     """
-    serializer = InputSerializer(data=request.query_params)
+    serializer = ListInputSerializer(data=request.query_params)
     serializer.is_valid(raise_exception=True)
 
     filters = cast(JobFilters, serializer.create(serializer.validated_data))

--- a/gateway/api/v1/views/jobs_new/provider_list.py
+++ b/gateway/api/v1/views/jobs_new/provider_list.py
@@ -32,7 +32,7 @@ class TypeFilterField(serializers.ChoiceField):
         return TypeFilter(value) if value else None
 
 
-class InputSerializer(serializers.Serializer):
+class ProviderListInputSerializer(serializers.Serializer):
     """
     Validate and sanitize the input
     """
@@ -58,7 +58,7 @@ class InputSerializer(serializers.Serializer):
         return JobFilters(**validated_data)
 
 
-class ProgramSummarySerializer(serializers.ModelSerializer):
+class ProviderListProviderProgramSummarySerializer(serializers.ModelSerializer):
     """
     Program serializer with summary fields for job listings.
     """
@@ -68,12 +68,12 @@ class ProgramSummarySerializer(serializers.ModelSerializer):
         fields = ["id", "title", "provider"]
 
 
-class JobSerializerWithoutResult(serializers.ModelSerializer):
+class ProviderListJobSerializerWithoutResult(serializers.ModelSerializer):
     """
     Job serializer. Include basic fields from the initial model.
     """
 
-    program = ProgramSummarySerializer(many=False)
+    program = ProviderListProviderProgramSummarySerializer(many=False)
 
     class Meta:
         model = Job
@@ -90,7 +90,7 @@ def serialize_output(
     """
     Prepare the output for the end-point
     """
-    serializer = JobSerializerWithoutResult(jobs, many=True)
+    serializer = ProviderListJobSerializerWithoutResult(jobs, many=True)
     return create_paginated_response(
         data=serializer.data,
         total_count=total_count,
@@ -158,7 +158,7 @@ def serialize_output(
         ),
     ],
     responses={
-        status.HTTP_200_OK: JobSerializerWithoutResult(many=True),
+        status.HTTP_200_OK: ProviderListJobSerializerWithoutResult(many=True),
         **standard_error_responses(
             not_found_example="Provider XXX doesn't exist.",
         ),
@@ -172,7 +172,7 @@ def get_provider_jobs(request: Request) -> Response:
     """
     Return a list of jobs for the given provider (and optional filters).
     """
-    serializer = InputSerializer(data=request.query_params)
+    serializer = ProviderListInputSerializer(data=request.query_params)
     serializer.is_valid(raise_exception=True)
 
     filters = JobFilters(**serializer.validated_data)

--- a/gateway/api/v1/views/jobs_new/save_result.py
+++ b/gateway/api/v1/views/jobs_new/save_result.py
@@ -21,7 +21,7 @@ from api.v1.endpoint_handle_exceptions import endpoint_handle_exceptions
 from api.v1.views.swagger_utils import standard_error_responses
 
 
-class InputSerializer(serializers.Serializer):
+class SaveResultInputSerializer(serializers.Serializer):
     """
     Validate and sanitize the input
     """
@@ -29,7 +29,7 @@ class InputSerializer(serializers.Serializer):
     result = serializers.DictField(required=True)
 
 
-class ProgramSerializer(api_serializers.ProgramSerializer):
+class SaveResultProgramSerializer(api_serializers.ProgramSerializer):
     """
     Program serializer first version. Include basic fields from the initial model.
     """
@@ -48,12 +48,12 @@ class ProgramSerializer(api_serializers.ProgramSerializer):
         ]
 
 
-class JobSerializer(api_serializers.JobSerializer):
+class SaveResultJobSerializer(api_serializers.JobSerializer):
     """
     Job serializer first version. Include basic fields from the initial model.
     """
 
-    program = ProgramSerializer(many=False)
+    program = SaveResultProgramSerializer(many=False)
 
     class Meta(api_serializers.JobSerializer.Meta):
         fields = ["id", "result", "status", "program", "created", "sub_status"]
@@ -69,15 +69,15 @@ def serialize_output(job: Job):
     Returns:
         Serialized job as a dictionary.
     """
-    return JobSerializer(job).data
+    return SaveResultJobSerializer(job).data
 
 
 @swagger_auto_schema(
     method="post",
     operation_description="Save the result for a job.",
-    request_body=InputSerializer,
+    request_body=SaveResultInputSerializer,
     responses={
-        status.HTTP_200_OK: JobSerializer(many=False),
+        status.HTTP_200_OK: SaveResultJobSerializer(many=False),
         **standard_error_responses(
             not_found_example="Job [XXXX] not found",
         ),
@@ -98,7 +98,7 @@ def save_result(request: Request, job_id: UUID) -> Response:
     Returns:
         Response containing the updated serialized job.
     """
-    serializer = InputSerializer(data=request.data)
+    serializer = SaveResultInputSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
 
     result = serializer.validated_data["result"]

--- a/gateway/api/v1/views/jobs_new/set_sub_status.py
+++ b/gateway/api/v1/views/jobs_new/set_sub_status.py
@@ -21,7 +21,7 @@ from api.v1.endpoint_handle_exceptions import endpoint_handle_exceptions
 from api.v1.views.swagger_utils import standard_error_responses
 
 
-class InputSerializer(serializers.Serializer):
+class SetSubStatusInputSerializer(serializers.Serializer):
     """
     Validates the request body for updating the sub-status.
     """
@@ -38,7 +38,7 @@ class InputSerializer(serializers.Serializer):
     )
 
 
-class ProgramSummarySerializer(api_serializers.ProgramSerializer):
+class SetSubStatusProgramSummarySerializer(api_serializers.ProgramSerializer):
     """
     Program serializer with summary fields for job listings.
     """
@@ -47,12 +47,12 @@ class ProgramSummarySerializer(api_serializers.ProgramSerializer):
         fields = ["id", "title", "provider"]
 
 
-class JobSerializerWithoutResult(api_serializers.JobSerializer):
+class SetSubstatusJobSerializerWithoutResult(api_serializers.JobSerializer):
     """
     Job representation without `result`.
     """
 
-    program = ProgramSummarySerializer(many=False)
+    program = SetSubStatusProgramSummarySerializer(many=False)
 
     class Meta(api_serializers.JobSerializer.Meta):
         fields = ["id", "status", "program", "created", "sub_status"]
@@ -68,15 +68,15 @@ def serialize_output(job: Job) -> dict[str, Any]:
     Returns:
         A dictionary containing the serialized job under the 'job' key.
     """
-    return {"job": JobSerializerWithoutResult(job).data}
+    return {"job": SetSubstatusJobSerializerWithoutResult(job).data}
 
 
 @swagger_auto_schema(
     method="patch",
     operation_description="Update the sub status of a job",
-    request_body=InputSerializer,
+    request_body=SetSubStatusInputSerializer,
     responses={
-        status.HTTP_200_OK: JobSerializerWithoutResult(many=False),
+        status.HTTP_200_OK: SetSubstatusJobSerializerWithoutResult(many=False),
         **standard_error_responses(
             bad_request_example="'sub_status' not provided or is not valid",
             forbidden_example="Cannot update 'sub_status' when job is not RUNNING.",
@@ -100,7 +100,7 @@ def set_sub_status(request: Request, job_id: UUID) -> Response:
     Returns:
         Response containing the updated job under the 'job' key.
     """
-    serializer = InputSerializer(data=request.data)
+    serializer = SetSubStatusInputSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
 
     sub_status = serializer.validated_data["sub_status"]

--- a/gateway/api/v1/views/jobs_new/stop.py
+++ b/gateway/api/v1/views/jobs_new/stop.py
@@ -12,7 +12,7 @@ from api.use_cases.jobs.stop import StopJobUseCase
 from api.v1.views.swagger_utils import standard_error_responses
 
 
-class InputSerializer(serializers.Serializer):
+class StopInputSerializer(serializers.Serializer):
     """
     Validate and sanitize the input
     """
@@ -38,7 +38,7 @@ def serialize_output(message: str) -> StopJobOutputSerializer:
 @swagger_auto_schema(
     method="post",
     operation_description="Stop a job.",
-    request_body=InputSerializer,
+    request_body=StopInputSerializer,
     responses={
         status.HTTP_200_OK: StopJobOutputSerializer,
         **standard_error_responses(
@@ -55,7 +55,7 @@ def stop(request, job_id):
     """
     Stop job
     """
-    serializer = InputSerializer(data=request.data)
+    serializer = StopInputSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
     validated_data = serializer.validated_data
     service = validated_data["service"]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR pretends to fix a problem from #1708 due to that Serializers with the same name between different views were generating errors when we try to access to our swagger documentation.