### PR TITLE
Fix pylint tests due to a new major version

### DIFF
--- a/client/requirements-dev.txt
+++ b/client/requirements-dev.txt
@@ -1,5 +1,5 @@
 coverage>=5.5
-pylint>=2.17.7
+pylint>=2.17.7, <4
 nbqa>=1.7.1
 treon>=0.1.4
 pytest>=6.2.5

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -1,5 +1,5 @@
 coverage>=5.5
-pylint>=2.17.7
+pylint>=2.17.7, <4
 nbqa>=1.7.1
 treon>=0.1.4
 pytest>=6.2.5

--- a/gateway/requirements-dev.txt
+++ b/gateway/requirements-dev.txt
@@ -1,4 +1,4 @@
-pylint>=2.17.7
+pylint>=2.17.7, <4
 pytest>=6.2.5
 pylint-django>=2.5.5
 # Black's formatting rules can change between major versions, so we use

--- a/tests/requirements-dev.txt
+++ b/tests/requirements-dev.txt
@@ -7,7 +7,7 @@ testcontainers>=4.7.2
 tox>=4.0.0
 black[jupyter]~=22.12
 requests-mock>=1.11.0
-pylint>=2.17.7
+pylint>=2.17.7, <4
 mypy>=0.991
 mypy-extensions>=0.4.4
 # dependency from ray and tox requires newer versions from cachetools


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Pylint released the new major version 4.0.0 and our current configuration is not compatible with the current configuration. This PR adds additional constrains to our pylint configuration to prevent the tests to fail until we can migrate to the new version.
