### PR TITLE
Prevent gateway/media/ from being created during test runs

### DIFF
--- a/gateway/tests/conftest.py
+++ b/gateway/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Global pytest fixtures for gateway tests."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def media_root_tmp(tmp_path, settings):
+    """Redirect MEDIA_ROOT to a temp directory for every test.
+
+    Prevents PathBuilder.absolute_path() from creating directories inside
+    the source tree (gateway/media/) during test runs.
+    """
+    settings.MEDIA_ROOT = str(tmp_path)

--- a/gateway/tests/scheduler/management/test_migrate_old_job_logs.py
+++ b/gateway/tests/scheduler/management/test_migrate_old_job_logs.py
@@ -1,386 +1,199 @@
 """Tests for migrate_old_job_logs command."""
 
-import tempfile
 from typing import Optional
 
+import pytest
 from django.contrib.auth.models import User, Group
 from django.core.management import call_command
-from django.test import override_settings
-from rest_framework.test import APITestCase
 
 from core.models import ComputeResource, Job, Program, Provider, Config
 from core.services.storage.logs_storage import LogsStorage
 
 
-@override_settings(MEDIA_ROOT=tempfile.mkdtemp())
-class TestMigrateOldJobLogs(APITestCase):
-    """Tests for migrate_old_job_logs command."""
+@pytest.fixture(autouse=True)
+def setup_config(db):
+    Config.add_defaults()
 
-    fixtures = ["tests/fixtures/schedule_fixtures.json"]
 
-    def setUp(self):
-        Config.add_defaults()
+def _create_test_job(
+    author: str = "test_author",
+    provider_admin: Optional[str] = None,
+    status: str = Job.PENDING,
+    compute_resource: Optional[ComputeResource] = None,
+    ray_job_id: str = "test-job-id",
+    gpu: bool = False,
+    logs: str = "No logs yet.",
+) -> Job:
+    if compute_resource is None:
+        compute_resource = ComputeResource.objects.create(title=f"test-cluster-{ray_job_id}", active=True)
 
-    def test_migrate_jobs_logs_to_storage_active(self):
-        """Tests that logs are not migrated with an active compute resource."""
+    author_user, _ = User.objects.get_or_create(username=author)
+    provider = None
 
-        with self.settings(JOB_LOGS_MIGRATION_BATCH_SIZE=10):
-            compute_resource_active = ComputeResource.objects.create(title=f"test-cluster-migrate-logs", active=True)
-            test_logs = "This is a log for testing pourposes"
+    if provider_admin:
+        provider = Provider.objects.create(name=provider_admin)
+        admin_group, _ = Group.objects.get_or_create(name=provider_admin)
+        admin_user, _ = User.objects.get_or_create(username=provider_admin)
+        admin_user.groups.add(admin_group)
+        provider.admin_groups.add(admin_group)
 
-            job_succeeded_active = self._create_test_job(
-                status=Job.SUCCEEDED,
-                compute_resource=compute_resource_active,
-                logs=test_logs,
-            )
-            job_failed_active = self._create_test_job(
-                status=Job.FAILED,
-                compute_resource=compute_resource_active,
-                logs=test_logs,
-            )
-            job_stopped_active = self._create_test_job(
-                status=Job.STOPPED,
-                compute_resource=compute_resource_active,
-                logs=test_logs,
-            )
-            job_queued_active = self._create_test_job(
-                status=Job.QUEUED,
-                compute_resource=compute_resource_active,
-                logs=test_logs,
-            )
-            job_running_active = self._create_test_job(
-                status=Job.RUNNING,
-                compute_resource=compute_resource_active,
-                logs=test_logs,
-            )
+    program = Program.objects.create(
+        title=f"program-{author_user.username}-{provider_admin or 'custom'}",
+        author=author_user,
+        provider=provider,
+    )
 
