### PR TITLE
Rename platform permission constants to function-namespaced values

### DIFF
--- a/gateway/core/models.py
+++ b/gateway/core/models.py
@@ -22,14 +22,17 @@ VIEW_PROGRAM_PERMISSION = "view_program"
 RUN_PROGRAM_PERMISSION = "run_program"
 
 # Platform permissions (Runtime API instances access client)
-PLATFORM_PERMISSION_READ = "function.read"
-PLATFORM_PERMISSION_RUN = "function.run"
-PLATFORM_PERMISSION_JOB_RETRIEVE = "function.job.retrieve"
-PLATFORM_PERMISSION_USER_FILES = "function.files"
-PLATFORM_PERMISSION_PROVIDER_UPLOAD = "function.provider.upload"
-PLATFORM_PERMISSION_PROVIDER_JOBS = "function.provider.jobs"
-PLATFORM_PERMISSION_PROVIDER_LOGS = "function.provider.logs"
-PLATFORM_PERMISSION_PROVIDER_FILES = "function.provider.files"
+PLATFORM_PERMISSION_READ = "function.read"  # see function in catalog and retrieve its metadata
+PLATFORM_PERMISSION_RUN = "function.run"  # execute a new job of this function
+PLATFORM_PERMISSION_JOB_RETRIEVE = (
+    "function.job.retrieve"  # retrieve a specific job from this function (non-author access)
+)
+PLATFORM_PERMISSION_USER_FILES = "function.files"  # list, download, upload and delete files in user space
+# Provider admin permissions
+PLATFORM_PERMISSION_PROVIDER_UPLOAD = "function.provider.upload"  # create or update this function's code
+PLATFORM_PERMISSION_PROVIDER_JOBS = "function.provider.jobs"  # list jobs from all users of this function
+PLATFORM_PERMISSION_PROVIDER_LOGS = "function.provider.logs"  # read provider-side logs of jobs from this function
+PLATFORM_PERMISSION_PROVIDER_FILES = "function.provider.files"  # list, download, upload, delete files in provider space
 
 
 def get_upload_path(instance, filename):

--- a/gateway/core/models.py
+++ b/gateway/core/models.py
@@ -21,15 +21,15 @@ logger = logging.getLogger("core.models")
 VIEW_PROGRAM_PERMISSION = "view_program"
 RUN_PROGRAM_PERMISSION = "run_program"
 
-# Platform permissions (external instance access client)
-PLATFORM_PERMISSION_VIEW = "view"
-PLATFORM_PERMISSION_RUN = "run"
-PLATFORM_PERMISSION_USER_FILES = "user.files"
-PLATFORM_PERMISSION_PROVIDER_UPLOAD = "provider.upload"
-PLATFORM_PERMISSION_PROVIDER_JOBS = "provider.jobs"
-PLATFORM_PERMISSION_JOB_RETRIEVE = "job.retrieve"
-PLATFORM_PERMISSION_PROVIDER_LOGS = "provider.logs"
-PLATFORM_PERMISSION_PROVIDER_FILES = "provider.files"
+# Platform permissions (Runtime API instances access client)
+PLATFORM_PERMISSION_READ = "function.view"
+PLATFORM_PERMISSION_RUN = "function.run"
+PLATFORM_PERMISSION_JOB_RETRIEVE = "function.job.retrieve"
+PLATFORM_PERMISSION_USER_FILES = "function.files"
+PLATFORM_PERMISSION_PROVIDER_UPLOAD = "function.provider.upload"
+PLATFORM_PERMISSION_PROVIDER_JOBS = "function.provider.jobs"
+PLATFORM_PERMISSION_PROVIDER_LOGS = "function.provider.logs"
+PLATFORM_PERMISSION_PROVIDER_FILES = "function.provider.files"
 
 
 def get_upload_path(instance, filename):

--- a/gateway/core/models.py
+++ b/gateway/core/models.py
@@ -24,9 +24,7 @@ RUN_PROGRAM_PERMISSION = "run_program"
 # Platform permissions (Runtime API instances access client)
 PLATFORM_PERMISSION_READ = "function.read"  # see function in catalog and retrieve its metadata
 PLATFORM_PERMISSION_RUN = "function.run"  # execute a new job of this function
