### PR TITLE
Expose fleet_id in job responses and runner in program admin

### DIFF
--- a/gateway/api/admin.py
+++ b/gateway/api/admin.py
@@ -39,7 +39,7 @@ class ProgramAdmin(admin.ModelAdmin):
     """ProgramAdmin."""
 
     search_fields = ["title", "author__username"]
-    list_filter = ["provider", "type", "disabled"]
+    list_filter = ["provider", "type", "runner", "disabled"]
     exclude = ["env_vars"]
     filter_horizontal = ["instances", "trial_instances"]
     change_form_template = "program/change_form.html"
@@ -49,6 +49,7 @@ class ProgramAdmin(admin.ModelAdmin):
         "provider",
         "author",
         "type",
+        "runner",
         "disabled",
     ]
 

--- a/gateway/api/serializers.py
+++ b/gateway/api/serializers.py
@@ -240,6 +240,7 @@ class RunJobSerializer(serializers.ModelSerializer):
             "status",
             "created",
             "compute_profile",
+            "fleet_id",
             "arguments",
             "program",
         ]

--- a/gateway/api/v1/serializers.py
+++ b/gateway/api/v1/serializers.py
@@ -220,6 +220,7 @@ class JobSerializer(serializers.JobSerializer):
             "program",
             "created",
             "sub_status",
+            "fleet_id",
             "compute_profile",
         ]
 
@@ -232,4 +233,4 @@ class JobSerializerWithoutResult(serializers.JobSerializer):
     program = ProgramSummarySerializer(many=False)
 
     class Meta(serializers.JobSerializer.Meta):
-        fields = ["id", "status", "program", "created", "sub_status", "compute_profile"]
+        fields = ["id", "status", "program", "created", "sub_status", "fleet_id", "compute_profile"]

--- a/gateway/api/views/programs.py
+++ b/gateway/api/views/programs.py
@@ -181,13 +181,15 @@ class ProgramViewSet(viewsets.GenericViewSet):
                 )
                 return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-        serializer.save(author=author, title=title, provider=provider_name)
+        runner = serializer.validated_data.get("runner", Function.RAY)
+        serializer.save(author=author, title=title, provider=provider_name, runner=runner)
 
         logger.info(
-            "[programs-upload] user_id=%s program=%s provider=%s | Function uploaded ok",
+            "[programs-upload] user_id=%s program=%s provider=%s runner=%s | Function uploaded ok",
             author.id,
             title,
             provider_name,
+            runner,
         )
         return Response(serializer.data)
 

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -997,3 +997,25 @@ class TestProgramApi(APITestCase):
 
         program = Program.objects.get(title="Fleets function")
         assert program.runner == Program.FLEETS
+
+    def test_upload_without_runner_defaults_to_ray(self):
+        """Upload without runner field defaults to Program.RAY."""
+        fake_file = ContentFile(b"print('Hello World')")
+        fake_file.name = "test_run.tar"
+
+        TestUtils.authorize_client(username="test_user_2", client=self.client)
+
+        with self.settings(MEDIA_ROOT=self.MEDIA_ROOT):
+            response = self.client.post(
+                "/api/v1/programs/upload/",
+                data={
+                    "title": "Default runner function",
+                    "entrypoint": "main.py",
+                    "dependencies": "[]",
+                    "artifact": fake_file,
+                },
+            )
+            assert response.status_code == status.HTTP_200_OK
+
+        program = Program.objects.get(title="Default runner function")
+        assert program.runner == Program.RAY

--- a/gateway/tests/api/test_v1_serializers.py
+++ b/gateway/tests/api/test_v1_serializers.py
@@ -13,6 +13,8 @@ from django.core.management import call_command
 from api.domain.authentication.channel import Channel
 from api.v1.serializers import (
     JobConfigSerializer,
+    JobSerializer,
+    JobSerializerWithoutResult,
     UploadProgramSerializer,
     RunProgramSerializer,
     RunJobSerializer,
@@ -428,3 +430,23 @@ class TestSerializers:
         serializer_2.is_valid()
         program_2: Program = serializer_2.save(author=user)
         assert description == program_2.description
+
+    def test_job_serializer_includes_fleet_id(self):
+        """JobSerializer output includes fleet_id when set on the job."""
+        user = models.User.objects.get(username="test_user")
+        program = Program.objects.get(id="1a7947f9-6ae8-4e3d-ac1e-e7d608deec82")
+        job = TestUtils.create_job(author=user, program=program, fleet_id="fleet-abc")
+
+        data = JobSerializer(job).data
+        assert "fleet_id" in data
+        assert data["fleet_id"] == "fleet-abc"
+
+    def test_job_serializer_without_result_includes_fleet_id(self):
+        """JobSerializerWithoutResult output includes fleet_id when set on the job."""
+        user = models.User.objects.get(username="test_user")
+        program = Program.objects.get(id="1a7947f9-6ae8-4e3d-ac1e-e7d608deec82")
+        job = TestUtils.create_job(author=user, program=program, fleet_id="fleet-xyz")
+
+        data = JobSerializerWithoutResult(job).data
+        assert "fleet_id" in data
+        assert data["fleet_id"] == "fleet-xyz"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
A few small gaps I noticed when debugging Fleets jobs in the demo environment: `fleet_id` wasn't coming back in the API response, and the admin panel had no way to filter or sort programs by runner type (I am not sure how relevant this one will be but I think it will be useful).

Changes:
- `api/serializers.py` + `api/v1/serializers.py`: add `fleet_id` to job response fields so clients can track the CE fleet backing a job
- `api/admin.py` — add `runner` to `list_filter` and `list_display` on `ProgramAdmin` so admins can filter Ray vs Fleets functions
- `api/views/programs.py` — explicitly pass `runner` to `serializer.save()`  so the runner type is correctly persisted on function upload

### Details and comments

