### PR TITLE
Support different accesses for Arguments storage

### DIFF
--- a/gateway/api/serializers.py
+++ b/gateway/api/serializers.py
@@ -18,7 +18,7 @@ from rest_framework import validators as validators_module
 from api.utils import build_env_variables, sanitize_name
 from core.domain.business_models import BusinessModel
 from core.model_managers.job_events import JobEventContext, JobEventOrigin
-from core.services.storage.arguments_storage import ArgumentsStorage
+from core.services.storage import get_arguments_storage
 from core.utils import encrypt_env_vars, create_gpujob_allowlist
 
 from core.models import (
@@ -361,7 +361,7 @@ class RunJobSerializer(serializers.ModelSerializer):
             )
         )
 
-        arguments_storage = ArgumentsStorage(author.username, program)
+        arguments_storage = get_arguments_storage(author.username, program)
         arguments_storage.save(job.id, arguments)
 
         try:

--- a/gateway/api/serializers.py
+++ b/gateway/api/serializers.py
@@ -361,8 +361,8 @@ class RunJobSerializer(serializers.ModelSerializer):
             )
         )
 
-        arguments_storage = get_arguments_storage(author.username, program)
-        arguments_storage.save(job.id, arguments)
+        arguments_storage = get_arguments_storage(job)
+        arguments_storage.save(arguments)
 
         try:
             env["traceparent"] = carrier["traceparent"]

--- a/gateway/core/services/runners/fleets_runner.py
+++ b/gateway/core/services/runners/fleets_runner.py
@@ -574,9 +574,8 @@ class FleetsRunner(AbstractRunner):
             handler: Initialized :class:`FleetHandler` with COS access.
             paths: Dict from :meth:`_build_cos_paths`.
         """
-        program = self.job.program
-        storage = get_arguments_storage(self.job.author.username, program)
-        content = storage.get(str(self.job.id)) or "{}"
+        storage = get_arguments_storage(self.job)
+        content = storage.get() or "{}"
 
         try:
             parsed = json.loads(content)

--- a/gateway/core/services/runners/fleets_runner.py
+++ b/gateway/core/services/runners/fleets_runner.py
@@ -35,7 +35,7 @@ from core.ibm_cloud.code_engine.fleets.utils import (
     build_run_env_variables,
     build_run_volume_mounts,
 )
-from core.services.storage.arguments_storage import ArgumentsStorage
+from core.services.storage import get_arguments_storage
 
 logger = logging.getLogger("FleetsRunner")
 
@@ -575,7 +575,7 @@ class FleetsRunner(AbstractRunner):
             paths: Dict from :meth:`_build_cos_paths`.
         """
         program = self.job.program
-        storage = ArgumentsStorage(self.job.author.username, program)
+        storage = get_arguments_storage(self.job.author.username, program)
         content = storage.get(str(self.job.id)) or "{}"
 
         try:

--- a/gateway/core/services/storage/__init__.py
+++ b/gateway/core/services/storage/__init__.py
@@ -3,7 +3,6 @@
 from core.models import Program
 from core.services.storage.arguments_storage import ArgumentsStorage
 from core.services.storage.arguments_storage_ray import RayArgumentsStorage
-from core.services.storage.arguments_storage_fleets import FleetsArgumentsStorage
 
 
 def get_arguments_storage(username: str, function: Program) -> ArgumentsStorage:
@@ -22,5 +21,6 @@ def get_arguments_storage(username: str, function: Program) -> ArgumentsStorage:
     if function.runner == Program.RAY:
         return RayArgumentsStorage(username, function)
     if function.runner == Program.FLEETS:
-        return FleetsArgumentsStorage(username, function)
+        # Replace with FleetsArgumentsStorage once implemented
+        return RayArgumentsStorage(username, function)
     raise ValueError(f"Unknown runner type: {function.runner}")

--- a/gateway/core/services/storage/__init__.py
+++ b/gateway/core/services/storage/__init__.py
@@ -1,16 +1,15 @@
 """Factory and exports for services storages."""
 
