### PR TITLE
Standardize Python version for tests and document libmagic dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,7 @@ You'll need to install these tools on your development environment:
 1. [helm](https://helm.sh/): to install qiskit-serverless on Kubernetes
 1. [tox](https://tox.wiki/en): to run tests and build the documentation
 1. [pre-commit](https://pre-commit.com/): to run linting checks automatically on commit/push
+2. [libmagic](https://github.com/ahupp/python-magic): for file type identification
 
 Note: Installing the `pip` and `venv` python libraries will also be useful
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ skipsdist = true
 skip_missing_interpreters = true
 
 [testenv:docs]
+basepython = python3.11
 skip_install = false
 install_command =
   pip install -U {opts} {packages}
@@ -19,6 +20,7 @@ commands =
   sphinx-build -v -W {posargs} docs/ docs/_build/html
 
 [testenv:cluster-deploy]
+basepython = python3.11
 skip_install = true
 allowlist_externals =
   kind


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
This PR standardizes the Python version for tox test environments and documents the libmagic dependency required for development.


### Details and comments
**Changes:**
1. **tox.ini**: Added `basepython = python3.11` to the `docs` and `cluster-deploy` test environments to ensure consistent Python version usage across these environments.

2. **CONTRIBUTING.md**: Added libmagic to the list of required development tools with a link to the python-magic repository.
