### PR TITLE
Support COS private endpoint configuration for FleetRunner

### DIFF
--- a/gateway/core/ibm_cloud/clients.py
+++ b/gateway/core/ibm_cloud/clients.py
@@ -211,34 +211,38 @@ class IBMCloudClientProvider:
         access_key_id: str,
         secret_access_key: str,
         bucket_region: str | None = None,
+        endpoint_url: str | None = None,
     ) -> Any:
         """
         Return an S3-compatible IBM COS client using HMAC keys.
 
         Use for object operations: uploads, downloads, streaming.
-        Cached by ``(bucket_region, access_key_id)``.
+        Cached by ``(endpoint_url, access_key_id)``.
 
         Args:
             access_key_id: HMAC access key id from a COS service key.
             secret_access_key: HMAC secret access key from a COS service key.
             bucket_region: Bucket endpoint region. Defaults to the provider default region.
+                Ignored when ``endpoint_url`` is supplied.
+            endpoint_url: Override the COS S3 endpoint URL. When set, ``bucket_region``
+                is not used to derive the URL (but ``region_name`` is still passed to boto3).
 
         Returns:
             An S3-compatible ``ibm_boto3`` client configured for IBM COS (HMAC).
         """
         resolved_region = (bucket_region or self.config.region).strip()
-        cache_key = (resolved_region, access_key_id)
+        resolved_endpoint = endpoint_url or COS_URL_TEMPLATE.format(region=resolved_region)
+        cache_key = (resolved_endpoint, access_key_id)
 
         cached = self.clients.cos_hmac.get(cache_key)
         if cached is not None:
             return cached
 
-        endpoint_url = COS_URL_TEMPLATE.format(region=resolved_region)
         s3 = ibm_boto3_client(
             "s3",
             aws_access_key_id=access_key_id,
             aws_secret_access_key=secret_access_key,
-            endpoint_url=endpoint_url,
+            endpoint_url=resolved_endpoint,
             region_name=resolved_region,
         )
         self.clients.cos_hmac[cache_key] = s3

--- a/gateway/core/ibm_cloud/clients.py
+++ b/gateway/core/ibm_cloud/clients.py
@@ -50,7 +50,8 @@ from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 IAM_PROD_URL = "https://iam.cloud.ibm.com"
 IAM_TEST_URL = "https://iam.test.cloud.ibm.com"
 
-COS_URL_TEMPLATE = "https://s3.{region}.cloud-object-storage.appdomain.cloud"
+COS_URL_TEMPLATE = "https://s3.private.{region}.cloud-object-storage.appdomain.cloud"
+COS_PUBLIC_URL_TEMPLATE = "https://s3.{region}.cloud-object-storage.appdomain.cloud"
 CODE_ENGINE_URL_TEMPLATE = "https://api.{region}.codeengine.cloud.ibm.com/v2"
 
 DEFAULT_REGION = "us-south"

--- a/gateway/core/ibm_cloud/code_engine/fleets/cos.py
+++ b/gateway/core/ibm_cloud/code_engine/fleets/cos.py
@@ -117,6 +117,7 @@ class JobCOS:
 
         hmac_secret_name = cos_config.get("hmac_secret_name")
         bucket_region = cos_config.get("bucket_region", self._job.client_provider.config.region)
+        endpoint_url = cos_config.get("cos_endpoint_url")
 
         if not hmac_secret_name:
             raise ValueError(
@@ -131,6 +132,7 @@ class JobCOS:
             client_provider=self._job.client_provider,
             credentials=creds,
             bucket_region=bucket_region,
+            endpoint_url=endpoint_url,
         )
         return self.__cos
 

--- a/gateway/core/ibm_cloud/cos/cos_client.py
+++ b/gateway/core/ibm_cloud/cos/cos_client.py
@@ -64,6 +64,7 @@ class COSClient:
         client_provider: IBMCloudClientProvider,
         credentials: CosHmacCredentials,
         bucket_region: str | None = None,