-from core.models import Program
+from core.models import Job, Program
 from core.services.storage.arguments_storage import ArgumentsStorage
 from core.services.storage.arguments_storage_ray import RayArgumentsStorage
 
 
-def get_arguments_storage(username: str, function: Program) -> ArgumentsStorage:
-    """Factory: return the appropriate ArgumentsStorage for the program's runner.
+def get_arguments_storage(job: Job) -> ArgumentsStorage:
+    """Factory: return the appropriate ArgumentsStorage for the job's program runner.
 
     Args:
-        username: The job author's username.
-        function: The Program instance whose runner determines the implementation.
+        job: The Job instance whose program runner determines the implementation.
 
     Returns:
         An ArgumentsStorage instance appropriate for the runner type.
@@ -18,9 +17,9 @@ def get_arguments_storage(username: str, function: Program) -> ArgumentsStorage:
     Raises:
         ValueError: If the runner type is unknown.
     """
-    if function.runner == Program.RAY:
-        return RayArgumentsStorage(username, function)
-    if function.runner == Program.FLEETS:
+    if job.program.runner == Program.RAY:
+        return RayArgumentsStorage(job)
+    if job.program.runner == Program.FLEETS:
         # Replace with FleetsArgumentsStorage once implemented
-        return RayArgumentsStorage(username, function)
-    raise ValueError(f"Unknown runner type: {function.runner}")
+        return RayArgumentsStorage(job)
+    raise ValueError(f"Unknown runner type: {job.program.runner}")

--- a/gateway/core/services/storage/__init__.py
+++ b/gateway/core/services/storage/__init__.py
@@ -1,0 +1,26 @@
+"""Factory and exports for services storages."""
+
+from core.models import Program
+from core.services.storage.arguments_storage import ArgumentsStorage
+from core.services.storage.arguments_storage_ray import RayArgumentsStorage
+from core.services.storage.arguments_storage_fleets import FleetsArgumentsStorage
+
+
+def get_arguments_storage(username: str, function: Program) -> ArgumentsStorage:
+    """Factory: return the appropriate ArgumentsStorage for the program's runner.
+
+    Args:
+        username: The job author's username.
+        function: The Program instance whose runner determines the implementation.
+
+    Returns:
+        An ArgumentsStorage instance appropriate for the runner type.
+
+    Raises:
+        ValueError: If the runner type is unknown.
+    """
+    if function.runner == Program.RAY:
+        return RayArgumentsStorage(username, function)
+    if function.runner == Program.FLEETS:
+        return FleetsArgumentsStorage(username, function)
+    raise ValueError(f"Unknown runner type: {function.runner}")

--- a/gateway/core/services/storage/arguments_storage.py
+++ b/gateway/core/services/storage/arguments_storage.py
@@ -8,9 +8,9 @@ class ArgumentsStorage(ABC):
     """Abstract interface for job arguments storage."""
 
     @abstractmethod
-    def get(self, job_id: str) -> Optional[str]:
-        """Retrieve arguments for the given job ID."""
+    def get(self) -> Optional[str]:
+        """Retrieve arguments for the job."""
 
     @abstractmethod
-    def save(self, job_id: str, arguments: str) -> None:
-        """Persist arguments for the given job ID."""
+    def save(self, arguments: str) -> None:
+        """Persist arguments for the job."""

--- a/gateway/core/services/storage/arguments_storage.py
+++ b/gateway/core/services/storage/arguments_storage.py
@@ -1,96 +1,16 @@
-"""
-This module handle the access to the arguments store
-"""
+"""Abstract base class for arguments storage."""
 
-import logging
-import os
+from abc import ABC, abstractmethod
 from typing import Optional
 
-from core.models import Program
-from core.services.storage.path_builder import PathBuilder
-from core.services.storage.enums.working_dir import WorkingDir
 
-logger = logging.getLogger("core.ArgumentsStorage")
+class ArgumentsStorage(ABC):
+    """Abstract interface for job arguments storage."""
 
-
-class ArgumentsStorage:
-    """Handles the storage and retrieval of user arguments."""
-
-    ARGUMENTS_FILE_EXTENSION = ".json"
-    PATH = "arguments"
-    ENCODING = "utf-8"
-
-    def __init__(self, username: str, function: Program) -> None:
-        function_title = function.title
-        provider_name = function.provider.name if function.provider else None
-
-        ### In this case arguments are always stored in user folder
-        self.sub_path = PathBuilder.sub_path(
-            working_dir=WorkingDir.USER_STORAGE,
-            username=username,
-            function_title=function_title,
-            provider_name=provider_name,
-            extra_sub_path=self.PATH,
-        )
-        self.absolute_path = PathBuilder.absolute_path(
-            working_dir=WorkingDir.USER_STORAGE,
-            username=username,
-            function_title=function_title,
-            provider_name=provider_name,
-            extra_sub_path=self.PATH,
-        )
-
-    def _get_arguments_path(self, job_id: str) -> str:
-        """Construct the full path for a arguments file."""
-        return os.path.join(self.absolute_path, f"{job_id}{self.ARGUMENTS_FILE_EXTENSION}")
-
+    @abstractmethod
     def get(self, job_id: str) -> Optional[str]:
-        """
-        Retrieve an arguments file for the given job id
+        """Retrieve arguments for the given job ID."""
 
