### PR TITLE
Fleet scheduling updates: fleet_id retry preservation and COS result retrieval

### DIFF
--- a/gateway/scheduler/tasks/schedule_queued_jobs.py
+++ b/gateway/scheduler/tasks/schedule_queued_jobs.py
@@ -109,6 +109,7 @@ class ScheduleQueuedJobs(SchedulerTask):
                 backup_logs = job.logs
                 backup_resource = job.compute_resource
                 backup_ray_job_id = job.ray_job_id
+                backup_fleet_id = job.fleet_id
 
                 succeed = False
                 attempts = settings.RAY_SETUP_MAX_RETRIES
@@ -144,6 +145,7 @@ class ScheduleQueuedJobs(SchedulerTask):
                         job.logs = backup_logs
                         job.compute_resource = backup_resource
                         job.ray_job_id = backup_ray_job_id
+                        job.fleet_id = backup_fleet_id
 
                 retries = settings.RAY_SETUP_MAX_RETRIES - attempts
                 if succeed:

--- a/gateway/scheduler/tasks/update_jobs_statuses.py
+++ b/gateway/scheduler/tasks/update_jobs_statuses.py
@@ -103,12 +103,22 @@ class UpdateJobsStatuses(SchedulerTask):
             if job.in_terminal_state():
                 job.sub_status = None
                 job.env_vars = "{}"
+                # Fleets logs are already in COS; only Ray logs need fetching and persisting.
                 if not is_fleets_job:
                     try:
                         logs = runner.logs() or ""
                     except RunnerError:
                         logs = ""
                     save_logs_to_storage(job, logs)
+                else:
+                    # For Fleets jobs, retrieve results from COS and save to database
+                    try:
+                        result_str = runner.get_result_from_cos()
+                        if result_str:
+                            job.result = result_str
+                            logger.info("Retrieved and saved results for Fleets job [%s]", job.id)
+                    except Exception as ex:  # pylint: disable=broad-exception-caught
+                        logger.warning("Failed to retrieve results for Fleets job [%s]: %s", job.id, str(ex))
                 job.logs = ""
                 if job.status == Job.SUCCEEDED:
                     self._record_execution_duration(job)
@@ -214,14 +224,17 @@ class UpdateJobsStatuses(SchedulerTask):
 
 
 def save_logs_to_storage(job: Job, logs: str):
-    """
-    Save the logs in the corresponding storages.
+    """Save Ray job logs to the local filesystem (COS-mounted volume).
 
-    This function is called exactly once when a job transitions to a terminal state.
+    Called once when a Ray job transitions to a terminal state. Filters the
+    combined log stream into public (user) and private (provider) logs.
+
+    This function is only used for Ray jobs. Fleets logs are written directly
+    to COS by the PDS shell wrapper during execution.
 
     Args:
-        job: Job that has reached a terminal state
-        job_handler: JobHandler to retrieve logs from Ray
+        job: Job that has reached a terminal state.
+        logs: Combined log stream from Ray.
     """
 
     logs = check_logs(logs, job)

--- a/gateway/tests/scheduler/test_schedule_queued_jobs.py
+++ b/gateway/tests/scheduler/test_schedule_queued_jobs.py
@@ -1,0 +1,67 @@
+# This code is part of a Qiskit project.
+#
+# (C) IBM 2026
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Unit tests for ScheduleQueuedJobs."""
+
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+from concurrency.exceptions import RecordModifiedError
+
+from scheduler.tasks.schedule_queued_jobs import ScheduleQueuedJobs
+
+_MOD = "scheduler.tasks.schedule_queued_jobs"
+
+
+def _make_task():
+    kill_signal = MagicMock()
+    kill_signal.received = False
+    return ScheduleQueuedJobs(kill_signal=kill_signal, metrics=MagicMock())
+
+
+def test_fleet_id_preserved_on_record_modified_error_retry():
+    """fleet_id set by execute_job is restored after RecordModifiedError + refresh_from_db."""
+    task = _make_task()
+
+    mock_job = MagicMock()
+    mock_job.fleet_id = "fleet-abc"
+    mock_job.status = "PENDING"
+    mock_job.logs = ""
+    mock_job.compute_resource = None
+    mock_job.ray_job_id = None
+    mock_job.env_vars = '{"traceparent": null}'
+
+    # First save raises RecordModifiedError; refresh_from_db wipes fleet_id; second save succeeds.
+    save_calls = [RecordModifiedError(target=mock_job), None]
+    mock_job.save.side_effect = save_calls
+
+    def fake_refresh():
+        mock_job.fleet_id = None  # simulates DB reload clearing the unsaved fleet_id
+
+    mock_job.refresh_from_db.side_effect = fake_refresh
+
+    with (
+        patch(f"{_MOD}.get_jobs_to_schedule_fair_share", return_value=[mock_job]),
+        patch(f"{_MOD}.execute_job", return_value=mock_job),
+        patch(f"{_MOD}.settings") as mock_settings,
+        patch(f"{_MOD}.JobEvent"),
+        patch(f"{_MOD}.TraceContextTextMapPropagator"),
+        patch(f"{_MOD}.trace"),
+    ):
+        mock_settings.RAY_SETUP_MAX_RETRIES = 3
+        mock_settings.LIMITS_MAX_FLEETS = 10
+        mock_settings.LIMITS_JOBS_PER_USER = 5
+        task._schedule_jobs_if_slots_available(  # pylint: disable=protected-access
+            max_slots_possible=5, number_of_slots_running=0, gpu_job=False
+        )
+
+    assert mock_job.fleet_id == "fleet-abc"

