### PR TITLE
Add "zone" to code engine project model

### DIFF
--- a/gateway/api/migrations/0051_codeengineproject_zone.py
+++ b/gateway/api/migrations/0051_codeengineproject_zone.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0050_unique_program_constraints"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="codeengineproject",
+            name="project_id",
+            field=models.CharField(max_length=255, help_text="IBM Code Engine project UUID"),
+        ),
+        migrations.AddField(
+            model_name="codeengineproject",
+            name="zone",
+            field=models.CharField(
+                blank=True,
+                help_text="Availability zone this project is pinned to (e.g. us-east-1)",
+                max_length=64,
+                null=True,
+                unique=True,
+            ),
+        ),
+    ]

--- a/gateway/core/models.py
+++ b/gateway/core/models.py
@@ -257,7 +257,7 @@ class CodeEngineProject(models.Model):
     updated = models.DateTimeField(auto_now=True)
 
     # Code Engine identifiers (we could save one or both)
-    project_id = models.CharField(max_length=255, unique=True, help_text="IBM Code Engine project UUID")
+    project_id = models.CharField(max_length=255, help_text="IBM Code Engine project UUID")
     project_name = models.CharField(max_length=255, help_text="Code Engine project name in IBM Cloud")
 
     # Location and ownership
@@ -266,6 +266,13 @@ class CodeEngineProject(models.Model):
 
     # Networking
     subnet_pool_id = models.CharField(max_length=255, help_text="Subnet pool ID for fleet networking")
+    zone = models.CharField(
+        max_length=64,
+        null=True,
+        blank=True,
+        unique=True,
+        help_text="Availability zone this project is pinned to (e.g. us-east-1)",
+    )
 
     # Storage and state management
     pds_name_state = models.CharField(max_length=255, help_text="Persistent Data Store name for task state")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR adds the "zone" value to the CodeEngine project model, and makes the project_id non-unique. These 2 changes allow to register the same code engine project with different associated zones and filter by zone.


### Details and comments