-        Args:
-            job_id (str): the id for the job to get the arguments
-
-        Returns:
-            Optional[str]: content of the file
-        """
-        arguments_path = self._get_arguments_path(job_id)
-        if not os.path.exists(arguments_path):
-            logger.info(
-                "Arguments file for job ID '%s' not found in directory '%s'.",
-                job_id,
-                arguments_path,
-            )
-            return None
-
-        try:
-            with open(arguments_path, "r", encoding=self.ENCODING) as arguments_file:
-                return arguments_file.read()
-        except (UnicodeDecodeError, IOError) as e:
-            logger.error(
-                "Failed to read arguments file for job ID '%s': %s",
-                job_id,
-                str(e),
-            )
-            return None
-
+    @abstractmethod
     def save(self, job_id: str, arguments: str) -> None:
-        """
-        Save the arguments to a file associated with the given job ID.
-
-        Args:
-            job_id (str): The unique identifier for the job. This will be used as the base
-                name for the arguments file.
-            arguments (str): The job arguments to be saved in the file.
-
-        Returns:
-            None
-        """
-        arguments_path = self._get_arguments_path(job_id)
-        with open(arguments_path, "w", encoding=self.ENCODING) as arguments_file:
-            arguments_file.write(arguments)
-        logger.info(
-            "Arguments for job ID '%s' successfully saved at '%s'.",
-            job_id,
-            arguments_path,
-        )
+        """Persist arguments for the given job ID."""

--- a/gateway/core/services/storage/arguments_storage_fleets.py
+++ b/gateway/core/services/storage/arguments_storage_fleets.py
@@ -2,18 +2,18 @@
 
 from typing import Optional
 
-from core.models import Program
+from core.models import Job
 from core.services.storage.arguments_storage import ArgumentsStorage
 
 
 class FleetsArgumentsStorage(ArgumentsStorage):
     """Handles the storage and retrieval of user arguments for Fleets jobs."""
 
-    def __init__(self, username: str, function: Program) -> None:
-        pass
+    def __init__(self, job: Job) -> None:
+        self._job_id = str(job.id)
 
-    def get(self, job_id: str) -> Optional[str]:
+    def get(self) -> Optional[str]:
         raise NotImplementedError
 
-    def save(self, job_id: str, arguments: str) -> None:
+    def save(self, arguments: str) -> None:
         raise NotImplementedError

--- a/gateway/core/services/storage/arguments_storage_fleets.py
+++ b/gateway/core/services/storage/arguments_storage_fleets.py
@@ -1,0 +1,19 @@
+"""Fleets implementation of arguments storage."""
+
+from typing import Optional
+
+from core.models import Program
+from core.services.storage.arguments_storage import ArgumentsStorage
+
+
+class FleetsArgumentsStorage(ArgumentsStorage):
+    """Handles the storage and retrieval of user arguments for Fleets jobs."""
+
+    def __init__(self, username: str, function: Program) -> None:
+        pass
+
+    def get(self, job_id: str) -> Optional[str]:
+        raise NotImplementedError
+
+    def save(self, job_id: str, arguments: str) -> None:
+        raise NotImplementedError

--- a/gateway/core/services/storage/arguments_storage_ray.py
+++ b/gateway/core/services/storage/arguments_storage_ray.py
@@ -1,0 +1,73 @@
+"""Ray implementation of arguments storage."""
+
+import logging
+import os
+from typing import Optional
+
+from core.models import Program
+from core.services.storage.arguments_storage import ArgumentsStorage
+from core.services.storage.path_builder import PathBuilder
+from core.services.storage.enums.working_dir import WorkingDir
+
+logger = logging.getLogger("core.RayArgumentsStorage")
+
+
+class RayArgumentsStorage(ArgumentsStorage):
+    """Handles the storage and retrieval of user arguments for Ray jobs."""
+
+    ARGUMENTS_FILE_EXTENSION = ".json"
+    PATH = "arguments"
+    ENCODING = "utf-8"
+
+    def __init__(self, username: str, function: Program) -> None:
+        function_title = function.title
+        provider_name = function.provider.name if function.provider else None
+
+        self.sub_path = PathBuilder.sub_path(
+            working_dir=WorkingDir.USER_STORAGE,
+            username=username,
+            function_title=function_title,
+            provider_name=provider_name,
+            extra_sub_path=self.PATH,
+        )
+        self.absolute_path = PathBuilder.absolute_path(
+            working_dir=WorkingDir.USER_STORAGE,
+            username=username,
+            function_title=function_title,
+            provider_name=provider_name,
+            extra_sub_path=self.PATH,
+        )
+
+    def _get_arguments_path(self, job_id: str) -> str:
+        return os.path.join(self.absolute_path, f"{job_id}{self.ARGUMENTS_FILE_EXTENSION}")
+
+    def get(self, job_id: str) -> Optional[str]:
+        arguments_path = self._get_arguments_path(job_id)
+        if not os.path.exists(arguments_path):
+            logger.info(
+                "Arguments file for job ID '%s' not found in directory '%s'.",
+                job_id,
+                arguments_path,
+            )
+            return None
+
+        try:
+            with open(arguments_path, "r", encoding=self.ENCODING) as arguments_file:
+                return arguments_file.read()
+        except (UnicodeDecodeError, IOError) as e:
+            logger.error(
+                "Failed to read arguments file for job ID '%s': %s",
+                job_id,
+                str(e),
+            )
+            return None
+
+    def save(self, job_id: str, arguments: str) -> None:
+        arguments_path = self._get_arguments_path(job_id)
+        with open(arguments_path, "w", encoding=self.ENCODING) as arguments_file:
+            arguments_file.write(arguments)
+        logger.info(
+            "Arguments for job ID '%s' successfully saved at '%s'.",
+            job_id,
+            arguments_path,
+        )

--- a/gateway/core/services/storage/arguments_storage_ray.py
+++ b/gateway/core/services/storage/arguments_storage_ray.py
@@ -4,7 +4,7 @@ import logging
 import os
 from typing import Optional
 
-from core.models import Program
+from core.models import Job
 from core.services.storage.arguments_storage import ArgumentsStorage
 from core.services.storage.path_builder import PathBuilder
 from core.services.storage.enums.working_dir import WorkingDir
@@ -19,9 +19,11 @@ class RayArgumentsStorage(ArgumentsStorage):
     PATH = "arguments"
     ENCODING = "utf-8"
 
-    def __init__(self, username: str, function: Program) -> None:
-        function_title = function.title
-        provider_name = function.provider.name if function.provider else None
+    def __init__(self, job: Job) -> None:
+        self._job_id = str(job.id)
+        username = job.author.username
+        function_title = job.program.title
+        provider_name = job.program.provider.name if job.program.provider else None
 
         self.sub_path = PathBuilder.sub_path(
             working_dir=WorkingDir.USER_STORAGE,
@@ -38,15 +40,15 @@ class RayArgumentsStorage(ArgumentsStorage):
             extra_sub_path=self.PATH,
         )
 
-    def _get_arguments_path(self, job_id: str) -> str:
-        return os.path.join(self.absolute_path, f"{job_id}{self.ARGUMENTS_FILE_EXTENSION}")
+    def _get_arguments_path(self) -> str:
+        return os.path.join(self.absolute_path, f"{self._job_id}{self.ARGUMENTS_FILE_EXTENSION}")
 
-    def get(self, job_id: str) -> Optional[str]:
-        arguments_path = self._get_arguments_path(job_id)
+    def get(self) -> Optional[str]:
+        arguments_path = self._get_arguments_path()
         if not os.path.exists(arguments_path):
             logger.info(
                 "Arguments file for job ID '%s' not found in directory '%s'.",
-                job_id,
+                self._job_id,
                 arguments_path,
             )
             return None
@@ -57,17 +59,17 @@ class RayArgumentsStorage(ArgumentsStorage):
         except (UnicodeDecodeError, IOError) as e:
             logger.error(
                 "Failed to read arguments file for job ID '%s': %s",
-                job_id,
+                self._job_id,
                 str(e),
             )
             return None
 
-    def save(self, job_id: str, arguments: str) -> None:
-        arguments_path = self._get_arguments_path(job_id)
+    def save(self, arguments: str) -> None:
+        arguments_path = self._get_arguments_path()
         with open(arguments_path, "w", encoding=self.ENCODING) as arguments_file:
             arguments_file.write(arguments)
         logger.info(
             "Arguments for job ID '%s' successfully saved at '%s'.",
-            job_id,
+            self._job_id,
             arguments_path,
         )

--- a/gateway/tests/api/test_job.py
+++ b/gateway/tests/api/test_job.py
@@ -385,26 +385,22 @@ class TestJobApi:
         assert user_job.program.provider is None
 
         # Save arguments for user function
-        user_args_storage = get_arguments_storage(username=user_job.author.username, function=user_job.program)
+        user_args_storage = get_arguments_storage(user_job)
         test_args = '{"param": "value"}'
-        user_args_storage.save(str(user_job.id), test_args)
+        user_args_storage.save(test_args)
 
         # Verify arguments saved in user's directory
         expected_user_path = os.path.join(settings.MEDIA_ROOT, "test_user", "arguments", f"{user_job.id}.json")
         assert os.path.exists(expected_user_path)
 
         # Verify we can retrieve the arguments
-        retrieved_args = user_args_storage.get(str(user_job.id))
+        retrieved_args = user_args_storage.get()
         assert retrieved_args == test_args
 
-        # Verify arguments are NOT in provider path
-        fake_program = MagicMock()
-        fake_program.title = user_job.program.title
-        fake_program.provider = MagicMock()
-        fake_program.provider.name = "fake_provider"
-        fake_program.runner = Program.RAY
-        wrong_provider_storage = get_arguments_storage(username=user_job.author.username, function=fake_program)
-        assert wrong_provider_storage.get(str(user_job.id)) is None
+        # Verify arguments are NOT in provider path (different job with provider program)
+        wrong_provider_job = self._create_job(author="test_user", provider_admin="fake_provider")
+        wrong_provider_storage = get_arguments_storage(wrong_provider_job)
+        assert wrong_provider_storage.get() is None
 
     def test_job_arguments_storage_path_provider(self, settings):
         """
