### PR TITLE
Pass job env vars to fleet containers

### DIFF
--- a/gateway/core/services/runners/fleets_runner.py
+++ b/gateway/core/services/runners/fleets_runner.py
@@ -27,6 +27,7 @@ from core.ibm_cloud.code_engine.ce_client.rest import ApiException
 
 from core.models import Job, CodeEngineProject
 from core.services.runners.abstract_runner import AbstractRunner, RunnerError
+from core.utils import decrypt_env_vars
 from core.ibm_cloud.clients import IBMCloudClientProvider
 from core.ibm_cloud.code_engine.fleets.handler import FleetHandler
 from core.ibm_cloud.code_engine.fleets.utils import (
@@ -218,12 +219,12 @@ class FleetsRunner(AbstractRunner):
                     secondary_log_filename=LOG_FILENAME,
                     secondary_log_filter_key=LOG_FILTER_KEY,
                 )
-                run_env_variables.extend(
-                    [
-                        {"type": "literal", "name": "JOB_ID_GATEWAY", "value": job_id},
-                        {"type": "literal", "name": "DATA_PATH", "value": paths["user_mount_path"]},
-                    ]
+                run_env_variables.append(
+                    {"type": "literal", "name": "JOB_ID_GATEWAY", "value": job_id},
                 )
+
+                gateway_env = self._build_gateway_env_vars()
+                run_env_variables.extend(gateway_env)
                 run_commands = build_run_commands(
                     app_run_commands=["python", f"{paths['provider_mount_path']}/{self.job.program.entrypoint}"],
                     secondary_log_filter_key=LOG_FILTER_KEY,
@@ -504,6 +505,27 @@ class FleetsRunner(AbstractRunner):
                 raise RunnerError(f"Failed to initialize FleetHandler for project [{name}]", ex) from ex
 
         return self._handler
+
+    def _build_gateway_env_vars(self) -> list[dict[str, str]]:
+        """Extract job env vars so the container can call save_result() and use Qiskit Runtime."""
+        try:
+            env = json.loads(self.job.env_vars)
+            env = decrypt_env_vars(env)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.warning("Could not decrypt env_vars for job [%s]", self.job.id)
+            return []
+
+        token = env.get("ENV_JOB_GATEWAY_TOKEN", "")
+        if token:
+            env["QISKIT_IBM_RUNTIME_CUSTOM_CLIENT_APP_HEADER"] = (
+                "middleware_job_id/" + str(self.job.id) + "," + token + "/"
+            )
+
+        return [
+            {"type": "literal", "name": k, "value": v}
+            for k, v in env.items()
+            if v
+        ]
 
     def _build_cos_paths(self) -> dict[str, str]:
         """Build COS key prefixes and container mount paths for the job.

--- a/gateway/core/services/runners/fleets_runner.py
+++ b/gateway/core/services/runners/fleets_runner.py
@@ -508,24 +508,10 @@ class FleetsRunner(AbstractRunner):
 
     def _build_gateway_env_vars(self) -> list[dict[str, str]]:
         """Extract job env vars so the container can call save_result() and use Qiskit Runtime."""
-        try:
-            env = json.loads(self.job.env_vars)
-            env = decrypt_env_vars(env)
-        except Exception:  # pylint: disable=broad-exception-caught
-            logger.warning("Could not decrypt env_vars for job [%s]", self.job.id)
-            return []
+        env = json.loads(self.job.env_vars)
+        env = decrypt_env_vars(env)
 
-        token = env.get("ENV_JOB_GATEWAY_TOKEN", "")
-        if token:
-            env["QISKIT_IBM_RUNTIME_CUSTOM_CLIENT_APP_HEADER"] = (
-                "middleware_job_id/" + str(self.job.id) + "," + token + "/"
-            )
-
-        return [
-            {"type": "literal", "name": k, "value": v}
-            for k, v in env.items()
-            if v
-        ]
+        return [{"type": "literal", "name": k, "value": v} for k, v in env.items() if v]
 
     def _build_cos_paths(self) -> dict[str, str]:
         """Build COS key prefixes and container mount paths for the job.

--- a/gateway/tests/core/services/runners/test_fleets_runner.py
+++ b/gateway/tests/core/services/runners/test_fleets_runner.py
@@ -622,3 +622,81 @@ def test_upload_arguments_to_cos_uploads_json():
     call_kwargs = mock_handler.cos.upload_fileobj.call_args.kwargs
     assert call_kwargs["bucket_name"] == "user-bucket"
     assert call_kwargs["key"] == "users/1/jobs/j/arguments.json"
+
+
+def test_build_gateway_env_vars_returns_formatted_list():
+    """_build_gateway_env_vars() returns env vars formatted for Code Engine."""
+    runner, _ = _make_runner()
+    runner.job.env_vars = '{"KEY1": "val1", "KEY2": "val2"}'
+
+    with patch(f"{_RUNNER_MOD}.decrypt_env_vars", side_effect=lambda e: e):
+        result = runner._build_gateway_env_vars()  # pylint: disable=protected-access
+
+    assert result == [
+        {"type": "literal", "name": "KEY1", "value": "val1"},
+        {"type": "literal", "name": "KEY2", "value": "val2"},
+    ]
+
+
+def test_build_gateway_env_vars_decrypts_tokens():
+    """_build_gateway_env_vars() passes env vars through decrypt_env_vars."""
+    runner, _ = _make_runner()
+    runner.job.env_vars = '{"QISKIT_IBM_TOKEN": "encrypted", "SOME_URL": "http://example.com"}'
+
+    decrypted = {"QISKIT_IBM_TOKEN": "decrypted", "SOME_URL": "http://example.com"}
+    with patch(f"{_RUNNER_MOD}.decrypt_env_vars", return_value=decrypted) as mock_decrypt:
+        result = runner._build_gateway_env_vars()  # pylint: disable=protected-access
+
+    mock_decrypt.assert_called_once_with({"QISKIT_IBM_TOKEN": "encrypted", "SOME_URL": "http://example.com"})
+    assert {"type": "literal", "name": "QISKIT_IBM_TOKEN", "value": "decrypted"} in result
+    assert {"type": "literal", "name": "SOME_URL", "value": "http://example.com"} in result
+
+
+def test_build_gateway_env_vars_filters_empty_values():
+    """_build_gateway_env_vars() excludes entries with empty or None values."""
+    runner, _ = _make_runner()
+    runner.job.env_vars = '{"KEEP": "value", "EMPTY": "", "NULL_VAL": null}'
+
+    def passthrough(e):
+        return e
+
+    with patch(f"{_RUNNER_MOD}.decrypt_env_vars", side_effect=passthrough):
+        result = runner._build_gateway_env_vars()  # pylint: disable=protected-access
+
+    assert result == [{"type": "literal", "name": "KEEP", "value": "value"}]
+
+
+def test_build_gateway_env_vars_empty_env_vars():
+    """_build_gateway_env_vars() returns an empty list when job has no env vars."""
+    runner, _ = _make_runner()
+    runner.job.env_vars = "{}"
+
+    with patch(f"{_RUNNER_MOD}.decrypt_env_vars", return_value={}):
+        result = runner._build_gateway_env_vars()  # pylint: disable=protected-access
+
+    assert result == []
+
+
+def test_submit_includes_gateway_env_vars():
+    """submit() includes decrypted gateway env vars in the run_env_variables."""
+    runner, mock_handler = _make_submit_runner()
+    runner.job.env_vars = '{"MY_TOKEN": "secret", "MY_URL": "http://example.com"}'
+    runner.job.author.id = "user-1"
+    runner.job.program.provider = None
+    runner.job.program.title = "prog"
+
+    runner._project.cos_bucket_user_data_name = "user-bucket"  # pylint: disable=protected-access
+    runner._project.cos_bucket_provider_data_name = "prov-bucket"  # pylint: disable=protected-access
+    runner._project.cos_instance_name = "cos-inst"  # pylint: disable=protected-access
+    runner._project.cos_key_name = "cos-key"  # pylint: disable=protected-access
+    runner._project.pds_name_users = "pds-users"  # pylint: disable=protected-access
+    runner._project.pds_name_providers = "pds-provs"  # pylint: disable=protected-access
+
+    decrypted = {"MY_TOKEN": "decrypted_secret", "MY_URL": "http://example.com"}
+    with _patch_settings(), patch(f"{_RUNNER_MOD}.decrypt_env_vars", return_value=decrypted):
+        runner.submit()
+
+    call_kwargs = mock_handler.submit_job.call_args.kwargs
+    env_list = call_kwargs["extra_fields"]["run_env_variables"]
+    assert {"type": "literal", "name": "MY_TOKEN", "value": "decrypted_secret"} in env_list
+    assert {"type": "literal", "name": "MY_URL", "value": "http://example.com"} in env_list


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
`FleetsRunner.submit()` now forwards decrypted `job.env_vars` to the CE container, matching the Ray runner path.


### Details and comments
- Decrypts and passes all env vars from `job.env_vars` (gateway token, Qiskit Runtime credentials, trial mode, etc.)
- Adds `QISKIT_IBM_RUNTIME_CUSTOM_CLIENT_APP_HEADER` for IBM Runtime attribution
- Removes redundant explicit `DATA_PATH` (already in `job.env_vars`)
- Enables `save_result()` calls from within fleet containers via the gateway API