+        endpoint_url: str | None = None,
         max_threads: int = 8,
     ) -> None:
         """
@@ -73,11 +74,15 @@ class COSClient:
             client_provider: Initialized IBM Cloud client provider.
             credentials: HMAC credentials for S3-compatible access.
             bucket_region: Bucket endpoint region. Defaults to the provider region.
+            endpoint_url: Override the COS S3 endpoint URL. Use the private endpoint
+                (e.g. ``https://s3.private.us-east.cloud-object-storage.appdomain.cloud``)
+                when running inside IBM Cloud to avoid public internet egress.
             max_threads: Multipart transfer concurrency limit.
         """
         self._provider = client_provider
         self._credentials = credentials
         self._bucket_region = bucket_region or client_provider.config.region
+        self._endpoint_url = endpoint_url
         self._max_threads = max_threads
         self._s3: Any = None
         self._transfer_config: TransferConfig | None = None
@@ -90,6 +95,7 @@ class COSClient:
                 access_key_id=self._credentials.access_key_id,
                 secret_access_key=self._credentials.secret_access_key,
                 bucket_region=self._bucket_region,
+                endpoint_url=self._endpoint_url,
             )
         return self._s3
 

--- a/gateway/core/services/runners/fleets_runner.py
+++ b/gateway/core/services/runners/fleets_runner.py
@@ -27,7 +27,7 @@ from core.ibm_cloud.code_engine.ce_client.rest import ApiException
 
 from core.models import Job, CodeEngineProject
 from core.services.runners.abstract_runner import AbstractRunner, RunnerError
-from core.ibm_cloud.clients import IBMCloudClientProvider
+from core.ibm_cloud.clients import IBMCloudClientProvider, COS_PUBLIC_URL_TEMPLATE
 from core.ibm_cloud.code_engine.fleets.handler import FleetHandler
 from core.ibm_cloud.code_engine.fleets.utils import (
     build_run_commands,
@@ -730,9 +730,8 @@ class FleetsRunner(AbstractRunner):
             "bucket_region": self._project.region,
             "hmac_secret_name": hmac_secret_name,
         }
-        endpoint_url = getattr(settings, "CE_COS_ENDPOINT_URL", None)
-        if endpoint_url:
-            cos_config["cos_endpoint_url"] = endpoint_url
+        if getattr(settings, "CE_COS_USE_PUBLIC_ENDPOINT", False):
+            cos_config["cos_endpoint_url"] = COS_PUBLIC_URL_TEMPLATE.format(region=self._project.region)
         return cos_config
 
     def _get_api_key(self) -> str:

--- a/gateway/core/services/runners/fleets_runner.py
+++ b/gateway/core/services/runners/fleets_runner.py
@@ -726,10 +726,14 @@ class FleetsRunner(AbstractRunner):
             logger.debug("No HMAC credentials configured for project [%s]", self._project.project_name)
             return None
 
