### PR TITLE
Refactor `is_active()`

### DIFF
--- a/gateway/api/use_cases/jobs/get_logs.py
+++ b/gateway/api/use_cases/jobs/get_logs.py
@@ -50,10 +50,10 @@ class GetJobLogsUseCase:
         if logs:
             return logs
 
-        # Get from Ray if it is already running. Then filter
-        if job.is_active():
+        runner = get_runner(job)
+        if runner.is_alive():
             try:
-                logs = get_runner(job).logs()
+                logs = runner.logs()
             except RunnerError:
                 return "Logs not available for this job during execution."
 

--- a/gateway/api/use_cases/jobs/get_logs.py
+++ b/gateway/api/use_cases/jobs/get_logs.py
@@ -51,7 +51,7 @@ class GetJobLogsUseCase:
             return logs
 
         runner = get_runner(job)
-        if runner.is_alive():
+        if runner.is_active():
             try:
                 logs = runner.logs()
             except RunnerError:

--- a/gateway/api/use_cases/jobs/provider_logs.py
+++ b/gateway/api/use_cases/jobs/provider_logs.py
@@ -51,7 +51,7 @@ class GetProviderJobLogsUseCase:
             return logs
 
         runner = get_runner(job)
-        if runner.is_alive():
+        if runner.is_active():
             try:
                 logs = runner.logs()
             except RunnerError:

--- a/gateway/api/use_cases/jobs/provider_logs.py
+++ b/gateway/api/use_cases/jobs/provider_logs.py
@@ -50,10 +50,10 @@ class GetProviderJobLogsUseCase:
         if logs:
             return logs
 
-        # Get from Ray if it is already running. Then filterjob.is_active()
-        if job.is_active():
+        runner = get_runner(job)
+        if runner.is_alive():
             try:
-                logs = get_runner(job).logs()
+                logs = runner.logs()
             except RunnerError:
                 return "Logs not available for this job during execution."
 

--- a/gateway/api/use_cases/jobs/stop.py
+++ b/gateway/api/use_cases/jobs/stop.py
@@ -110,9 +110,10 @@ class StopJobUseCase:
             self.status_messages.append(f"Runtime job {job_id_str} could not be canceled (invalid state).")
 
     def _stop_ray_job_if_active(self, job: Job):
-        if job.is_active():
+        runner = get_runner(job)
+        if runner.is_alive():
             try:
-                was_running = get_runner(job).stop()
+                was_running = runner.stop()
                 if was_running:
                     self.status_messages.append("Serverless job was running and has been stopped.")
                 else:

--- a/gateway/api/use_cases/jobs/stop.py
+++ b/gateway/api/use_cases/jobs/stop.py
@@ -111,7 +111,7 @@ class StopJobUseCase:
 
     def _stop_ray_job_if_active(self, job: Job):
         runner = get_runner(job)
-        if runner.is_alive():
+        if runner.is_active():
             try:
                 was_running = runner.stop()
                 if was_running:

--- a/gateway/core/models.py
+++ b/gateway/core/models.py
@@ -353,10 +353,6 @@ class Job(models.Model):
         """Returns true if job is in terminal state."""
         return self.status in self.TERMINAL_STATUSES
 
-    def is_active(self) -> bool:
-        """Returns true if job has any active pod."""
-        return self.compute_resource and self.compute_resource.active
-
 
 class RuntimeJob(models.Model):
     """Runtime Job model."""

--- a/gateway/core/services/runners/abstract_runner.py
+++ b/gateway/core/services/runners/abstract_runner.py
@@ -96,8 +96,8 @@ class AbstractRunner(ABC):
     # --- Methods that DO require connection (lazy connect) ---
 
     @abstractmethod
-    def is_alive(self) -> bool:
-        """Check if the engine host is alive and reachable.
+    def is_active(self) -> bool:
+        """Check if the engine host is active even id the job is finished.
 
         Performs a lightweight HTTP check to the engine host.
         Does NOT require a full SDK connection.

--- a/gateway/core/services/runners/abstract_runner.py
+++ b/gateway/core/services/runners/abstract_runner.py
@@ -96,6 +96,18 @@ class AbstractRunner(ABC):
     # --- Methods that DO require connection (lazy connect) ---
 
     @abstractmethod
+    def is_alive(self) -> bool:
+        """Check if the engine host is alive and reachable.
+
+        Performs a lightweight HTTP check to the engine host.
+        Does NOT require a full SDK connection.
+
+        Returns:
+            True if the engine host responds, False otherwise.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def status(self) -> Optional[str]:
         """
         Get job status (mapped to Job.STATUS).

--- a/gateway/core/services/runners/fleets_runner.py
+++ b/gateway/core/services/runners/fleets_runner.py
@@ -14,6 +14,10 @@ class FleetsRunner(AbstractRunner):
     def disconnect(self) -> None:
         """Disconnect from CodeEngine?? (remove the SDK)"""
 
