### PR TITLE
Fix template to allow previous versions

### DIFF
--- a/gateway/templates/main.tmpl
+++ b/gateway/templates/main.tmpl
@@ -37,5 +37,5 @@ except Exception as e:
     if send_error is not None:
         send_error(code, message, exception, details)
     if send_error is None or not hasattr(e, 'code'):
-        save_result( traceback.format_exception_only(e))
+        save_result(traceback.format_exception_only(e))
     raise

--- a/gateway/templates/main.tmpl
+++ b/gateway/templates/main.tmpl
@@ -7,7 +7,7 @@ import traceback
 from qiskit_serverless import get_arguments, save_result
 
 # send_error is available from qiskit_serverless >= 0.31.0
-# Not all partners may have upgraded yet, so we fall back to save_result
+# For backwards compatibility, we fall back to save_result
 try:
     from qiskit_serverless import send_error
 except ImportError:

--- a/gateway/templates/main.tmpl
+++ b/gateway/templates/main.tmpl
@@ -4,7 +4,14 @@ import os
 import sys
 import traceback
 
-from qiskit_serverless import get_arguments, save_result, send_error
+from qiskit_serverless import get_arguments, save_result
+
+# send_error is available from qiskit_serverless >= 0.31.0
+# Not all partners may have upgraded yet, so we fall back to save_result
+try:
+    from qiskit_serverless import send_error
+except ImportError:
+    send_error = None
 
 sys.path.append("{{mount_path}}")
 
@@ -27,7 +34,8 @@ except Exception as e:
     message = getattr(e, 'message', '\n'.join(traceback.format_exception_only(e)))
     exception = type(e).__name__
     details = getattr(e, 'details', None)
-    send_error(code, message, exception, details)
-    if not hasattr(e, 'code'):
-        save_result(traceback.format_exception_only(e))
+    if send_error is not None:
+        send_error(code, message, exception, details)
+    if send_error is None or not hasattr(e, 'code'):
+        save_result( traceback.format_exception_only(e))
     raise


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The template `main.tmpl` should work with new versions, where send_error is available, and old versions too, where the send_error is not present yet

### Details and comments

This PR imports and calls safely to the send_error code.