-PLATFORM_PERMISSION_JOB_RETRIEVE = (
-    "function.job.retrieve"  # retrieve a specific job from this function (non-author access)
-)
+PLATFORM_PERMISSION_JOB_READ = "function.job.read"  # retrieve a specific job from this function (non-author access)
 PLATFORM_PERMISSION_USER_FILES = "function.files"  # list, download, upload and delete files in user space
 # Provider admin permissions
 PLATFORM_PERMISSION_PROVIDER_UPLOAD = "function.provider.upload"  # create or update this function's code

--- a/gateway/core/models.py
+++ b/gateway/core/models.py
@@ -22,7 +22,7 @@ VIEW_PROGRAM_PERMISSION = "view_program"
 RUN_PROGRAM_PERMISSION = "run_program"
 
 # Platform permissions (Runtime API instances access client)
-PLATFORM_PERMISSION_READ = "function.view"
+PLATFORM_PERMISSION_READ = "function.read"
 PLATFORM_PERMISSION_RUN = "function.run"
 PLATFORM_PERMISSION_JOB_RETRIEVE = "function.job.retrieve"
 PLATFORM_PERMISSION_USER_FILES = "function.files"

--- a/gateway/tests/api/domain/authorization/test_function_access_entry.py
+++ b/gateway/tests/api/domain/authorization/test_function_access_entry.py
@@ -3,14 +3,14 @@
 import pytest
 
 from api.domain.authorization.function_access_entry import FunctionAccessEntry
-from core.models import PLATFORM_PERMISSION_RUN, PLATFORM_PERMISSION_VIEW
+from core.models import PLATFORM_PERMISSION_RUN, PLATFORM_PERMISSION_READ
 
 
 def test_valid_entry():
     entry = FunctionAccessEntry(
         provider_name="my-provider",
         function_title="my-function",
-        permissions={PLATFORM_PERMISSION_RUN, PLATFORM_PERMISSION_VIEW},
+        permissions={PLATFORM_PERMISSION_RUN, PLATFORM_PERMISSION_READ},
         business_model="TRIAL",
     )
     assert entry.provider_name == "my-provider"

--- a/gateway/tests/api/domain/authorization/test_function_access_result.py
+++ b/gateway/tests/api/domain/authorization/test_function_access_result.py
@@ -2,7 +2,7 @@
 
 from api.domain.authorization.function_access_entry import FunctionAccessEntry
 from api.domain.authorization.function_access_result import FunctionAccessResult
-from core.models import PLATFORM_PERMISSION_RUN, PLATFORM_PERMISSION_VIEW, PLATFORM_PERMISSION_PROVIDER_JOBS
+from core.models import PLATFORM_PERMISSION_RUN, PLATFORM_PERMISSION_READ, PLATFORM_PERMISSION_PROVIDER_JOBS
 
 
 def _entry(provider_name, function_title, permissions, business_model="SUBSIDIZED"):
@@ -29,7 +29,7 @@ def test_get_function():
 def test_has_permission_for_provider():
     entries = [
         _entry("prov", "func1", {PLATFORM_PERMISSION_PROVIDER_JOBS}),
-        _entry("prov", "func2", {PLATFORM_PERMISSION_VIEW}),
+        _entry("prov", "func2", {PLATFORM_PERMISSION_READ}),
     ]
     result = FunctionAccessResult(has_response=True, functions=entries)
     assert result.has_permission_for_provider("prov", PLATFORM_PERMISSION_PROVIDER_JOBS) is True
@@ -42,7 +42,7 @@ def test_get_functions_by_provider():
         _entry("prov-a", "func1", {PLATFORM_PERMISSION_RUN}),
         _entry("prov-a", "func2", {PLATFORM_PERMISSION_RUN}),
         _entry("prov-b", "func3", {PLATFORM_PERMISSION_RUN}),
-        _entry("prov-b", "func4", {PLATFORM_PERMISSION_VIEW}),  # no RUN
+        _entry("prov-b", "func4", {PLATFORM_PERMISSION_READ}),  # no RUN
     ]
     result = FunctionAccessResult(has_response=True, functions=entries)
     assert result.get_functions_by_provider(PLATFORM_PERMISSION_RUN) == {


### PR DESCRIPTION
## Summary

Renames the PLATFORM_PERMISSION constants to final values. These constants are consumed by the Runtime Instances API client (not yet in production), so no external contract is affected.