### PR TITLE
Rename permission_name to legacy_permission_name in FunctionsQuerySet

### DIFF
--- a/gateway/api/use_cases/files/delete.py
+++ b/gateway/api/use_cases/files/delete.py
@@ -34,7 +34,7 @@ class FilesDeleteUseCase:
         """
         function = Function.objects.get_function_by_permission(
             user=user,
-            permission_name=RUN_PROGRAM_PERMISSION,
+            legacy_permission_name=RUN_PROGRAM_PERMISSION,
             function_title=function_title,
             provider_name=provider_name,
         )

--- a/gateway/api/use_cases/files/download.py
+++ b/gateway/api/use_cases/files/download.py
@@ -35,7 +35,7 @@ class FilesDownloadUseCase:
         """
         function = Function.objects.get_function_by_permission(
             user=user,
-            permission_name=RUN_PROGRAM_PERMISSION,
+            legacy_permission_name=RUN_PROGRAM_PERMISSION,
             function_title=function_title,
             provider_name=provider_name,
         )

--- a/gateway/api/use_cases/files/list.py
+++ b/gateway/api/use_cases/files/list.py
@@ -27,7 +27,7 @@ class FilesListUseCase:
         """
         function = Function.objects.get_function_by_permission(
             user=user,
-            permission_name=RUN_PROGRAM_PERMISSION,
+            legacy_permission_name=RUN_PROGRAM_PERMISSION,
             function_title=function_title,
             provider_name=provider_name,
         )

--- a/gateway/api/use_cases/files/provider_delete.py
+++ b/gateway/api/use_cases/files/provider_delete.py
@@ -43,7 +43,7 @@ class FilesProviderDeleteUseCase:
 
         function = Function.objects.get_function_by_permission(
             user=user,
-            permission_name=RUN_PROGRAM_PERMISSION,
+            legacy_permission_name=RUN_PROGRAM_PERMISSION,
             function_title=function_title,
             provider_name=provider_name,
         )

--- a/gateway/api/use_cases/files/provider_download.py
+++ b/gateway/api/use_cases/files/provider_download.py
@@ -44,7 +44,7 @@ class FilesProviderDownloadUseCase:
 
         function = Function.objects.get_function_by_permission(
             user=user,
-            permission_name=RUN_PROGRAM_PERMISSION,
+            legacy_permission_name=RUN_PROGRAM_PERMISSION,
             function_title=function_title,
             provider_name=provider_name,
         )

--- a/gateway/api/use_cases/files/provider_list.py
+++ b/gateway/api/use_cases/files/provider_list.py
@@ -36,7 +36,7 @@ class FilesProviderListUseCase:
 
         function = Function.objects.get_function_by_permission(
             user=user,
-            permission_name=RUN_PROGRAM_PERMISSION,
+            legacy_permission_name=RUN_PROGRAM_PERMISSION,
             function_title=function_title,
             provider_name=provider_name,
         )

--- a/gateway/api/use_cases/files/provider_upload.py
+++ b/gateway/api/use_cases/files/provider_upload.py
@@ -43,7 +43,7 @@ class FilesProviderUploadUseCase:
 
         function = Function.objects.get_function_by_permission(
             user=user,
-            permission_name=RUN_PROGRAM_PERMISSION,
+            legacy_permission_name=RUN_PROGRAM_PERMISSION,
             function_title=function_title,
             provider_name=provider_name,
         )

--- a/gateway/api/use_cases/files/upload.py
+++ b/gateway/api/use_cases/files/upload.py
@@ -34,7 +34,7 @@ class FilesUploadUseCase:
         """
         function = Function.objects.get_function_by_permission(
             user=user,
-            permission_name=RUN_PROGRAM_PERMISSION,
+            legacy_permission_name=RUN_PROGRAM_PERMISSION,
             function_title=function_title,
             provider_name=provider_name,
         )

--- a/gateway/api/views/programs.py
+++ b/gateway/api/views/programs.py
@@ -125,11 +125,11 @@ class ProgramViewSet(viewsets.GenericViewSet):
             # Catalog filter only returns providers functions that user has access:
             # author has view permissions and the function has a provider assigned
             functions = Function.objects.provider_functions().with_permission(
-                author, permission_name=RUN_PROGRAM_PERMISSION
+                author, legacy_permission_name=RUN_PROGRAM_PERMISSION
             )
         else:
             # If filter is not applied we return author and providers functions together