+    def is_alive(self) -> bool:
+        """Check if the Fleets engine is alive."""
+        raise NotImplementedError("FleetsRunner not yet implemented")
+
     def submit(self) -> None:
         """
         Submit the job to Fleets.

--- a/gateway/core/services/runners/fleets_runner.py
+++ b/gateway/core/services/runners/fleets_runner.py
@@ -14,7 +14,7 @@ class FleetsRunner(AbstractRunner):
     def disconnect(self) -> None:
         """Disconnect from CodeEngine?? (remove the SDK)"""
 
-    def is_alive(self) -> bool:
+    def is_active(self) -> bool:
         """Check if the Fleets engine is alive."""
         raise NotImplementedError("FleetsRunner not yet implemented")
 

--- a/gateway/core/services/runners/ray_runner.py
+++ b/gateway/core/services/runners/ray_runner.py
@@ -66,7 +66,7 @@ class RayRunner(AbstractRunner):
         """Check if the Ray cluster host is alive and reachable.
         True if the Ray dashboard responds, False otherwise.
         """
-        if not self._job or not self._job.compute_resource or self._job.compute_resource.active == False:
+        if not self._job or not self._job.compute_resource or not self._job.compute_resource.active:
             return False
 
         try:

--- a/gateway/core/services/runners/ray_runner.py
+++ b/gateway/core/services/runners/ray_runner.py
@@ -66,6 +66,9 @@ class RayRunner(AbstractRunner):
         """Check if the Ray cluster host is alive and reachable.
         True if the Ray dashboard responds, False otherwise.
         """
+        if not self._job or not self._job.compute_resource or self._job.compute_resource.active == False:
+            return False
+
         try:
             self._create_client()  # the client ray pings the server when it's created
             return True
@@ -74,11 +77,11 @@ class RayRunner(AbstractRunner):
 
     def _create_client(self):
         if not self._job:
-            raise RunnerError(f"Unable to connect to Ray cluster at. No job linked to the client")
+            raise RunnerError("Unable to connect to Ray cluster at. No job linked to the client")
 
         compute_resource = self._job.compute_resource
         if not compute_resource:
-            raise RunnerError(f"Unable to connect to Ray cluster at. No compute resource")
+            raise RunnerError("Unable to connect to Ray cluster at. No compute resource")
         host = compute_resource.host
         try:
             client = retry_function(

--- a/gateway/core/services/runners/ray_runner.py
+++ b/gateway/core/services/runners/ray_runner.py
@@ -62,7 +62,7 @@ class RayRunner(AbstractRunner):
         self._client = None
         self._connected = False
 
-    def is_alive(self) -> bool:
+    def is_active(self) -> bool:
         """Check if the Ray cluster host is alive and reachable.
         True if the Ray dashboard responds, False otherwise.
         """

--- a/gateway/core/services/runners/ray_runner.py
+++ b/gateway/core/services/runners/ray_runner.py
@@ -54,21 +54,45 @@ class RayRunner(AbstractRunner):
         if self._connected:
             return
 
+        self._client = self._create_client()
+        self._connected = True
+
+    def disconnect(self) -> None:
+        """Close connection to Ray cluster."""
+        self._client = None
+        self._connected = False
+
+    def is_alive(self) -> bool:
+        """Check if the Ray cluster host is alive and reachable.
+        True if the Ray dashboard responds, False otherwise.
+        """
+        try:
+            self._create_client()  # the client ray pings the server when it's created
+            return True
+        except Exception:  # pylint: disable=broad-exception-caught
+            return False
+
+    def _create_client(self):
+        if not self._job:
+            raise RunnerError(f"Unable to connect to Ray cluster at. No job linked to the client")
+
         compute_resource = self._job.compute_resource
+        if not compute_resource:
+            raise RunnerError(f"Unable to connect to Ray cluster at. No compute resource")
         host = compute_resource.host
         try:
-            self._client = retry_function(
+            client = retry_function(
                 callback=lambda: JobSubmissionClient(host),
                 num_retries=settings.RAY_SETUP_MAX_RETRIES,
                 error_message=f"Ray JobClientSubmission setup failed for host [{host}].",
             )
-            self._connected = True
             logger.info(
                 "[connect] job_id=%s cluster=%s host=%s Connected to Ray cluster",
                 self._job.id,
                 compute_resource,
                 host,
             )
+            return client
         except Exception as ex:
             logger.error(
                 "[connect] job_id=%s cluster=%s host=%s error=%s Unable to connect to Ray cluster",
@@ -78,11 +102,6 @@ class RayRunner(AbstractRunner):
                 ex,
             )
             raise RunnerError(f"Unable to connect to Ray cluster at [{host}]", ex) from ex
-
-    def disconnect(self) -> None:
-        """Close connection to Ray cluster."""
-        self._client = None
-        self._connected = False
 
     def submit(self) -> None:
         """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The `job.is_active()` only checks if ComputeResource.active. We need a better way to:
- Ensure that if the ComputeResource is active, the host responds, so we can safely call the `logs()` or `stop()` methods (we can't rely on the job.status field because it may not be updated).
- Move this behavior in a Runner, so Fleets can have its own is_active() implementation.

