### PR TITLE
Update client requirements to qiskit-ibm-runtime>0.47

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -2,7 +2,7 @@ ray[default]>=2.30, <3
 requests>=2.32.2, <3
 importlib-metadata>=5.2.0, <9
 qiskit[qpy-compat]>=1.4, <3
-qiskit-ibm-runtime>=0.40.1, <0.46.0
+qiskit-ibm-runtime>=0.40.1, <0.47.0
 # Make sure ray node and notebook node have the same version of cloudpickle
 cloudpickle==3.1.2
 tqdm>=4.66.3, <5


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
This changes the version requirements for the `qiskit-serverless` package to support `qiskit-ibm-runtime=0.46.1`. The team [maintaining the Qiskit documentation site](https://github.com/Qiskit/documentation) needs all packages in our test suite to support this version of runtime in order for us to test our documentation correctly.

If possible after this gets merged, it'd be great if a patch release could be published so we just have to update our test's version requirements.


### Details and comments

