### PR TITLE
Arguments Storage input unification

### DIFF
--- a/gateway/api/serializers.py
+++ b/gateway/api/serializers.py
@@ -361,8 +361,7 @@ class RunJobSerializer(serializers.ModelSerializer):
             )
         )
 
-        provider_name = program.provider.name if program.provider else None
-        arguments_storage = ArgumentsStorage(author.username, program.title, provider_name)
+        arguments_storage = ArgumentsStorage(author.username, program)
         arguments_storage.save(job.id, arguments)
 
         try:

--- a/gateway/core/services/runners/fleets_runner.py
+++ b/gateway/core/services/runners/fleets_runner.py
@@ -567,8 +567,7 @@ class FleetsRunner(AbstractRunner):
             paths: Dict from :meth:`_build_cos_paths`.
         """
         program = self.job.program
-        provider_name = program.provider.name if program.provider else None
-        storage = ArgumentsStorage(self.job.author.username, program.title, provider_name)
+        storage = ArgumentsStorage(self.job.author.username, program)
         content = storage.get(str(self.job.id)) or "{}"
 
         try:

--- a/gateway/core/services/storage/arguments_storage.py
+++ b/gateway/core/services/storage/arguments_storage.py
@@ -6,6 +6,7 @@ import logging
 import os
 from typing import Optional
 
+from core.models import Program
 from core.services.storage.path_builder import PathBuilder
 from core.services.storage.enums.working_dir import WorkingDir
 
@@ -19,7 +20,10 @@ class ArgumentsStorage:
     PATH = "arguments"
     ENCODING = "utf-8"
 
-    def __init__(self, username: str, function_title: str, provider_name: Optional[str] = None):
+    def __init__(self, username: str, function: Program) -> None:
+        function_title = function.title
+        provider_name = function.provider.name if function.provider else None
+
         ### In this case arguments are always stored in user folder
         self.sub_path = PathBuilder.sub_path(
             working_dir=WorkingDir.USER_STORAGE,

--- a/gateway/tests/api/test_job.py
+++ b/gateway/tests/api/test_job.py
@@ -468,9 +468,7 @@ class TestJobApi:
         assert user_job.program.provider is None
 
         # Save arguments for user function
-        user_args_storage = ArgumentsStorage(
-            username=user_job.author.username, function_title=user_job.program.title, provider_name=None
-        )
+        user_args_storage = ArgumentsStorage(username=user_job.author.username, function=user_job.program)
         test_args = '{"param": "value"}'
         user_args_storage.save(str(user_job.id), test_args)
 
@@ -483,9 +481,11 @@ class TestJobApi:
         assert retrieved_args == test_args
 
         # Verify arguments are NOT in provider path
-        wrong_provider_storage = ArgumentsStorage(
-            username=user_job.author.username, function_title=user_job.program.title, provider_name="fake_provider"
-        )
+        fake_program = MagicMock()
+        fake_program.title = user_job.program.title
+        fake_program.provider = MagicMock()
+        fake_program.provider.name = "fake_provider"
+        wrong_provider_storage = ArgumentsStorage(username=user_job.author.username, function=fake_program)
         assert wrong_provider_storage.get(str(user_job.id)) is None
 
     def test_job_arguments_storage_path_provider(self, settings):
@@ -506,8 +506,7 @@ class TestJobApi:
         # Save arguments for provider function
         provider_args_storage = ArgumentsStorage(
             username=provider_job.author.username,
-            function_title=provider_job.program.title,
-            provider_name=provider_job.program.provider.name,
+            function=provider_job.program,
         )
         provider_test_args = '{"provider_param": "provider_value"}'
         provider_args_storage.save(str(provider_job.id), provider_test_args)
@@ -528,9 +527,10 @@ class TestJobApi:
         assert retrieved_provider_args == provider_test_args
 
         # Verify provider function arguments are NOT in user-only path
-        wrong_user_storage = ArgumentsStorage(
-            username=provider_job.author.username, function_title=provider_job.program.title, provider_name=None
-        )
+        no_provider_program = MagicMock()
+        no_provider_program.title = provider_job.program.title
+        no_provider_program.provider = None
+        wrong_user_storage = ArgumentsStorage(username=provider_job.author.username, function=no_provider_program)
         assert wrong_user_storage.get(str(provider_job.id)) is None
 
     def test_job_update_sub_status(self):

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -361,7 +361,7 @@ class TestProgramApi(APITestCase):
             assert job.config.auto_scaling is True
 
             program = Program.objects.get(title="Program", author=user)
-            arguments_storage = ArgumentsStorage(user.username, program.title, None)
+            arguments_storage = ArgumentsStorage(user.username, program)
             stored_arguments = arguments_storage.get(job.id)
 
             assert stored_arguments == arguments
@@ -424,8 +424,7 @@ class TestProgramApi(APITestCase):
             assert job.config.auto_scaling is True
 
             program = Program.objects.get(title="Docker-Image-Program", author=user)
-            provider_name = program.provider.name if program.provider else None
-            arguments_storage = ArgumentsStorage(user.username, program.title, provider_name)
+            arguments_storage = ArgumentsStorage(user.username, program)
             stored_arguments = arguments_storage.get(job.id)
 
             assert stored_arguments == arguments
@@ -1055,7 +1054,7 @@ class TestProgramApi(APITestCase):
             assert job.program.provider is None
 
             # Verify arguments are stored in the correct path (user storage, not provider)
-            arguments_storage = ArgumentsStorage(user.username, user_program.title, None)
+            arguments_storage = ArgumentsStorage(user.username, user_program)
             stored_arguments = arguments_storage.get(job.id)
             assert stored_arguments == arguments
 

--- a/gateway/tests/core/services/storage/test_arguments_storage.py
+++ b/gateway/tests/core/services/storage/test_arguments_storage.py
@@ -1,49 +1,46 @@
 """Tests for ArgumentsStorage service."""
 
 import os
-from unittest.mock import MagicMock
+
+import pytest
 
 from core.services.storage.arguments_storage import ArgumentsStorage
+from tests.utils import TestUtils
 
 
-def _make_program(title: str, provider_name: str = None) -> MagicMock:
-    program = MagicMock()
-    program.title = title
-    if provider_name:
-        program.provider = MagicMock()
-        program.provider.name = provider_name
-    else:
-        program.provider = None
-    return program
-
-
+@pytest.mark.django_db
 class TestArgumentsStorage:
     """Tests for ArgumentsStorage path generation and file operations."""
 
-    def test_path_without_provider(self, tmp_path, settings):
+    @pytest.fixture
+    def program(self):
+        return TestUtils.create_program(program_title="myfun", author="user1")
+
+    @pytest.fixture
+    def program_with_provider(self):
+        return TestUtils.create_program(program_title="myfun", author="user1", provider="provider1")
+
+    def test_path_without_provider(self, tmp_path, settings, program):
         """User job: path is {username}/arguments/"""
         settings.MEDIA_ROOT = str(tmp_path)
-        storage = ArgumentsStorage(username="user1", function=_make_program("myfun"))
+        storage = ArgumentsStorage(username="user1", function=program)
 
         assert storage.sub_path == "user1/arguments"
         assert storage.absolute_path == f"{tmp_path}/user1/arguments"
         assert os.path.exists(storage.absolute_path)
 
-    def test_path_with_provider(self, tmp_path, settings):
+    def test_path_with_provider(self, tmp_path, settings, program_with_provider):
         """Provider job: path is {username}/{provider}/{function}/arguments/"""
         settings.MEDIA_ROOT = str(tmp_path)
-        storage = ArgumentsStorage(
-            username="user1",
-            function=_make_program("myfun", provider_name="provider1"),
-        )
+        storage = ArgumentsStorage(username="user1", function=program_with_provider)
 
         assert storage.sub_path == "user1/provider1/myfun/arguments"
         assert storage.absolute_path == f"{tmp_path}/user1/provider1/myfun/arguments"
 
-    def test_save_and_get(self, tmp_path, settings):
+    def test_save_and_get(self, tmp_path, settings, program):
         """Test saving and retrieving arguments."""
         settings.MEDIA_ROOT = str(tmp_path)
-        storage = ArgumentsStorage(username="user1", function=_make_program("myfun"))
+        storage = ArgumentsStorage(username="user1", function=program)
 
         # file not found returns None
         assert storage.get("id") is None

--- a/gateway/tests/core/services/storage/test_arguments_storage.py
+++ b/gateway/tests/core/services/storage/test_arguments_storage.py
@@ -1,8 +1,20 @@
 """Tests for ArgumentsStorage service."""
 
 import os
+from unittest.mock import MagicMock
 
 from core.services.storage.arguments_storage import ArgumentsStorage
+
+
+def _make_program(title: str, provider_name: str = None) -> MagicMock:
+    program = MagicMock()
+    program.title = title
+    if provider_name:
+        program.provider = MagicMock()
+        program.provider.name = provider_name
+    else:
+        program.provider = None
+    return program
 
 
 class TestArgumentsStorage:
@@ -11,7 +23,7 @@ class TestArgumentsStorage:
     def test_path_without_provider(self, tmp_path, settings):
         """User job: path is {username}/arguments/"""
         settings.MEDIA_ROOT = str(tmp_path)
-        storage = ArgumentsStorage(username="user1", function_title="myfun")
+        storage = ArgumentsStorage(username="user1", function=_make_program("myfun"))
 
         assert storage.sub_path == "user1/arguments"
         assert storage.absolute_path == f"{tmp_path}/user1/arguments"
@@ -22,8 +34,7 @@ class TestArgumentsStorage:
         settings.MEDIA_ROOT = str(tmp_path)
         storage = ArgumentsStorage(
             username="user1",
-            function_title="myfun",
-            provider_name="provider1",
+            function=_make_program("myfun", provider_name="provider1"),
         )
 
         assert storage.sub_path == "user1/provider1/myfun/arguments"
@@ -32,7 +43,7 @@ class TestArgumentsStorage:
     def test_save_and_get(self, tmp_path, settings):
         """Test saving and retrieving arguments."""
         settings.MEDIA_ROOT = str(tmp_path)
-        storage = ArgumentsStorage(username="user1", function_title="myfun")
+        storage = ArgumentsStorage(username="user1", function=_make_program("myfun"))
 
         # file not found returns None
         assert storage.get("id") is None


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR is a previous PR to start working in the abstraction of the storages from @korgan00 PR: #2061 

The change is pretty simple. `ArgumentStorage` will now receive a `Program` instead to receive `title` and `provider` separetely following the same pattern as the other one. 