-            call_command("migrate_old_job_logs")
+    return Job.objects.create(
+        author=author_user,
+        program=program,
+        status=status,
+        compute_resource=compute_resource,
+        ray_job_id=ray_job_id,
+        gpu=gpu,
+        logs=logs,
+    )
 
-            job_succeeded_active.refresh_from_db()
-            job_succeeded_active_storage = LogsStorage(job_succeeded_active)
-            job_failed_active.refresh_from_db()
-            job_failed_active_storage = LogsStorage(job_failed_active)
-            job_stopped_active.refresh_from_db()
-            job_stopped_active_storage = LogsStorage(job_stopped_active)
-            job_queued_active.refresh_from_db()
-            job_queued_active_storage = LogsStorage(job_queued_active)
-            job_running_active.refresh_from_db()
-            job_running_active_storage = LogsStorage(job_running_active)
 
-            self.assertEqual(job_succeeded_active.logs, test_logs)
-            self.assertEqual(job_succeeded_active_storage.get_public_logs(), None)
+@pytest.mark.django_db
+def test_migrate_jobs_logs_to_storage_active():
+    """Tests that logs are not migrated with an active compute resource."""
+    compute_resource_active = ComputeResource.objects.create(title="test-cluster-migrate-logs", active=True)
+    test_logs = "This is a log for testing pourposes"
 
-            self.assertEqual(job_failed_active.logs, test_logs)
-            self.assertEqual(job_failed_active_storage.get_public_logs(), None)
+    job_succeeded_active = _create_test_job(
+        status=Job.SUCCEEDED, compute_resource=compute_resource_active, logs=test_logs
+    )
+    job_failed_active = _create_test_job(status=Job.FAILED, compute_resource=compute_resource_active, logs=test_logs)
+    job_stopped_active = _create_test_job(status=Job.STOPPED, compute_resource=compute_resource_active, logs=test_logs)
+    job_queued_active = _create_test_job(status=Job.QUEUED, compute_resource=compute_resource_active, logs=test_logs)
+    job_running_active = _create_test_job(status=Job.RUNNING, compute_resource=compute_resource_active, logs=test_logs)
 
-            self.assertEqual(job_stopped_active.logs, test_logs)
-            self.assertEqual(job_stopped_active_storage.get_public_logs(), None)
+    call_command("migrate_old_job_logs")
 
-            self.assertEqual(job_queued_active.logs, test_logs)
-            self.assertEqual(job_queued_active_storage.get_public_logs(), None)
+    for job in [job_succeeded_active, job_failed_active, job_stopped_active, job_queued_active, job_running_active]:
+        job.refresh_from_db()
+        assert job.logs == test_logs
+        assert LogsStorage(job).get_public_logs() is None
 
-            self.assertEqual(job_running_active.logs, test_logs)
-            self.assertEqual(job_running_active_storage.get_public_logs(), None)
 
-    def test_migrate_jobs_logs_to_storage_active_with_provider(self):
-        """Tests that logs are not migrated with an active compute resource belonging a provider function."""
+@pytest.mark.django_db
+def test_migrate_jobs_logs_to_storage_active_with_provider():
+    """Tests that logs are not migrated with an active compute resource belonging to a provider function."""
+    compute_resource_active = ComputeResource.objects.create(title="test-cluster-migrate-logs", active=True)
+    test_logs = "This is a log for testing pourposes"
 
