### PR TITLE
Update integration tests to inspect result contents

### DIFF
--- a/tests/basic/function/runner.py
+++ b/tests/basic/function/runner.py
@@ -16,7 +16,7 @@ def custom_function(arguments):
 
     # running Sampler primitive
     sampler = Sampler()
-    quasi_dists = sampler.run([(circuit)]).result()[0].data.meas.get_counts()
+    quasi_dists = sampler.run([circuit]).result()[0].data.meas.get_counts()
 
     print("Completed running pattern.")
     return quasi_dists

--- a/tests/basic/source_files/pattern.py
+++ b/tests/basic/source_files/pattern.py
@@ -14,7 +14,7 @@ circuit.measure_all()
 
 # running Sampler primitive
 sampler = Sampler()
-quasi_dists = sampler.run([(circuit)]).result()[0].data.meas.get_counts()
+quasi_dists = sampler.run([circuit]).result()[0].data.meas.get_counts()
 
 # saves results of program execution,
 # which will be accessible by calling `.result()`

--- a/tests/basic/source_files/pattern_with_arguments.py
+++ b/tests/basic/source_files/pattern_with_arguments.py
@@ -12,7 +12,7 @@ circuit = arguments.get("circuit")
 
 sampler = Sampler()
 
-quasi_dists = sampler.run([(circuit)]).result()[0].data.meas.get_counts()
+quasi_dists = sampler.run([circuit]).result()[0].data.meas.get_counts()
 
 print(f"Quasi distribution: {quasi_dists}")
 

--- a/tests/basic/source_files/pattern_with_parallel_workflow.py
+++ b/tests/basic/source_files/pattern_with_parallel_workflow.py
@@ -10,7 +10,7 @@ from qiskit.circuit.random import random_circuit
 @distribute_task()
 def distributed_sample(circuit: QuantumCircuit):
     """Distributed task that returns quasi distribution for given circuit."""
-    return Sampler().run([(circuit)]).result()[0].data.meas.get_counts()
+    return Sampler().run([circuit]).result()[0].data.meas.get_counts()
 
 
 arguments = get_arguments()
@@ -18,7 +18,7 @@ circuits = arguments.get("circuits")
 
 # run distributed tasks as async function
 # we get task references as a return type
-sample_task_references = [distributed_sample([(circuit)]) for circuit in circuits]
+sample_task_references = [distributed_sample([circuit]) for circuit in circuits]
 
 # now we need to collect results from task references
 results = get(sample_task_references)

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -1,5 +1,5 @@
 # pylint: disable=import-error, invalid-name
-""" Fixtures for tests """
+"""Fixtures for tests"""
 import os
 
 from pytest import fixture

--- a/tests/docker/source_files/pattern.py
+++ b/tests/docker/source_files/pattern.py
@@ -14,7 +14,7 @@ circuit.measure_all()
 
 # running Sampler primitive
 sampler = Sampler()
-quasi_dists = sampler.run([(circuit)]).result()[0].data.meas.get_counts()
+quasi_dists = sampler.run([circuit]).result()[0].data.meas.get_counts()
 
 # saves results of program execution,
 # which will be accessible by calling `.result()`

--- a/tests/docker/source_files/pattern_with_arguments.py
+++ b/tests/docker/source_files/pattern_with_arguments.py
@@ -12,7 +12,7 @@ circuit = arguments.get("circuit")
 
 sampler = Sampler()
 
-quasi_dists = sampler.run([(circuit)]).result()[0].data.meas.get_counts()
+quasi_dists = sampler.run([circuit]).result()[0].data.meas.get_counts()
 
 print(f"Quasi distribution: {quasi_dists}")
 

--- a/tests/docker/source_files/pattern_with_parallel_workflow.py
+++ b/tests/docker/source_files/pattern_with_parallel_workflow.py
@@ -10,7 +10,7 @@ from qiskit.circuit.random import random_circuit
 @distribute_task()
 def distributed_sample(circuit: QuantumCircuit):
     """Distributed task that returns quasi distribution for given circuit."""
-    return Sampler().run([(circuit)]).result()[0].data.meas.get_counts()
+    return Sampler().run([circuit]).result()[0].data.meas.get_counts()
 
 
 arguments = get_arguments()
@@ -18,7 +18,7 @@ circuits = arguments.get("circuits")
 
 # run distributed tasks as async function
 # we get task references as a return type
-sample_task_references = [distributed_sample([(circuit)]) for circuit in circuits]
+sample_task_references = [distributed_sample([circuit]) for circuit in circuits]
 
 # now we need to collect results from task references
 results = get(sample_task_references)

--- a/tests/docker/source_files/program.py
+++ b/tests/docker/source_files/program.py
@@ -14,7 +14,7 @@ circuit.measure_all()
 
 # running Sampler primitive
 sampler = Sampler()