--- a/gateway/tests/scheduler/test_update_jobs_statuses.py
+++ b/gateway/tests/scheduler/test_update_jobs_statuses.py
@@ -1,0 +1,101 @@
+# This code is part of a Qiskit project.
+#
+# (C) IBM 2026
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Unit tests for UpdateJobsStatuses."""
+
+from unittest.mock import MagicMock, patch
+
+from core.models import Job, Program
+from scheduler.tasks.update_jobs_statuses import UpdateJobsStatuses
+
+_MOD = "scheduler.tasks.update_jobs_statuses"
+
+
+def _make_task():
+    kill_signal = MagicMock()
+    kill_signal.received = False
+    return UpdateJobsStatuses(kill_signal=kill_signal, metrics=MagicMock())
+
+
+def _make_fleets_job(status=Job.RUNNING, fleet_id="fleet-123"):
+    job = MagicMock(spec=Job)
+    job.runner = Program.FLEETS
+    job.fleet_id = fleet_id
+    job.status = status
+    job.result = None
+    job.logs = ""
+    job.env_vars = "{}"
+    job.sub_status = None
+    job.in_terminal_state.return_value = False
+    job.SUCCEEDED = Job.SUCCEEDED
+    job.FAILED = Job.FAILED
+    return job
+
+
+def test_fleets_result_retrieved_from_cos_on_terminal_state():
+    """update_job_status() saves COS result to job.result when Fleets job reaches terminal state."""
+    task = _make_task()
+    job = _make_fleets_job()
+    job.in_terminal_state.return_value = True
+
+    mock_runner = MagicMock()
+    mock_runner.status.return_value = Job.SUCCEEDED
+    mock_runner.get_result_from_cos.return_value = '{"counts": {"00": 512}}'
+
+    with (
+        patch(f"{_MOD}.get_runner", return_value=mock_runner),
+        patch(f"{_MOD}.check_job_timeout", return_value=False),
+        patch(f"{_MOD}.JobEvent"),
+    ):
+        task.update_job_status(job)
+
+    mock_runner.get_result_from_cos.assert_called_once()
+    assert job.result == '{"counts": {"00": 512}}'
+
+
+def test_fleets_result_skipped_when_cos_returns_none():
+    """update_job_status() leaves job.result unchanged when get_result_from_cos returns None."""
+    task = _make_task()
+    job = _make_fleets_job()
+    job.in_terminal_state.return_value = True
+    job.result = "previous-result"
+
+    mock_runner = MagicMock()
+    mock_runner.status.return_value = Job.SUCCEEDED
+    mock_runner.get_result_from_cos.return_value = None
+
+    with (
+        patch(f"{_MOD}.get_runner", return_value=mock_runner),
+        patch(f"{_MOD}.check_job_timeout", return_value=False),
+        patch(f"{_MOD}.JobEvent"),
+    ):
+        task.update_job_status(job)
+
+    assert job.result == "previous-result"
+
+
+def test_fleets_result_cos_error_is_swallowed():
+    """update_job_status() logs a warning and continues if get_result_from_cos raises."""
+    task = _make_task()
+    job = _make_fleets_job()
+    job.in_terminal_state.return_value = True
+
+    mock_runner = MagicMock()
+    mock_runner.status.return_value = Job.SUCCEEDED
+    mock_runner.get_result_from_cos.side_effect = RuntimeError("COS unavailable")
+
+    with (
+        patch(f"{_MOD}.get_runner", return_value=mock_runner),
+        patch(f"{_MOD}.check_job_timeout", return_value=False),
+        patch(f"{_MOD}.JobEvent"),
+    ):
+        task.update_job_status(job)  # should not raise


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Two scheduler fixes for Fleets jobs discovered during demo deployment.

**`fleet_id` lost on RecordModifiedError retry** (`schedule_queued_jobs.py`) -> `FleetsRunner.submit()` sets `job.fleet_id` in memory, but the field isn't persisted until `job.save()`. If a concurrent write causes `RecordModifiedError`, `refresh_from_db()` reloads the DB state and wipes the in-memory `fleet_id`. The retry then saves the job without it, permanently losing the fleet reference. Fix: back up and restore `fleet_id` alongside the existing `ray_job_id` backup.

**Fleets results not saved to database** (`update_jobs_statuses.py`) ->  When a Fleets job reaches a terminal state, the scheduler was only fetching and persisting logs for Ray jobs. Fleets jobs have their logs written directly to COS by the PDS shell wrapper, but results (return values) still need to be pulled from COS and saved to `job.result`. Added the `else` branch that calls `runner.get_result_from_cos()` on terminal transition, with a logged warning on failure so a COS error doesn't fail the job status update.

Also updated the `save_logs_to_storage` docstring to clarify it is Ray-only.

### Details and comments

