### PR TITLE
Add business_model to job get state endpoint

### DIFF
--- a/gateway/api/v1/views/jobs/retrieve.py
+++ b/gateway/api/v1/views/jobs/retrieve.py
@@ -68,7 +68,7 @@ class JobSerializer(api_serializers.JobSerializer):
     program = ProgramSerializer(many=False)
 
     class Meta(api_serializers.JobSerializer.Meta):
-        fields = ["id", "result", "status", "program", "created", "sub_status", "compute_profile"]
+        fields = ["id", "result", "status", "program", "created", "sub_status", "compute_profile", "business_model"]
         ref_name = "JobsRetrieveJobSerializer"
 
 
@@ -87,7 +87,7 @@ class JobSerializerWithoutResult(api_serializers.JobSerializer):
     program = ProgramSummary(read_only=True)
 
     class Meta(api_serializers.JobSerializer.Meta):
-        fields = ["id", "status", "program", "created", "sub_status", "compute_profile"]
+        fields = ["id", "status", "program", "created", "sub_status", "compute_profile", "business_model"]
 
 
 def serialize_output(job: Job, with_result: bool) -> Job:

--- a/gateway/tests/api/test_job.py
+++ b/gateway/tests/api/test_job.py
@@ -319,6 +319,7 @@ class TestJobApi:
         )
         assert jobs_response.status_code == status.HTTP_200_OK
         assert jobs_response.data.get("result") == '{"ultimate": 42}'
+        assert jobs_response.data.get("business_model") == BusinessModel.SUBSIDIZED
 
     def test_job_detail_without_result_param(self):
         """Tests job detail authorized."""
@@ -330,6 +331,7 @@ class TestJobApi:
         )
         assert jobs_response.status_code == status.HTTP_200_OK
         assert jobs_response.data.get("result") is None
+        assert jobs_response.data.get("business_model") == BusinessModel.SUBSIDIZED
 
     def test_job_detail_without_result_file(self):
         """Tests job detail authorized."""

--- a/gateway/tests/core/domain/authorization/test_function_access_entry.py
+++ b/gateway/tests/core/domain/authorization/test_function_access_entry.py
@@ -19,6 +19,16 @@ def test_valid_entry():
     assert entry.business_model == "TRIAL"
 
 
+def test_business_model_normalized_to_uppercase():
+    entry = FunctionAccessEntry(
+        provider_name="p",
+        function_title="f",
+        permissions={PLATFORM_PERMISSION_RUN},
+        business_model="trial",
+    )
+    assert entry.business_model == "TRIAL"
+
+
 def test_invalid_business_model_raises():
     with pytest.raises(ValueError, match="Invalid business_model"):
         FunctionAccessEntry(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Add `bussiness_model` to the GET /jobs/:id endpoint