-quasi_dists = sampler.run([(circuit)]).result()[0].data.meas.get_counts()
+quasi_dists = sampler.run([circuit]).result()[0].data.meas.get_counts()
 
 # saves results of program execution,
 # which will be accessible by calling `.result()`

--- a/tests/docker/test_docker.py
+++ b/tests/docker/test_docker.py
@@ -45,8 +45,13 @@ class TestFunctionsDocker:
 
         job = runnable_function.run()
 
+        # pylint: disable=duplicate-code
         assert job is not None
         assert job.result() is not None
+        allowed_keys = {"00", "11"}
+        for entry in job.result().get("results", []):
+            assert set(entry.keys()).issubset(allowed_keys)
+
         assert job.status() == "DONE"
         assert isinstance(job.logs(), str)
 
@@ -114,6 +119,9 @@ class TestFunctionsDocker:
 
         assert job is not None
         assert job.result() is not None
+        allowed_keys = {"00", "11"}
+        for entry in job.result().get("results", []):
+            assert set(entry.keys()).issubset(allowed_keys)
         assert job.status() == "DONE"
         assert isinstance(job.logs(), str)
 
@@ -134,6 +142,7 @@ class TestFunctionsDocker:
 
         assert job is not None
         assert job.result() is not None
+        assert job.result() == {"hours": 3}
         assert job.status() == "DONE"
         assert isinstance(job.logs(), str)
 
@@ -194,6 +203,9 @@ class TestFunctionsDocker:
 
         assert job is not None
         assert job.result() is not None
+        allowed_keys = {"00", "11", "01", "10"}
+        for entry in job.result().get("results", []):
+            assert set(entry.keys()).issubset(allowed_keys)
         assert job.status() == "DONE"
         assert isinstance(job.logs(), str)
 

--- a/tests/docker/test_docker_experimental.py
+++ b/tests/docker/test_docker_experimental.py
@@ -35,8 +35,10 @@ class TestDockerExperimental:
 
         job = file_producer_function.run()
 
+        # pylint: disable=duplicate-code
         assert job is not None
         assert job.result() is not None
+        assert job.result() == {"Message": "my_file.txt archived into my_file.tar"}
         assert job.status() == "DONE"
         assert isinstance(job.logs(), str)
 
@@ -60,7 +62,8 @@ class TestDockerExperimental:
 
         job = file_consumer_function.run()
         assert job is not None
-        assert job.result() is not None
+        assert job.result()
+        assert job.result() == {"Message": "Hello"}
         assert job.status() == "DONE"
         assert isinstance(job.logs(), str)
 

--- a/tests/experimental/running_programs_using_decorators.py
+++ b/tests/experimental/running_programs_using_decorators.py
@@ -30,7 +30,7 @@ def hello_qiskit():
     circuit.draw()
 
     sampler = Sampler()
-    quasi_dists = sampler.run([(circuit)]).result()[0].data.meas.get_counts()
+    quasi_dists = sampler.run([circuit]).result()[0].data.meas.get_counts()
 
     return quasi_dists
 
@@ -49,12 +49,12 @@ print(job.logs())
 @distribute_task(target={"cpu": 1})
 def distributed_sample(circuit: QuantumCircuit):
     """Distributed task that returns quasi distribution for given circuit."""
-    return Sampler().run([(circuit)]).result()[0].data.meas.get_counts()
+    return Sampler().run([circuit]).result()[0].data.meas.get_counts()
 
 
 @distribute_qiskit_function(provider)
 def function_with_distributed_tasks(circuits):
-    sample_task_references = [distributed_sample([(circuit)]) for circuit in circuits]
+    sample_task_references = [distributed_sample([circuit]) for circuit in circuits]
     results = get(sample_task_references)
     print(results)
 
@@ -79,10 +79,7 @@ print(job.logs())
 @distribute_qiskit_function(provider, working_dir="./")
 def my_function_with_modules():
     quasi_dists = (
-        Sampler()
-        .run([(create_hello_world_circuit())])
-        .result()[0]
-        .data.meas.get_counts()
+        Sampler().run([create_hello_world_circuit()]).result()[0].data.meas.get_counts()
     )
     return {"quasi_dists": quasi_dists}
 

--- a/tests/experimental/source_files/program.py
+++ b/tests/experimental/source_files/program.py
@@ -14,7 +14,7 @@ circuit.measure_all()
 
 # running Sampler primitive
 sampler = Sampler()
-quasi_dists = sampler.run([(circuit)]).result()[0].data.meas.get_counts()
+quasi_dists = sampler.run([circuit]).result()[0].data.meas.get_counts()
 
 # saves results of program execution,
 # which will be accessible by calling `.result()`


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR is a follow-up to https://github.com/Qiskit/qiskit-serverless/pull/1729 that updates integration tests to not only check that `job.result()` is not `None`, but also confirm that it returns a dictionary with specific content. This should allow to catch potential regressions in the `save_result` functionality.


### Details and comments