@@ -422,12 +418,9 @@ class TestJobApi:
         assert provider_job.program.provider.name == "test_provider"
 
         # Save arguments for provider function
-        provider_args_storage = get_arguments_storage(
-            username=provider_job.author.username,
-            function=provider_job.program,
-        )
+        provider_args_storage = get_arguments_storage(provider_job)
         provider_test_args = '{"provider_param": "provider_value"}'
-        provider_args_storage.save(str(provider_job.id), provider_test_args)
+        provider_args_storage.save(provider_test_args)
 
         # Verify arguments saved in provider's directory structure
         expected_provider_path = os.path.join(
@@ -441,16 +434,13 @@ class TestJobApi:
         assert os.path.exists(expected_provider_path)
 
         # Verify we can retrieve the arguments
-        retrieved_provider_args = provider_args_storage.get(str(provider_job.id))
+        retrieved_provider_args = provider_args_storage.get()
         assert retrieved_provider_args == provider_test_args
 
-        # Verify provider function arguments are NOT in user-only path
-        no_provider_program = MagicMock()
-        no_provider_program.title = provider_job.program.title
-        no_provider_program.provider = None
-        no_provider_program.runner = Program.RAY
-        wrong_user_storage = get_arguments_storage(username=provider_job.author.username, function=no_provider_program)
-        assert wrong_user_storage.get(str(provider_job.id)) is None
+        # Verify provider function arguments are NOT in user-only path (different job without provider)
+        wrong_user_job = self._create_job(author="test_user")
+        wrong_user_storage = get_arguments_storage(wrong_user_job)
+        assert wrong_user_storage.get() is None
 
     def test_job_update_sub_status(self):
         """Test job update sub status"""

--- a/gateway/tests/api/test_job.py
+++ b/gateway/tests/api/test_job.py
@@ -463,14 +463,14 @@ class TestJobApi:
         This validates the DATA_PATH environment variable computation in build_env_variables()
         for user functions.
         """
-        from core.services.storage.arguments_storage import ArgumentsStorage
+        from core.services.storage import get_arguments_storage
 
         # Create user function (no provider)
         user_job = self._create_job(author="test_user")
         assert user_job.program.provider is None
 
         # Save arguments for user function
-        user_args_storage = ArgumentsStorage(username=user_job.author.username, function=user_job.program)
+        user_args_storage = get_arguments_storage(username=user_job.author.username, function=user_job.program)
         test_args = '{"param": "value"}'
         user_args_storage.save(str(user_job.id), test_args)
 
@@ -487,7 +487,8 @@ class TestJobApi:
         fake_program.title = user_job.program.title
         fake_program.provider = MagicMock()
         fake_program.provider.name = "fake_provider"
-        wrong_provider_storage = ArgumentsStorage(username=user_job.author.username, function=fake_program)
+        fake_program.runner = Program.RAY
+        wrong_provider_storage = get_arguments_storage(username=user_job.author.username, function=fake_program)
         assert wrong_provider_storage.get(str(user_job.id)) is None
 
     def test_job_arguments_storage_path_provider(self, settings):
@@ -498,7 +499,7 @@ class TestJobApi:
         This validates the DATA_PATH environment variable computation in build_env_variables()
         for provider functions.
         """
-        from core.services.storage.arguments_storage import ArgumentsStorage
+        from core.services.storage import get_arguments_storage
 
         # Create provider function
         provider_job = self._create_job(author="test_user", provider_admin="test_provider")
@@ -506,7 +507,7 @@ class TestJobApi:
         assert provider_job.program.provider.name == "test_provider"
 
         # Save arguments for provider function
-        provider_args_storage = ArgumentsStorage(
+        provider_args_storage = get_arguments_storage(
             username=provider_job.author.username,
             function=provider_job.program,
         )
@@ -532,7 +533,8 @@ class TestJobApi:
         no_provider_program = MagicMock()
         no_provider_program.title = provider_job.program.title
         no_provider_program.provider = None
-        wrong_user_storage = ArgumentsStorage(username=provider_job.author.username, function=no_provider_program)
+        no_provider_program.runner = Program.RAY
+        wrong_user_storage = get_arguments_storage(username=provider_job.author.username, function=no_provider_program)
         assert wrong_user_storage.get(str(provider_job.id)) is None
 
     def test_job_update_sub_status(self):

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -360,9 +360,8 @@ class TestProgramApi(APITestCase):
             assert job.config.workers is None
             assert job.config.auto_scaling is True
 
-            program = Program.objects.get(title="Program", author=user)
-            arguments_storage = get_arguments_storage(user.username, program)
-            stored_arguments = arguments_storage.get(job.id)
+            arguments_storage = get_arguments_storage(job)
+            stored_arguments = arguments_storage.get()
 
             assert stored_arguments == arguments
 
@@ -423,9 +422,8 @@ class TestProgramApi(APITestCase):
             assert job.config.workers is None
             assert job.config.auto_scaling is True
 
-            program = Program.objects.get(title="Docker-Image-Program", author=user)
-            arguments_storage = get_arguments_storage(user.username, program)
-            stored_arguments = arguments_storage.get(job.id)
+            arguments_storage = get_arguments_storage(job)
+            stored_arguments = arguments_storage.get()
 
             assert stored_arguments == arguments
 
@@ -1054,8 +1052,8 @@ class TestProgramApi(APITestCase):
             assert job.program.provider is None
 
             # Verify arguments are stored in the correct path (user storage, not provider)
-            arguments_storage = get_arguments_storage(user.username, user_program)
-            stored_arguments = arguments_storage.get(job.id)
+            arguments_storage = get_arguments_storage(job)
+            stored_arguments = arguments_storage.get()
             assert stored_arguments == arguments
 
             # Verify the storage path is for user function (no provider in path)

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -25,7 +25,7 @@ from core.models import (
     PLATFORM_PERMISSION_RUN,
     Program,
 )
-from core.services.storage.arguments_storage import ArgumentsStorage
+from core.services.storage import get_arguments_storage
 from tests.utils import TestUtils
 
 
@@ -361,7 +361,7 @@ class TestProgramApi(APITestCase):
             assert job.config.auto_scaling is True
 
             program = Program.objects.get(title="Program", author=user)
-            arguments_storage = ArgumentsStorage(user.username, program)
+            arguments_storage = get_arguments_storage(user.username, program)
             stored_arguments = arguments_storage.get(job.id)
 
             assert stored_arguments == arguments
@@ -424,7 +424,7 @@ class TestProgramApi(APITestCase):
             assert job.config.auto_scaling is True
 
             program = Program.objects.get(title="Docker-Image-Program", author=user)
-            arguments_storage = ArgumentsStorage(user.username, program)
+            arguments_storage = get_arguments_storage(user.username, program)
             stored_arguments = arguments_storage.get(job.id)
 
             assert stored_arguments == arguments
@@ -1054,7 +1054,7 @@ class TestProgramApi(APITestCase):
             assert job.program.provider is None
 
             # Verify arguments are stored in the correct path (user storage, not provider)
-            arguments_storage = ArgumentsStorage(user.username, user_program)
+            arguments_storage = get_arguments_storage(user.username, user_program)
             stored_arguments = arguments_storage.get(job.id)
             assert stored_arguments == arguments
 

--- a/gateway/tests/core/services/runners/test_fleets_runner.py
+++ b/gateway/tests/core/services/runners/test_fleets_runner.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from core.ibm_cloud.code_engine.ce_client.rest import ApiException
+from core.models import Program
 from core.services.runners.abstract_runner import RunnerError
 from core.services.runners.fleets_runner import FleetsRunner
 
@@ -718,7 +719,7 @@ def test_upload_arguments_to_cos_uploads_json():
 
     paths = {"user_arguments_key": "users/1/jobs/j/arguments.json"}
 
-    with patch(f"{_RUNNER_MOD}.ArgumentsStorage") as mock_storage_cls:
+    with patch(f"{_RUNNER_MOD}.get_arguments_storage") as mock_storage_cls:
         mock_storage_cls.return_value.get.return_value = '{"backend_name": "ibm_sherbrooke"}'
         runner._upload_arguments_to_cos(mock_handler, paths)  # pylint: disable=protected-access
 
@@ -788,6 +789,7 @@ def test_submit_includes_gateway_env_vars():
     runner.job.author.id = "user-1"
     runner.job.program.provider = None
     runner.job.program.title = "prog"
+    runner.job.program.runner = Program.FLEETS
 
     runner._project.cos_bucket_user_data_name = "user-bucket"  # pylint: disable=protected-access
     runner._project.cos_bucket_provider_data_name = "prov-bucket"  # pylint: disable=protected-access

--- a/gateway/tests/core/services/storage/test_arguments_storage.py
+++ b/gateway/tests/core/services/storage/test_arguments_storage.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from core.services.storage.arguments_storage import ArgumentsStorage
+from core.services.storage.arguments_storage_ray import RayArgumentsStorage as ArgumentsStorage
 from tests.utils import TestUtils
 
 

--- a/gateway/tests/core/services/storage/test_arguments_storage.py
+++ b/gateway/tests/core/services/storage/test_arguments_storage.py
@@ -13,40 +13,42 @@ class TestArgumentsStorage:
     """Tests for ArgumentsStorage path generation and file operations."""
 
     @pytest.fixture
-    def program(self):
-        return TestUtils.create_program(program_title="myfun", author="user1")
+    def job(self):
+        program = TestUtils.create_program(program_title="myfun", author="user1")
+        return TestUtils.create_job(author="user1", program=program)
 
     @pytest.fixture
-    def program_with_provider(self):
-        return TestUtils.create_program(program_title="myfun", author="user1", provider="provider1")
+    def job_with_provider(self):
+        program = TestUtils.create_program(program_title="myfun", author="user1", provider="provider1")
+        return TestUtils.create_job(author="user1", program=program)
 
-    def test_path_without_provider(self, tmp_path, settings, program):
+    def test_path_without_provider(self, tmp_path, settings, job):
         """User job: path is {username}/arguments/"""
         settings.MEDIA_ROOT = str(tmp_path)
-        storage = ArgumentsStorage(username="user1", function=program)
+        storage = ArgumentsStorage(job=job)
 
         assert storage.sub_path == "user1/arguments"
         assert storage.absolute_path == f"{tmp_path}/user1/arguments"
         assert os.path.exists(storage.absolute_path)
 
-    def test_path_with_provider(self, tmp_path, settings, program_with_provider):
+    def test_path_with_provider(self, tmp_path, settings, job_with_provider):
         """Provider job: path is {username}/{provider}/{function}/arguments/"""
         settings.MEDIA_ROOT = str(tmp_path)
-        storage = ArgumentsStorage(username="user1", function=program_with_provider)
+        storage = ArgumentsStorage(job=job_with_provider)
 
         assert storage.sub_path == "user1/provider1/myfun/arguments"
         assert storage.absolute_path == f"{tmp_path}/user1/provider1/myfun/arguments"
 
-    def test_save_and_get(self, tmp_path, settings, program):
+    def test_save_and_get(self, tmp_path, settings, job):
         """Test saving and retrieving arguments."""
         settings.MEDIA_ROOT = str(tmp_path)
-        storage = ArgumentsStorage(username="user1", function=program)
+        storage = ArgumentsStorage(job=job)
 
         # file not found returns None
-        assert storage.get("id") is None
+        assert storage.get() is None
 
-        storage.save("id", "foo")
-        assert storage.get("id") == "foo"
+        storage.save("foo")
+        assert storage.get() == "foo"
 
-        storage.save("id", "overwrite")
-        assert storage.get("id") == "overwrite"
+        storage.save("overwrite")
+        assert storage.get() == "overwrite"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR prepares the main structure to be able to inject different storages in the platform. The idea behind the refactor was the next:
- Unify inputs through ArgumentsStorage (and potentially among others storages like in this case LogsStorage).
- Create a factory to abstract the usage of the specific implementation for each kind of storage.

### Details and comments

- ArgumentsStorage was divided in two: one for ray and another one for fleets.
- ArgumentsStorage now uses Job as inpit simplifying the instantiation and unifying interfaces with LogsStorage.

This PR works as a first iteration from a bigger work here: #2061 

Co-authored-by: @korgan00 