### PR TITLE
Configure cache and url for Runtime API /functions call

### DIFF
--- a/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
+++ b/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
@@ -182,8 +182,6 @@ spec:
               value: {{ .Values.application.ray.openTelemetryCollector.insecure | quote }}
             - name: QISKIT_IBM_URL
               value: {{ .Values.application.qiskitRuntime.url }}
-            - name: IQP_QCON_API_BASE_URL
-              value: {{ .Values.application.iqpQcon.url }}
             - name: RUNTIME_API_BASE_URL
               value: {{ .Values.application.runtimeApi.url | quote }}
             - name: RUNTIME_API_CACHE_TTL

--- a/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
+++ b/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
@@ -184,6 +184,10 @@ spec:
               value: {{ .Values.application.qiskitRuntime.url }}
             - name: IQP_QCON_API_BASE_URL
               value: {{ .Values.application.iqpQcon.url }}
+            - name: RUNTIME_API_BASE_URL
+              value: {{ .Values.application.runtimeApi.url | quote }}
+            - name: RUNTIME_API_CACHE_TTL
+              value: {{ .Values.application.runtimeApi.cacheTtl | quote }}
             - name: DATABASE_HOST
               valueFrom:
                 secretKeyRef:

--- a/charts/qiskit-serverless/charts/gateway/values.yaml
+++ b/charts/qiskit-serverless/charts/gateway/values.yaml
@@ -56,8 +56,6 @@ application:
     programTimeoutDays: 14
   qiskitRuntime:
     url: "https://cloud.ibm.com"
-  iqpQcon:
-    url: "https://api-qcon.quantum.ibm.com/api"
   runtimeApi:
     url: "https://quantum.cloud.ibm.com"
     cacheTtl: "60"

--- a/charts/qiskit-serverless/charts/gateway/values.yaml
+++ b/charts/qiskit-serverless/charts/gateway/values.yaml
@@ -58,6 +58,9 @@ application:
     url: "https://cloud.ibm.com"
   iqpQcon:
     url: "https://api-qcon.quantum.ibm.com/api"
+  runtimeApi:
+    url: "https://quantum.cloud.ibm.com"
+    cacheTtl: "60"
   allowedHosts: "*"
   trustedOrigins: "http://localhost"
   corsOrigins: "http://localhost"

--- a/gateway/api/clients/function_access_client.py
+++ b/gateway/api/clients/function_access_client.py
@@ -4,6 +4,7 @@ import logging
 
 import requests
 from django.conf import settings
+from django.core.cache import cache
 
 from api.domain.authorization.function_access_entry import FunctionAccessEntry
 from api.domain.authorization.function_access_result import FunctionAccessResult
@@ -25,6 +26,11 @@ class FunctionAccessClient:
         base_url = settings.RUNTIME_INSTANCES_API_BASE_URL
         if not base_url:
             return FunctionAccessResult(has_response=False)
