### PR TITLE
Refactor FleetsRunner to 3-mount layout for SDK compatibility

### DIFF
--- a/gateway/core/services/runners/fleets_runner.py
+++ b/gateway/core/services/runners/fleets_runner.py
@@ -204,18 +204,23 @@ class FleetsRunner(AbstractRunner):
 
                 run_volume_mounts = build_run_volume_mounts(
                     mounts=[
-                        (paths["user_mount_path"], self._project.pds_name_users, paths["user_function_prefix"]),
+                        (paths["user_mount_path"], self._project.pds_name_users, paths["user_job_prefix"]),
                         (
                             paths["provider_mount_path"],
                             self._project.pds_name_providers,
                             paths["provider_function_prefix"],
                         ),
+                        (
+                            paths["provider_logs_mount_path"],
+                            self._project.pds_name_providers,
+                            paths["provider_job_prefix"],
+                        ),
                     ]
                 )
                 run_env_variables = build_run_env_variables(
-                    primary_mount_path=f"{paths['provider_mount_path']}/jobs/{job_id}",
+                    primary_mount_path=paths["provider_logs_mount_path"],
                     primary_log_filename=LOG_FILENAME,
-                    secondary_mount_path=f"{paths['user_mount_path']}/jobs/{job_id}",
+                    secondary_mount_path=paths["user_mount_path"],
                     secondary_log_filename=LOG_FILENAME,
                     secondary_log_filter_key=LOG_FILTER_KEY,
                 )
@@ -525,9 +530,10 @@ class FleetsRunner(AbstractRunner):
     def _build_cos_paths(self) -> dict[str, str]:
         """Build COS key prefixes and container mount paths for the job.
 
-        Both PDS volumes mount at function level so all jobs sharing the same
-        program share function-level files while having isolated job-level
-        directories for arguments, logs, and results.
+        Three PDS volume mounts provide job-level isolation:
+          - /data          → user-data-bucket @ user_job_prefix (job level)
+          - /function_data → provider-data-bucket @ provider_function_prefix (function level)
+          - /provider_logs → provider-data-bucket @ provider_job_prefix (job level)
 
         Returns:
             Dict with function/job prefixes, COS log/argument keys, and
@@ -550,17 +556,19 @@ class FleetsRunner(AbstractRunner):
             "provider_job_prefix": provider_job_prefix,
             "user_log_key": f"{user_job_prefix}/{LOG_FILENAME}",
             "provider_log_key": f"{provider_job_prefix}/{LOG_FILENAME}",
-            "user_arguments_key": f"{user_job_prefix}/arguments.json",
+            "user_arguments_key": f"{user_job_prefix}/arguments/{job_id}.json",
             "user_mount_path": "/data",
             "provider_mount_path": "/function_data",
+            "provider_logs_mount_path": "/provider_logs",
         }
 
     def _upload_arguments_to_cos(self, handler: FleetHandler, paths: dict[str, str]) -> None:
         """Upload job arguments from local storage to the COS user bucket.
 
         Reads from :class:`ArgumentsStorage` and uploads to
-        ``{user_job_prefix}/arguments.json``. Unwraps a single-key
-        ``{"arguments": ...}`` envelope if present.
+        ``{user_job_prefix}/arguments/{job_id}.json`` so the SDK's
+        ``get_arguments()`` finds them at ``/data/arguments/{job_id}.json``.
+        Unwraps a single-key ``{"arguments": ...}`` envelope if present.
 
         Args:
             handler: Initialized :class:`FleetHandler` with COS access.
@@ -590,7 +598,7 @@ class FleetsRunner(AbstractRunner):
         """Extract the program artifact tar and upload files to COS.
 
         Entrypoint → provider bucket (accessible at ``/function_data/{entrypoint}``).
-        All other files → user bucket (accessible at ``/data/{filename}``).
+        All other files → user bucket at job level (accessible at ``/data/{filename}``).
 
         Provider functions skip this — their files are pre-uploaded by the
         provider admin.
@@ -621,7 +629,7 @@ class FleetsRunner(AbstractRunner):
                         key = f"{paths['provider_function_prefix']}/{member.name}"
                     else:
                         bucket_name = user_bucket
-                        key = f"{paths['user_function_prefix']}/{member.name}"
+                        key = f"{paths['user_job_prefix']}/{member.name}"
 
                     handler.cos.upload_fileobj(fileobj=extracted, bucket_name=bucket_name, key=key)
                     logger.debug("Uploaded [%s] for job [%s] to %s/%s", member.name, self.job.id, bucket_name, key)

--- a/gateway/tests/core/services/runners/test_fleets_runner.py
+++ b/gateway/tests/core/services/runners/test_fleets_runner.py
@@ -262,9 +262,13 @@ def test_build_cos_paths_structure():
     assert paths["user_job_prefix"] == "users/user-42/provider_functions/default/my-program/jobs/job-uuid"
     assert paths["user_log_key"].endswith("/logs.log")
     assert paths["provider_log_key"].endswith("/logs.log")
-    assert paths["user_arguments_key"].endswith("/arguments.json")
+    assert (
+        paths["user_arguments_key"]
+        == "users/user-42/provider_functions/default/my-program/jobs/job-uuid/arguments/job-uuid.json"
+    )
     assert paths["user_mount_path"] == "/data"
     assert paths["provider_mount_path"] == "/function_data"
+    assert paths["provider_logs_mount_path"] == "/provider_logs"
 
 
 def test_submit_sets_fleet_id_without_cos():


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary                                                                                                                         

While working on fleet integration tests, I found that `get_arguments()` from the SDK doesn't work with Fleets — the volume  mount layout exposes arguments at the wrong path. Investigating further, the function-level sub_paths also expose files from all jobs to each container, which is a job isolation issue.

This PR refactors from a 2-mount (function-level) layout to a 3-mount (job-level) layout that fixes both problems.

### Details

**Before (2 mounts, function-level sub_paths):**
   - `/data` → user-data-bucket @ `users/.../title` — container sees all jobs' files
   - `/function_data` → provider-data-bucket @ `providers/.../title`

**After (3 mounts, job-level isolation):**
   - `/data` → user-data-bucket @ `users/.../title/jobs/{job_id}` — SDK finds `/data/arguments/{job_id}.json`
   - `/function_data` → provider-data-bucket @ `providers/.../title` — shared entrypoint code
   - `/provider_logs` → provider-data-bucket @ `providers/.../title/jobs/{job_id}` — isolated provider logs

**Changes:**
   - `_build_cos_paths()`: new `provider_logs_mount_path`, arguments key follows SDK convention
   - `submit()`: 3 volume mounts, env vars use mount paths directly
   - `_upload_artifact_to_cos()`: non-entrypoint files → job-level prefix
   - Unit tests updated
