### PR TITLE
Make program title read-only on edit in admin

### DIFF
--- a/gateway/api/admin.py
+++ b/gateway/api/admin.py
@@ -52,6 +52,12 @@ class ProgramAdmin(admin.ModelAdmin):
         "disabled",
     ]
 
+    def get_readonly_fields(self, request, obj=None):
+        readonly_fields = list(super().get_readonly_fields(request, obj))
+        if obj:
+            readonly_fields.append("title")
+        return readonly_fields
+
     def get_urls(self):
         """Add program history url to the available urls."""
         custom_urls = [


### PR DESCRIPTION
## Summary

Prevents editing the `title` field of a Program from the Django admin once it has been created. The field remains editable only during creation.