+
+        cache_key = f"accesible_functions:{instance_crn}"
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached
 
         try:
             response = requests.get(
@@ -58,4 +64,6 @@ class FunctionAccessClient:
             except (KeyError, ValueError) as exc:
                 logger.error("FunctionAccessClient: invalid entry %s — %s", f, exc)
 
-        return FunctionAccessResult(has_response=True, functions=functions)
+        result = FunctionAccessResult(has_response=True, functions=functions)
+        cache.set(cache_key, result, timeout=settings.RUNTIME_INSTANCES_API_CACHE_TTL)
+        return result

--- a/gateway/api/clients/function_access_client.py
+++ b/gateway/api/clients/function_access_client.py
@@ -23,7 +23,7 @@ class FunctionAccessClient:
         if not enabled:
             return FunctionAccessResult(has_response=False)
 
-        base_url = settings.RUNTIME_INSTANCES_API_BASE_URL
+        base_url = settings.RUNTIME_API_BASE_URL
         if not base_url:
             return FunctionAccessResult(has_response=False)
 
@@ -34,7 +34,7 @@ class FunctionAccessClient:
 
         try:
             response = requests.get(
-                f"{base_url}/instances/functions",
+                f"{base_url}/api/v1/functions",
                 headers={"Service-CRN": instance_crn},
                 timeout=5,
             )
@@ -65,5 +65,5 @@ class FunctionAccessClient:
                 logger.error("FunctionAccessClient: invalid entry %s — %s", f, exc)
 
         result = FunctionAccessResult(has_response=True, functions=functions)
-        cache.set(cache_key, result, timeout=settings.RUNTIME_INSTANCES_API_CACHE_TTL)
+        cache.set(cache_key, result, timeout=settings.RUNTIME_API_CACHE_TTL)
         return result

--- a/gateway/api/clients/function_access_client.py
+++ b/gateway/api/clients/function_access_client.py
@@ -42,6 +42,11 @@ class FunctionAccessClient:
             logger.exception("FunctionAccessClient: connection error for CRN %s", instance_crn)
             return FunctionAccessResult(has_response=False)
 
+        if response.status_code == 204:
+            # We agreed with Runtime that 204 response means there is no functions configured
+            # for this instance, so we should fallback to Django
+            return FunctionAccessResult(has_response=False)
+
         if response.status_code != 200:
             logger.warning(
                 "FunctionAccessClient: unexpected status %s for CRN %s",

--- a/gateway/api/clients/function_access_client.py
+++ b/gateway/api/clients/function_access_client.py
@@ -20,11 +20,8 @@ class FunctionAccessClient:
     def get_accessible_functions(self, instance_crn: str) -> FunctionAccessResult:
         """Return all functions accessible to the given instance CRN with their permissions."""
         enabled = Config.get_bool(ConfigKey.RUNTIME_INSTANCES_API_ENABLED)
-        if not enabled:
-            return FunctionAccessResult(has_response=False)
-
         base_url = settings.RUNTIME_API_BASE_URL
-        if not base_url:
+        if not enabled or not base_url:
             return FunctionAccessResult(has_response=False)
 
         cache_key = f"accesible_functions:{instance_crn}"
@@ -47,7 +44,7 @@ class FunctionAccessClient:
             # for this instance, so we should fallback to Django
             return FunctionAccessResult(has_response=False)
 
-        if response.status_code != 200:
+        elif response.status_code != 200:
             logger.warning(
                 "FunctionAccessClient: unexpected status %s for CRN %s",
                 response.status_code,

--- a/gateway/api/clients/function_access_client.py
+++ b/gateway/api/clients/function_access_client.py
@@ -44,7 +44,7 @@ class FunctionAccessClient:
             # for this instance, so we should fallback to Django
             return FunctionAccessResult(has_response=False)
 
-        elif response.status_code != 200:
+        if response.status_code != 200:
             logger.warning(
                 "FunctionAccessClient: unexpected status %s for CRN %s",
                 response.status_code,

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -325,6 +325,7 @@ GATEWAY_GPU_JOBS_CONFIG = str(os.environ.get("GATEWAY_GPU_JOBS_CONFIG", "api/v1/
 # authentication base url for qiskit runtime
 QISKIT_IBM_URL = os.environ.get("QISKIT_IBM_URL", "https://cloud.ibm.com")
 RUNTIME_INSTANCES_API_BASE_URL = os.environ.get("RUNTIME_INSTANCES_API_BASE_URL")
+RUNTIME_INSTANCES_API_CACHE_TTL = int(os.environ.get("RUNTIME_INSTANCES_API_CACHE_TTL", "60"))
 # quantum api
 IQP_QCON_API_BASE_URL = os.environ.get("IQP_QCON_API_BASE_URL", None)
 

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -324,8 +324,8 @@ GATEWAY_GPU_JOBS_CONFIG = str(os.environ.get("GATEWAY_GPU_JOBS_CONFIG", "api/v1/
 
 # authentication base url for qiskit runtime
 QISKIT_IBM_URL = os.environ.get("QISKIT_IBM_URL", "https://cloud.ibm.com")
-RUNTIME_INSTANCES_API_BASE_URL = os.environ.get("RUNTIME_INSTANCES_API_BASE_URL")
-RUNTIME_INSTANCES_API_CACHE_TTL = int(os.environ.get("RUNTIME_INSTANCES_API_CACHE_TTL", "60"))
+RUNTIME_API_BASE_URL = os.environ.get("RUNTIME_API_BASE_URL")
+RUNTIME_API_CACHE_TTL = int(os.environ.get("RUNTIME_API_CACHE_TTL", "60"))
 # quantum api
 IQP_QCON_API_BASE_URL = os.environ.get("IQP_QCON_API_BASE_URL", None)
 

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -326,8 +326,6 @@ GATEWAY_GPU_JOBS_CONFIG = str(os.environ.get("GATEWAY_GPU_JOBS_CONFIG", "api/v1/
 QISKIT_IBM_URL = os.environ.get("QISKIT_IBM_URL", "https://cloud.ibm.com")
 RUNTIME_API_BASE_URL = os.environ.get("RUNTIME_API_BASE_URL")
 RUNTIME_API_CACHE_TTL = int(os.environ.get("RUNTIME_API_CACHE_TTL", "60"))
-# quantum api
-IQP_QCON_API_BASE_URL = os.environ.get("IQP_QCON_API_BASE_URL", None)
 
 # IBM Cloud
 

--- a/gateway/tests/api/clients/conftest.py
+++ b/gateway/tests/api/clients/conftest.py
@@ -9,6 +9,7 @@ import pytest
 
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
+        self.server.request_count += 1
         cfg = self.server.response_config
         body = json.dumps(cfg["body"]).encode() if "body" in cfg else b""
         self.send_response(cfg["status"])
@@ -34,6 +35,11 @@ class InstancesServer:
     def __init__(self, httpd: HTTPServer):
         self._httpd = httpd
         self.reset()
+
+    @property
+    def request_count(self) -> int:
+        """Number of HTTP requests received by the server."""
+        return self._httpd.request_count
 
     def grant(
         self,
@@ -71,6 +77,7 @@ class InstancesServer:
 def instances_server(settings):
     """Real HTTP server on a random port simulating the external instances API."""
     httpd = HTTPServer(("127.0.0.1", 0), Handler)
+    httpd.request_count = 0
     t = threading.Thread(target=httpd.serve_forever)
     t.daemon = True
     t.start()
@@ -79,3 +86,13 @@ def instances_server(settings):
     yield server
     httpd.shutdown()
     t.join()
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Clear Django cache before and after each test to avoid cross-test pollution."""
+    from django.core.cache import cache  # pylint: disable=import-outside-toplevel
+
+    cache.clear()
+    yield
+    cache.clear()

--- a/gateway/tests/api/clients/conftest.py
+++ b/gateway/tests/api/clients/conftest.py
@@ -82,7 +82,7 @@ def instances_server(settings):
     t.daemon = True
     t.start()
     server = InstancesServer(httpd)
-    settings.RUNTIME_INSTANCES_API_BASE_URL = f"http://127.0.0.1:{httpd.server_address[1]}"
+    settings.RUNTIME_API_BASE_URL = f"http://127.0.0.1:{httpd.server_address[1]}"
     yield server
     httpd.shutdown()
     t.join()

--- a/gateway/tests/api/clients/test_function_access_client.py
+++ b/gateway/tests/api/clients/test_function_access_client.py
@@ -52,3 +52,23 @@ def test_returns_no_response_when_disabled(monkeypatch):
     result = FunctionAccessClient().get_accessible_functions("crn:test:000")
 
     assert result.has_response is False
+
+
+def test_caches_successful_response(instances_server):
+    instances_server.grant("ibm", "sampler", [PLATFORM_PERMISSION_RUN])
+
+    FunctionAccessClient().get_accessible_functions("crn:cache:hit")
+    result = FunctionAccessClient().get_accessible_functions("crn:cache:hit")
+
+    assert instances_server.request_count == 1
+    assert result.has_response is True
+    assert result.get_function("ibm", "sampler") is not None
+
+
+def test_does_not_cache_error_response(instances_server):
+    instances_server.error(500)
+
+    FunctionAccessClient().get_accessible_functions("crn:cache:err")
+    FunctionAccessClient().get_accessible_functions("crn:cache:err")
+
+    assert instances_server.request_count == 2


### PR DESCRIPTION
### Summary

All authorization (IBM IAM) accesses are cached with 60s TTL to avoid trigger rate limit.

This PR adds cache to the Runtime API Instances `/functions` call, which is made in every request.

### Details and comments

No comments.