-        with self.settings(JOB_LOGS_MIGRATION_BATCH_SIZE=10):
-            compute_resource_active = ComputeResource.objects.create(title=f"test-cluster-migrate-logs", active=True)
-            test_logs = "This is a log for testing pourposes"
-
-            job_succeeded_active = self._create_test_job(
-                status=Job.SUCCEEDED,
-                compute_resource=compute_resource_active,
-                logs=test_logs,
-                provider_admin="test_provider_1",
-            )
-            job_failed_active = self._create_test_job(
-                status=Job.FAILED,
-                compute_resource=compute_resource_active,
-                logs=test_logs,
-                provider_admin="test_provider_2",
-            )
-            job_stopped_active = self._create_test_job(
-                status=Job.STOPPED,
-                compute_resource=compute_resource_active,
-                logs=test_logs,
-                provider_admin="test_provider_3",
-            )
-            job_queued_active = self._create_test_job(
-                status=Job.QUEUED,
-                compute_resource=compute_resource_active,
-                logs=test_logs,
-                provider_admin="test_provider_4",
-            )
-            job_running_active = self._create_test_job(
-                status=Job.RUNNING,
-                compute_resource=compute_resource_active,
-                logs=test_logs,
-                provider_admin="test_provider_5",
-            )
-
-            call_command("migrate_old_job_logs")
-
-            job_succeeded_active.refresh_from_db()
-            job_succeeded_active_storage = LogsStorage(job_succeeded_active)
-            job_failed_active.refresh_from_db()
-            job_failed_active_storage = LogsStorage(job_failed_active)
-            job_stopped_active.refresh_from_db()
-            job_stopped_active_storage = LogsStorage(job_stopped_active)
-            job_queued_active.refresh_from_db()
-            job_queued_active_storage = LogsStorage(job_queued_active)
-            job_running_active.refresh_from_db()
-            job_running_active_storage = LogsStorage(job_running_active)
-
-            self.assertEqual(job_succeeded_active.logs, test_logs)
-            self.assertEqual(job_succeeded_active_storage.get_public_logs(), None)
-            self.assertEqual(job_succeeded_active_storage.get_private_logs(), None)
-
-            self.assertEqual(job_failed_active.logs, test_logs)
-            self.assertEqual(job_failed_active_storage.get_public_logs(), None)
-            self.assertEqual(job_failed_active_storage.get_private_logs(), None)
-
-            self.assertEqual(job_stopped_active.logs, test_logs)
-            self.assertEqual(job_stopped_active_storage.get_public_logs(), None)
-            self.assertEqual(job_stopped_active_storage.get_private_logs(), None)
-
-            self.assertEqual(job_queued_active.logs, test_logs)
-            self.assertEqual(job_queued_active_storage.get_public_logs(), None)
-            self.assertEqual(job_queued_active_storage.get_private_logs(), None)
-
-            self.assertEqual(job_running_active.logs, test_logs)
-            self.assertEqual(job_running_active_storage.get_public_logs(), None)
-            self.assertEqual(job_running_active_storage.get_private_logs(), None)
-
-    def test_migrate_jobs_logs_to_storage_not_active(self):
-        """Tests that logs are properly migrated with a not active compute resource."""
-
-        with self.settings(JOB_LOGS_MIGRATION_BATCH_SIZE=10):
-            compute_resource_not_active = ComputeResource.objects.create(
-                title=f"test-cluster-migrate-logs", active=False
-            )
-            test_logs = "This is a log for testing pourposes"
-
-            job_succeeded_not_active = self._create_test_job(
-                status=Job.SUCCEEDED,
-                compute_resource=compute_resource_not_active,
-                logs=test_logs,
-            )
-            job_failed_not_active = self._create_test_job(
-                status=Job.FAILED,
-                compute_resource=compute_resource_not_active,
-                logs=test_logs,
-            )
-            job_stopped_not_active = self._create_test_job(
-                status=Job.STOPPED,
-                compute_resource=compute_resource_not_active,
-                logs=test_logs,
-            )
-            job_queued_not_active = self._create_test_job(
-                status=Job.QUEUED,
-                compute_resource=compute_resource_not_active,
-                logs=test_logs,
-            )
-            job_running_not_active = self._create_test_job(
-                status=Job.RUNNING,
-                compute_resource=compute_resource_not_active,
-                logs=test_logs,
-            )
-
-            call_command("migrate_old_job_logs")
-
-            job_succeeded_not_active.refresh_from_db()
-            job_succeeded_not_active_storage = LogsStorage(job_succeeded_not_active)
-            job_failed_not_active.refresh_from_db()
-            job_failed_not_active_storage = LogsStorage(job_failed_not_active)
-            job_stopped_not_active.refresh_from_db()
-            job_stopped_not_active_storage = LogsStorage(job_stopped_not_active)
-            job_queued_not_active.refresh_from_db()
-            job_queued_not_active_storage = LogsStorage(job_queued_not_active)
-            job_running_not_active.refresh_from_db()
-            job_running_not_active_storage = LogsStorage(job_running_not_active)
-
-            self.assertEqual(job_succeeded_not_active.logs, "")
-            self.assertEqual(job_succeeded_not_active_storage.get_public_logs(), test_logs)
-
-            self.assertEqual(job_failed_not_active.logs, "")
-            self.assertEqual(job_failed_not_active_storage.get_public_logs(), test_logs)
-
-            self.assertEqual(job_stopped_not_active.logs, "")
-            self.assertEqual(job_stopped_not_active_storage.get_public_logs(), test_logs)
-
-            self.assertEqual(job_queued_not_active.logs, test_logs)
-            self.assertEqual(job_queued_not_active_storage.get_public_logs(), None)
-
-            self.assertEqual(job_running_not_active.logs, test_logs)
-            self.assertEqual(job_running_not_active_storage.get_public_logs(), None)
-
-    def test_migrate_jobs_logs_to_storage_not_active_with_provider(self):
-        """Tests that logs are properly migrated with a not active compute resource belonging a provider function."""
-
-        with self.settings(JOB_LOGS_MIGRATION_BATCH_SIZE=10):
-            compute_resource_not_active = ComputeResource.objects.create(
-                title=f"test-cluster-migrate-logs", active=False
-            )
-            test_logs = "This is a log for testing pourposes"
-
-            job_succeeded_not_active = self._create_test_job(
-                status=Job.SUCCEEDED,
-                compute_resource=compute_resource_not_active,
-                logs=test_logs,
-                provider_admin="test_provider_1",
-            )
-            job_failed_not_active = self._create_test_job(
-                status=Job.FAILED,
-                compute_resource=compute_resource_not_active,
-                logs=test_logs,
-                provider_admin="test_provider_2",
-            )
-            job_stopped_not_active = self._create_test_job(
-                status=Job.STOPPED,
-                compute_resource=compute_resource_not_active,
-                logs=test_logs,
-                provider_admin="test_provider_3",
-            )
-            job_queued_not_active = self._create_test_job(
-                status=Job.QUEUED,
-                compute_resource=compute_resource_not_active,
-                logs=test_logs,
-                provider_admin="test_provider_4",
-            )
-            job_running_not_active = self._create_test_job(
-                status=Job.RUNNING,
-                compute_resource=compute_resource_not_active,
-                logs=test_logs,
-                provider_admin="test_provider_5",
-            )
-
-            call_command("migrate_old_job_logs")
-
-            job_succeeded_not_active.refresh_from_db()
-            job_succeeded_not_active_storage = LogsStorage(job_succeeded_not_active)
-            job_failed_not_active.refresh_from_db()
-            job_failed_not_active_storage = LogsStorage(job_failed_not_active)
-            job_stopped_not_active.refresh_from_db()
-            job_stopped_not_active_storage = LogsStorage(job_stopped_not_active)
-            job_queued_not_active.refresh_from_db()
-            job_queued_not_active_storage = LogsStorage(job_queued_not_active)
-            job_running_not_active.refresh_from_db()
-            job_running_not_active_storage = LogsStorage(job_running_not_active)
-
-            self.assertEqual(job_succeeded_not_active.logs, "")
-            self.assertEqual(job_succeeded_not_active_storage.get_public_logs(), None)
-            self.assertEqual(job_succeeded_not_active_storage.get_private_logs(), test_logs)
-
-            self.assertEqual(job_failed_not_active.logs, "")
-            self.assertEqual(job_failed_not_active_storage.get_public_logs(), None)
-            self.assertEqual(job_failed_not_active_storage.get_private_logs(), test_logs)
-
-            self.assertEqual(job_stopped_not_active.logs, "")
-            self.assertEqual(job_stopped_not_active_storage.get_public_logs(), None)
-            self.assertEqual(job_stopped_not_active_storage.get_private_logs(), test_logs)
-
-            self.assertEqual(job_queued_not_active.logs, test_logs)
-            self.assertEqual(job_queued_not_active_storage.get_public_logs(), None)
-            self.assertEqual(job_queued_not_active_storage.get_private_logs(), None)
-
-            self.assertEqual(job_running_not_active.logs, test_logs)
-            self.assertEqual(job_running_not_active_storage.get_public_logs(), None)
-            self.assertEqual(job_running_not_active_storage.get_private_logs(), None)
-
-    def test_migrate_jobs_logs_to_storage_too_much_elements(self):
-        """Tests that logs are properly migrated in batches of JOB_LOGS_MIGRATION_BATCH_SIZE."""
-
-        with self.settings(JOB_LOGS_MIGRATION_BATCH_SIZE=10):
-            compute_resource_not_active = ComputeResource.objects.create(
-                title=f"test-cluster-migrate-logs", active=False
-            )
-            test_logs = "This is a log for testing pourposes"
-
-            job_list = [
-                self._create_test_job(
-                    status=Job.SUCCEEDED,
-                    compute_resource=compute_resource_not_active,
-                    logs=test_logs,
-                )
-                for _ in range(15)
-            ]
-
-            call_command("migrate_old_job_logs")
-
-            empty_logs_count = 0
-            for job in job_list:
-                job.refresh_from_db()
-                if job.logs == "":
-                    empty_logs_count += 1
-
-            self.assertEqual(empty_logs_count, 15)
-
-    def test_migrate_jobs_logs_to_storage_max_jobs(self):
-        """Tests that --max-jobs 1 only migrates a single job."""
-
-        with self.settings(JOB_LOGS_MIGRATION_BATCH_SIZE=10):
-            compute_resource_not_active = ComputeResource.objects.create(
-                title=f"test-cluster-migrate-logs", active=False
-            )
-            test_logs = "This is a log for testing pourposes"
-
-            job_list = [
-                self._create_test_job(
-                    status=Job.SUCCEEDED,
-                    compute_resource=compute_resource_not_active,
-                    logs=test_logs,
-                )
-                for _ in range(5)
-            ]
-
-            call_command("migrate_old_job_logs", max_jobs=1)
-
-            empty_logs_count = 0
-            for job in job_list:
-                job.refresh_from_db()
-                if job.logs == "":
-                    empty_logs_count += 1
-
-            self.assertEqual(empty_logs_count, 1)
-
-    def _create_test_job(
-        self,
-        author: str = "test_author",
-        provider_admin: Optional[str] = None,
-        status: str = Job.PENDING,
-        compute_resource: Optional[ComputeResource] = None,
-        ray_job_id: str = "test-job-id",
-        gpu: bool = False,
-        logs: str = "No logs yet.",
-    ) -> Job:
-        """Helper method to create a test job."""
-        if compute_resource is None:
-            compute_resource = ComputeResource.objects.create(title=f"test-cluster-{ray_job_id}", active=True)
-
-        author_user, _ = User.objects.get_or_create(username=author)
-        provider = None
-
-        if provider_admin:
-            provider = Provider.objects.create(name=provider_admin)
-            admin_group, _ = Group.objects.get_or_create(name=provider_admin)
-            admin_user, _ = User.objects.get_or_create(username=provider_admin)
-            admin_user.groups.add(admin_group)
-            provider.admin_groups.add(admin_group)
-
-        program = Program.objects.create(
-            title=f"program-{author_user.username}-{provider_admin or 'custom'}",
-            author=author_user,
-            provider=provider,
+    jobs = [
+        _create_test_job(
+            status=status, compute_resource=compute_resource_active, logs=test_logs, provider_admin=f"test_provider_{i}"
         )
+        for i, status in enumerate([Job.SUCCEEDED, Job.FAILED, Job.STOPPED, Job.QUEUED, Job.RUNNING], 1)
+    ]
 
-        return Job.objects.create(
-            author=author_user,
-            program=program,
-            status=status,
-            compute_resource=compute_resource,
-            ray_job_id=ray_job_id,
-            gpu=gpu,
-            logs=logs,
-        )
+    call_command("migrate_old_job_logs")
+
+    for job in jobs:
+        job.refresh_from_db()
+        assert job.logs == test_logs
+        assert LogsStorage(job).get_public_logs() is None
+        assert LogsStorage(job).get_private_logs() is None
+
+
+@pytest.mark.django_db
+def test_migrate_jobs_logs_to_storage_not_active(settings):
+    """Tests that logs are properly migrated with a not active compute resource."""
+    settings.JOB_LOGS_MIGRATION_BATCH_SIZE = 10
+    compute_resource = ComputeResource.objects.create(title="test-cluster-migrate-logs", active=False)
+    test_logs = "This is a log for testing pourposes"
+
+    job_succeeded = _create_test_job(status=Job.SUCCEEDED, compute_resource=compute_resource, logs=test_logs)
+    job_failed = _create_test_job(status=Job.FAILED, compute_resource=compute_resource, logs=test_logs)
+    job_stopped = _create_test_job(status=Job.STOPPED, compute_resource=compute_resource, logs=test_logs)
+    job_queued = _create_test_job(status=Job.QUEUED, compute_resource=compute_resource, logs=test_logs)
+    job_running = _create_test_job(status=Job.RUNNING, compute_resource=compute_resource, logs=test_logs)
+
+    call_command("migrate_old_job_logs")
+
+    for job, expected_logs, expected_storage in [
+        (job_succeeded, "", test_logs),
+        (job_failed, "", test_logs),
+        (job_stopped, "", test_logs),
+        (job_queued, test_logs, None),
+        (job_running, test_logs, None),
+    ]:
+        job.refresh_from_db()
+        assert job.logs == expected_logs
+        assert LogsStorage(job).get_public_logs() == expected_storage
+
+
+@pytest.mark.django_db
+def test_migrate_jobs_logs_to_storage_not_active_with_provider(settings):
+    """Tests that logs are properly migrated with a not active compute resource belonging to a provider function."""
+    settings.JOB_LOGS_MIGRATION_BATCH_SIZE = 10
+    compute_resource = ComputeResource.objects.create(title="test-cluster-migrate-logs", active=False)
+    test_logs = "This is a log for testing pourposes"
+
+    job_succeeded = _create_test_job(
+        status=Job.SUCCEEDED, compute_resource=compute_resource, logs=test_logs, provider_admin="test_provider_1"
+    )
+    job_failed = _create_test_job(
+        status=Job.FAILED, compute_resource=compute_resource, logs=test_logs, provider_admin="test_provider_2"
+    )
+    job_stopped = _create_test_job(
+        status=Job.STOPPED, compute_resource=compute_resource, logs=test_logs, provider_admin="test_provider_3"
+    )
+    job_queued = _create_test_job(
+        status=Job.QUEUED, compute_resource=compute_resource, logs=test_logs, provider_admin="test_provider_4"
+    )
+    job_running = _create_test_job(
+        status=Job.RUNNING, compute_resource=compute_resource, logs=test_logs, provider_admin="test_provider_5"
+    )
+
+    call_command("migrate_old_job_logs")
+
+    for job, expected_logs, expected_public, expected_private in [
+        (job_succeeded, "", None, test_logs),
+        (job_failed, "", None, test_logs),
+        (job_stopped, "", None, test_logs),
+        (job_queued, test_logs, None, None),
+        (job_running, test_logs, None, None),
+    ]:
+        job.refresh_from_db()
+        assert job.logs == expected_logs
+        assert LogsStorage(job).get_public_logs() == expected_public
+        assert LogsStorage(job).get_private_logs() == expected_private
+
+
+@pytest.mark.django_db
+def test_migrate_jobs_logs_to_storage_too_much_elements(settings):
+    """Tests that logs are properly migrated in batches of JOB_LOGS_MIGRATION_BATCH_SIZE."""
+    settings.JOB_LOGS_MIGRATION_BATCH_SIZE = 10
+    compute_resource = ComputeResource.objects.create(title="test-cluster-migrate-logs", active=False)
+    test_logs = "This is a log for testing pourposes"
+
+    jobs = [
+        _create_test_job(status=Job.SUCCEEDED, compute_resource=compute_resource, logs=test_logs) for _ in range(15)
+    ]
+
+    call_command("migrate_old_job_logs")
+
+    for job in jobs:
+        job.refresh_from_db()
+    empty_logs_count = sum(1 for job in jobs if job.logs == "")
+    assert empty_logs_count == 15
+
+
+@pytest.mark.django_db
+def test_migrate_jobs_logs_to_storage_max_jobs(settings):
+    """Tests that --max-jobs 1 only migrates a single job."""
+    settings.JOB_LOGS_MIGRATION_BATCH_SIZE = 10
+    compute_resource = ComputeResource.objects.create(title="test-cluster-migrate-logs", active=False)
+    test_logs = "This is a log for testing pourposes"
+
+    jobs = [_create_test_job(status=Job.SUCCEEDED, compute_resource=compute_resource, logs=test_logs) for _ in range(5)]
+
+    call_command("migrate_old_job_logs", max_jobs=1)
+
+    for job in jobs:
+        job.refresh_from_db()
+    empty_logs_count = sum(1 for job in jobs if job.logs == "")
+    assert empty_logs_count == 1

--- a/gateway/tests/scheduler/management/test_migrate_old_job_logs.py
+++ b/gateway/tests/scheduler/management/test_migrate_old_job_logs.py
@@ -1,15 +1,18 @@
 """Tests for migrate_old_job_logs command."""
 
+import tempfile
 from typing import Optional
 
 from django.contrib.auth.models import User, Group
 from django.core.management import call_command
+from django.test import override_settings
 from rest_framework.test import APITestCase
 
 from core.models import ComputeResource, Job, Program, Provider, Config
 from core.services.storage.logs_storage import LogsStorage
 
 
+@override_settings(MEDIA_ROOT=tempfile.mkdtemp())
 class TestMigrateOldJobLogs(APITestCase):
     """Tests for migrate_old_job_logs command."""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
`PathBuilder.absolute_path()` calls `os.makedirs()` eagerly whenever a storage path is constructed, including during tests. Since `MEDIA_ROOT` defaults to `gateway/media/` in `settings.py`, running the test suite causes this directory to accumulate files (job logs, serialized arguments) that can be accidentally committed.

This issue has existed for a while. An earlier fix by @avilches (#1934) addressed some tests by wrapping specific calls in `tempfile.TemporaryDirectory() + self.settings(MEDIA_ROOT=...)`, but there were tests added after that (like `TestMigrateOldJobLogs`) that weren't covered. The issue became visible again I think around #2031, which started triggering job scheduling and log storage more broadly, causing `gateway/media/` to appear again in the working tree.

### Details and comments

This PR implements 2 main changes: 

  - tests/conftest.py (new): adds a global autouse pytest fixture that redirects `MEDIA_ROOT` to a temporary
  directory for all pytest-based tests, so no individual test needs to handle this.
  - tests/scheduler/management/test_migrate_old_job_logs.py: migrated from Django's APITestCase to pytest style,
  so it is now covered by the global fixture like all other tests.

 **Follow-up:** `test_v1_program.py` still uses Django's `APITestCase` with manual `self.settings(MEDIA_ROOT=...)` calls and would benefit from a similar pytest migration, but it's left out of scope for this PR because it's not causing issues.