### PR TITLE
Update GitHub Action to release to pip

### DIFF
--- a/.github/workflows/client-pypi-release.yaml
+++ b/.github/workflows/client-pypi-release.yaml
@@ -12,25 +12,23 @@ jobs:
   release-package:
     name: Build and Publish Release Artifacts
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/qiskit-serverless
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.11'
-      - name: Install Deps
-        run: pip install -U twine==5.1.1 wheel==0.44.0
-      - name: Build Artifacts
-        run: |
-          cd client
-          python setup.py sdist
-          python setup.py bdist_wheel
-        shell: bash
-      - uses: actions/upload-artifact@v4
+      - name: Install dependencies
+        run: | 
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build artifacts
+        run: python -m build
+      - name: Publish release to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          path: ./client/dist/qiskit_serverless*
-      - name: Publish to PyPi
-        env:
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        run: twine upload client/dist/qiskit_serverless*
+          user: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR updates the current GitHub action that releases to pip as the old one it's not working. We took inspiration from different addons repositories as they make use of the action: `pypa/gh-action-pypi-publish`, to do the release.