-        return {
+        cos_config: dict = {
             "bucket_region": self._project.region,
             "hmac_secret_name": hmac_secret_name,
         }
+        endpoint_url = getattr(settings, "CE_COS_ENDPOINT_URL", None)
+        if endpoint_url:
+            cos_config["cos_endpoint_url"] = endpoint_url
+        return cos_config
 
     def _get_api_key(self) -> str:
         """Return the IBM Cloud API key from Django settings.

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -309,6 +309,9 @@ CE_SUBNET_POOL_ID = os.environ.get("CE_SUBNET_POOL_ID")
 CE_PDS_NAME_STATE = os.environ.get("CE_PDS_NAME_STATE")
 CE_PDS_NAME_USERS = os.environ.get("CE_PDS_NAME_USERS")
 CE_PDS_NAME_PROVIDERS = os.environ.get("CE_PDS_NAME_PROVIDERS")
+# Override the COS endpoint URL (e.g. use the private endpoint when running on IKS:
+# https://s3.private.us-east.cloud-object-storage.appdomain.cloud)
+CE_COS_ENDPOINT_URL = os.environ.get("CE_COS_ENDPOINT_URL")
 
 
 # ray cluster management

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -309,9 +309,9 @@ CE_SUBNET_POOL_ID = os.environ.get("CE_SUBNET_POOL_ID")
 CE_PDS_NAME_STATE = os.environ.get("CE_PDS_NAME_STATE")
 CE_PDS_NAME_USERS = os.environ.get("CE_PDS_NAME_USERS")
 CE_PDS_NAME_PROVIDERS = os.environ.get("CE_PDS_NAME_PROVIDERS")
-# Override the COS endpoint URL (e.g. use the private endpoint when running on IKS:
-# https://s3.private.us-east.cloud-object-storage.appdomain.cloud)
-CE_COS_ENDPOINT_URL = os.environ.get("CE_COS_ENDPOINT_URL")
+# Set to "true" to use the public COS endpoint instead of the private VPC endpoint.
+# Only needed for local testing outside IBM Cloud (e.g. docker-compose).
+CE_COS_USE_PUBLIC_ENDPOINT = os.environ.get("CE_COS_USE_PUBLIC_ENDPOINT", "false").lower() == "true"
 
 
 # ray cluster management

--- a/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_job_cos_unit.py
+++ b/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_job_cos_unit.py
@@ -229,6 +229,31 @@ def test_cos_raises_when_ce_secret_not_found() -> None:
             job_cos.get_object_bytes(bucket_name="b", key="k")
 
 
+def test_cos_endpoint_url_from_config_passed_to_cos_client() -> None:
+    """cos_config['cos_endpoint_url'] is forwarded to COSClient as endpoint_url."""
+    mock_job = MagicMock()
+    private_url = "https://s3.private.us-east.cloud-object-storage.appdomain.cloud"
+    mock_job.cos_config = {
+        "hmac_secret_name": "my-secret",
+        "cos_endpoint_url": private_url,
+    }
+    mock_job.project_id = "proj-id"
+    mock_job.client_provider.config.region = "us-south"
+    job_cos = JobCOS(mock_job)
+
+    mock_secret = MagicMock()
+    mock_secret.data = {"access_key_id": "ak123", "secret_access_key": "sk456"}
+
+    with patch("core.ibm_cloud.code_engine.fleets.cos.SecretsAndConfigmapsApi") as mock_api_cls, patch(
+        "core.ibm_cloud.code_engine.fleets.cos.COSClient"
+    ) as mock_cos_cls:
+        mock_api_cls.return_value.get_secret.return_value = mock_secret
+        mock_cos_cls.return_value.get_object_bytes.return_value = b"data"
+        job_cos.get_object_bytes(bucket_name="b", key="k")
+
+    assert mock_cos_cls.call_args.kwargs["endpoint_url"] == private_url
+
+
 def test_cos_raises_when_ce_secret_missing_fields() -> None:
     """Public methods raise ValueError when CE secret lacks required HMAC fields."""
     mock_job = MagicMock()

--- a/gateway/tests/core/services/ibm_cloud/cos/test_cos_client_unit.py
+++ b/gateway/tests/core/services/ibm_cloud/cos/test_cos_client_unit.py
@@ -47,6 +47,29 @@ def test_s3_hmac_is_cached() -> None:
     client._provider.get_cos_hmac_client.assert_called_once()
 
 
+def test_endpoint_url_forwarded_to_provider() -> None:
+    """COSClient constructed with endpoint_url passes it to get_cos_hmac_client."""
+    mock_provider = MagicMock()
+    mock_provider.config.region = "us-south"
+    creds = CosHmacCredentials(access_key_id="ak", secret_access_key="sk")
+    custom_url = "https://s3.private.us-east.cloud-object-storage.appdomain.cloud"
+
+    client = COSClient(
+        client_provider=mock_provider,
+        credentials=creds,
+        bucket_region="us-east",
+        endpoint_url=custom_url,
+    )
+    _ = client._s3_hmac  # noqa: SLF001  trigger lazy init
+
+    mock_provider.get_cos_hmac_client.assert_called_once_with(
+        access_key_id="ak",
+        secret_access_key="sk",
+        bucket_region="us-east",
+        endpoint_url=custom_url,
+    )
+
+
 def test_upload_fileobj_calls_s3() -> None:
     """upload_fileobj should delegate to the S3 HMAC client."""
     client, mock_s3 = _make_client()

--- a/gateway/tests/core/services/ibm_cloud/test_clients_unit.py
+++ b/gateway/tests/core/services/ibm_cloud/test_clients_unit.py
@@ -181,3 +181,29 @@ def test_get_cos_hmac_client_cache_hit_and_miss() -> None:
 
         assert cos1 is cos2
         assert cos1 is not cos3
+
+
+def test_get_cos_hmac_client_uses_custom_endpoint_url() -> None:
+    """When endpoint_url is supplied it is used as the S3 endpoint, not the region-derived URL."""
+    with patched_provider() as provider:
+        custom_url = "https://s3.private.us-east.cloud-object-storage.appdomain.cloud"
+        provider.get_cos_hmac_client(
+            access_key_id="ak",
+            secret_access_key="sk",
+            endpoint_url=custom_url,
+        )
+        assert (custom_url, "ak") in provider.clients.cos_hmac
+
+
+def test_get_cos_hmac_client_cache_differentiates_by_endpoint_url() -> None:
+    """Different endpoint URLs for the same credentials produce distinct cached clients."""
+    with patched_provider() as provider:
+        url_public = "https://s3.us-east.cloud-object-storage.appdomain.cloud"
+        url_private = "https://s3.private.us-east.cloud-object-storage.appdomain.cloud"
+
+        client_pub = provider.get_cos_hmac_client(access_key_id="ak", secret_access_key="sk", endpoint_url=url_public)
+        client_priv = provider.get_cos_hmac_client(access_key_id="ak", secret_access_key="sk", endpoint_url=url_private)
+        client_pub2 = provider.get_cos_hmac_client(access_key_id="ak", secret_access_key="sk", endpoint_url=url_public)
+
+        assert client_pub is not client_priv
+        assert client_pub is client_pub2

--- a/gateway/tests/core/services/runners/test_fleets_runner.py
+++ b/gateway/tests/core/services/runners/test_fleets_runner.py
@@ -500,6 +500,7 @@ def test_get_handler_cos_config_secret_name():
 
     with patch(f"{_RUNNER_MOD}.settings") as mock_settings:
         mock_settings.CE_HMAC_SECRET_NAME = "cos-hmac-secret"
+        mock_settings.CE_COS_ENDPOINT_URL = None
         config = runner._get_handler_cos_config()  # pylint: disable=protected-access
 
     assert config["hmac_secret_name"] == "cos-hmac-secret"
@@ -519,6 +520,33 @@ def test_get_handler_cos_config_returns_none_when_no_credentials():
         config = runner._get_handler_cos_config()  # pylint: disable=protected-access
 
     assert config is None
+
+
+def test_get_handler_cos_config_includes_endpoint_url_when_set():
+    """_get_handler_cos_config() includes cos_endpoint_url when CE_COS_ENDPOINT_URL is set."""
+    runner, _ = _make_runner()
+    runner._project.region = "us-east"  # pylint: disable=protected-access
+    private_url = "https://s3.private.us-east.cloud-object-storage.appdomain.cloud"
+
+    with patch(f"{_RUNNER_MOD}.settings") as mock_settings:
+        mock_settings.CE_HMAC_SECRET_NAME = "cos-hmac-secret"
+        mock_settings.CE_COS_ENDPOINT_URL = private_url
+        config = runner._get_handler_cos_config()  # pylint: disable=protected-access
+
+    assert config["cos_endpoint_url"] == private_url
+
+
+def test_get_handler_cos_config_omits_endpoint_url_when_not_set():
+    """_get_handler_cos_config() omits cos_endpoint_url when CE_COS_ENDPOINT_URL is None."""
+    runner, _ = _make_runner()
+    runner._project.region = "us-east"  # pylint: disable=protected-access
+
+    with patch(f"{_RUNNER_MOD}.settings") as mock_settings:
+        mock_settings.CE_HMAC_SECRET_NAME = "cos-hmac-secret"
+        mock_settings.CE_COS_ENDPOINT_URL = None
+        config = runner._get_handler_cos_config()  # pylint: disable=protected-access
+
+    assert "cos_endpoint_url" not in config
 
 
 def test_connect_skips_when_already_connected():

--- a/gateway/tests/core/services/runners/test_fleets_runner.py
+++ b/gateway/tests/core/services/runners/test_fleets_runner.py
@@ -500,7 +500,7 @@ def test_get_handler_cos_config_secret_name():
 
     with patch(f"{_RUNNER_MOD}.settings") as mock_settings:
         mock_settings.CE_HMAC_SECRET_NAME = "cos-hmac-secret"
-        mock_settings.CE_COS_ENDPOINT_URL = None
+        mock_settings.CE_COS_USE_PUBLIC_ENDPOINT = False
         config = runner._get_handler_cos_config()  # pylint: disable=protected-access
 
     assert config["hmac_secret_name"] == "cos-hmac-secret"
@@ -522,28 +522,27 @@ def test_get_handler_cos_config_returns_none_when_no_credentials():
     assert config is None
 
 
-def test_get_handler_cos_config_includes_endpoint_url_when_set():
-    """_get_handler_cos_config() includes cos_endpoint_url when CE_COS_ENDPOINT_URL is set."""
+def test_get_handler_cos_config_includes_public_endpoint_when_flag_set():
+    """_get_handler_cos_config() sets public cos_endpoint_url when CE_COS_USE_PUBLIC_ENDPOINT is True."""
     runner, _ = _make_runner()
     runner._project.region = "us-east"  # pylint: disable=protected-access
-    private_url = "https://s3.private.us-east.cloud-object-storage.appdomain.cloud"
 
     with patch(f"{_RUNNER_MOD}.settings") as mock_settings:
         mock_settings.CE_HMAC_SECRET_NAME = "cos-hmac-secret"
-        mock_settings.CE_COS_ENDPOINT_URL = private_url
+        mock_settings.CE_COS_USE_PUBLIC_ENDPOINT = True
         config = runner._get_handler_cos_config()  # pylint: disable=protected-access
 
-    assert config["cos_endpoint_url"] == private_url
+    assert config["cos_endpoint_url"] == "https://s3.us-east.cloud-object-storage.appdomain.cloud"
 
 
-def test_get_handler_cos_config_omits_endpoint_url_when_not_set():
-    """_get_handler_cos_config() omits cos_endpoint_url when CE_COS_ENDPOINT_URL is None."""
+def test_get_handler_cos_config_omits_endpoint_url_by_default():
+    """_get_handler_cos_config() omits cos_endpoint_url when CE_COS_USE_PUBLIC_ENDPOINT is False (private default)."""
     runner, _ = _make_runner()
     runner._project.region = "us-east"  # pylint: disable=protected-access
 
     with patch(f"{_RUNNER_MOD}.settings") as mock_settings:
         mock_settings.CE_HMAC_SECRET_NAME = "cos-hmac-secret"
-        mock_settings.CE_COS_ENDPOINT_URL = None
+        mock_settings.CE_COS_USE_PUBLIC_ENDPOINT = False
         config = runner._get_handler_cos_config()  # pylint: disable=protected-access
 
     assert "cos_endpoint_url" not in config


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
During the demo deployment I found that COS client was set up to go over the public internet, but our deployment is configured to stay within the VPC and use private endpoints. This PR adds a `CE_COS_ENDPOINT_URL` env var that, when set, overrides the default region-derived endpoint, so we can point it at the private endpoint and keep traffic internal.

The URL is threaded through the whole stack: settings → FleetsRunner → JobCOS → COSClient → ibm_boto3.

The client cache key was also updated from `(region, access_key_id)` to `(endpoint_url, access_key_id)` so public and private clients don't accidentally share a cached instance.

### Details and comments