-            functions = Function.objects.with_permission(author, permission_name=VIEW_PROGRAM_PERMISSION)
+            functions = Function.objects.with_permission(author, legacy_permission_name=VIEW_PROGRAM_PERMISSION)
 
         serializer = self.get_serializer(list(functions), many=True)
         logger.info(
@@ -209,7 +209,7 @@ class ProgramViewSet(viewsets.GenericViewSet):
         function_title = sanitize_name(serializer.data.get("title"))
         function = Function.objects.get_function_by_permission(
             user=author,
-            permission_name=RUN_PROGRAM_PERMISSION,
+            legacy_permission_name=RUN_PROGRAM_PERMISSION,
             function_title=function_title,
             provider_name=provider_name,
         )
@@ -306,7 +306,7 @@ class ProgramViewSet(viewsets.GenericViewSet):
         if provider_name:
             function = Function.objects.get_function_by_permission(
                 user=author,
-                permission_name=VIEW_PROGRAM_PERMISSION,
+                legacy_permission_name=VIEW_PROGRAM_PERMISSION,
                 function_title=function_title,
                 provider_name=provider_name,
             )

--- a/gateway/core/model_managers/functions.py
+++ b/gateway/core/model_managers/functions.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 class FunctionsQuerySet(QuerySet):
     """Functions query set to transform into a manager."""
 
-    def with_permission(self, author: AbstractUser, permission_name: str) -> Self:
+    def with_permission(self, author: AbstractUser, legacy_permission_name: str) -> Self:
         """
         Returns all the functions available to the user. This means:
             - User functions where the user is the author
@@ -24,13 +24,13 @@ class FunctionsQuerySet(QuerySet):
 
         Args:
             author: Django author from who retrieve the functions
-            permission_name (str): name of the permission. Values accepted
-            RUN_PROGRAM_PERMISSION, VIEW_PROGRAM_PERMISSION
+            legacy_permission_name (str): Django permission codename. Values accepted:
+                RUN_PROGRAM_PERMISSION, VIEW_PROGRAM_PERMISSION
 
         Returns:
             List[Function]: all the functions available to the user
         """
-        groups = Group.objects.filter(user=author, permissions__codename=permission_name)
+        groups = Group.objects.filter(user=author, permissions__codename=legacy_permission_name)
         author_groups_with_permissions_criteria = Q(instances__in=groups)
         author_criteria = Q(author=author)
 
@@ -108,7 +108,7 @@ class FunctionsQuerySet(QuerySet):
     def get_function_by_permission(
         self,
         user,
-        permission_name: str,
+        legacy_permission_name: str,
         function_title: str,
         provider_name: Optional[str],
     ) -> Optional[Function]:
@@ -118,8 +118,8 @@ class FunctionsQuerySet(QuerySet):
 
         Args:
             user: Django user of the function that wants to get it
-            permission_name (str): name of the permission. Values accepted
-            RUN_PROGRAM_PERMISSION, VIEW_PROGRAM_PERMISSION
+            legacy_permission_name (str): Django permission codename. Values accepted:
+                RUN_PROGRAM_PERMISSION, VIEW_PROGRAM_PERMISSION
             function_title (str): title of the function
             provider_name (str | None): name of the provider owner of the function
 
@@ -130,7 +130,7 @@ class FunctionsQuerySet(QuerySet):
         if provider_name:
             return self.with_permission(
                 author=user,
-                permission_name=permission_name,
+                legacy_permission_name=legacy_permission_name,
             ).get_function(function_title, provider_name)
 
         return self.user_functions(author=user).get_function(function_title)


### PR DESCRIPTION
## Summary

Renames the `permission_name` parameter to `legacy_permission_name` in `FunctionsQuerySet.with_permission()` and `get_function_by_permission()`.

All callers in `api/views/programs.py` and `api/use_cases/files/` are updated accordingly.

### Why?

This clarifies that the parameter refers to a Django permission codename (legacy auth path), preparing for the upcoming Runtime Instances API integration which uses a different permission model and need a `permission` parameter in the same call.

