### PR TITLE
Small fix: handle US spelling of canceled in fleet status mapping

### DIFF
--- a/gateway/core/services/runners/fleets_runner.py
+++ b/gateway/core/services/runners/fleets_runner.py
@@ -826,6 +826,7 @@ class FleetsRunner(AbstractRunner):
             "failed": Job.FAILED,
             "stopped": Job.STOPPED,
             "cancelled": Job.STOPPED,
+            "canceled": Job.STOPPED,
             "canceling": Job.STOPPED,
         }
         return status_map.get(fleet_status.lower(), Job.PENDING)

--- a/gateway/tests/core/services/runners/test_fleets_runner.py
+++ b/gateway/tests/core/services/runners/test_fleets_runner.py
@@ -178,6 +178,7 @@ def test_is_active_false_on_connection_error():
         ("failed", "FAILED"),
         ("stopped", "STOPPED"),
         ("cancelled", "STOPPED"),
+        ("canceled", "STOPPED"),
         ("canceling", "STOPPED"),
         ("unknown-status", "PENDING"),
     ],


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
CE can return either "cancelled" (UK) or "canceled" (US) depending on the API version, we were only handling the UK spelling, so US-spelled statuses were silently falling through to PENDING instead of STOPPED.

One line fix + test case added to the parametrized status mapping suite.

### Details and comments

