### PR TITLE
Rename and improve Runtime API permissions

### DIFF
--- a/gateway/api/access_policies/providers.py
+++ b/gateway/api/access_policies/providers.py
@@ -97,7 +97,7 @@ class ProviderAccessPolicy:
         function_title: str,
         accessible_functions: Optional[FunctionAccessResult] = None,
     ) -> bool:
-        """Runtime instances: checks function has provider.files.read permission. Legacy: checks provider admin group."""
+        """Runtime instances: checks function has provider.files.read permission. Legacy:checks provider admin group."""
         if provider is None:
             raise ValueError("provider cannot be None")
         has_access = _check(
@@ -114,7 +114,7 @@ class ProviderAccessPolicy:
         function_title: str,
         accessible_functions: Optional[FunctionAccessResult] = None,
     ) -> bool:
-        """Runtime instances: checks function has provider.files.write permission. Legacy: checks provider admin group."""
+        """Runtime instances: checks function has provider.files.write permission.Legacy:checks provider admin group."""
         if provider is None:
             raise ValueError("provider cannot be None")
         has_access = _check(

--- a/gateway/api/access_policies/providers.py
+++ b/gateway/api/access_policies/providers.py
@@ -7,11 +7,11 @@ from typing import Optional
 
 from core.models import (
     Provider,
-    PLATFORM_PERMISSION_JOB_READ,
-    PLATFORM_PERMISSION_PROVIDER_FILES,
-    PLATFORM_PERMISSION_PROVIDER_JOBS,
+    PLATFORM_PERMISSION_PROVIDER_FILES_READ,
+    PLATFORM_PERMISSION_PROVIDER_FILES_WRITE,
+    PLATFORM_PERMISSION_JOBS_READ,
     PLATFORM_PERMISSION_PROVIDER_LOGS,
-    PLATFORM_PERMISSION_PROVIDER_UPLOAD,
+    PLATFORM_PERMISSION_WRITE,
 )
 from core.domain.authorization.function_access_result import FunctionAccessResult
 
@@ -55,7 +55,7 @@ class ProviderAccessPolicy:
         """Runtime instances: checks function has job.retrieve permission. Legacy: checks provider admin group."""
         if provider is None:
             raise ValueError("provider cannot be None")
-        has_access = _check(user, provider, function_title, accessible_functions, PLATFORM_PERMISSION_JOB_READ)
+        has_access = _check(user, provider, function_title, accessible_functions, PLATFORM_PERMISSION_JOBS_READ)
         if not has_access:
             logger.warning("[can_retrieve_job] provider=%s user_id=%s | no access", provider.name, user.id)
         return has_access
@@ -85,24 +85,43 @@ class ProviderAccessPolicy:
         """Runtime instances: checks function has provider.jobs permission. Legacy: checks provider admin group."""
         if provider is None:
             raise ValueError("provider cannot be None")
-        has_access = _check(user, provider, function_title, accessible_functions, PLATFORM_PERMISSION_PROVIDER_JOBS)
+        has_access = _check(user, provider, function_title, accessible_functions, PLATFORM_PERMISSION_JOBS_READ)
         if not has_access:
             logger.warning("[can_list_jobs] provider=%s user_id=%s | no access", provider.name, user.id)
         return has_access
 
     @staticmethod
-    def can_manage_files(
+    def can_read_files(
         user,
         provider: Provider,
         function_title: str,
         accessible_functions: Optional[FunctionAccessResult] = None,
     ) -> bool:
-        """Runtime instances: checks function has provider.files permission. Legacy: checks provider admin group."""
+        """Runtime instances: checks function has provider.files.read permission. Legacy: checks provider admin group."""
         if provider is None:
             raise ValueError("provider cannot be None")
-        has_access = _check(user, provider, function_title, accessible_functions, PLATFORM_PERMISSION_PROVIDER_FILES)
+        has_access = _check(
+            user, provider, function_title, accessible_functions, PLATFORM_PERMISSION_PROVIDER_FILES_READ
+        )
         if not has_access:
-            logger.warning("[can_manage_files] provider=%s user_id=%s | no access", provider.name, user.id)
+            logger.warning("[can_read_files] provider=%s user_id=%s | no access", provider.name, user.id)
+        return has_access
+
+    @staticmethod
+    def can_write_files(
+        user,
+        provider: Provider,
+        function_title: str,
+        accessible_functions: Optional[FunctionAccessResult] = None,
+    ) -> bool:
+        """Runtime instances: checks function has provider.files.write permission. Legacy: checks provider admin group."""
+        if provider is None:
+            raise ValueError("provider cannot be None")
+        has_access = _check(
+            user, provider, function_title, accessible_functions, PLATFORM_PERMISSION_PROVIDER_FILES_WRITE
+        )
+        if not has_access:
+            logger.warning("[can_write_files] provider=%s user_id=%s | no access", provider.name, user.id)
         return has_access
 
     @staticmethod
@@ -115,7 +134,7 @@ class ProviderAccessPolicy:
         """Runtime instances: checks function has provider.upload permission. Legacy: checks provider admin group."""
         if provider is None:
             raise ValueError("provider cannot be None")
-        has_access = _check(user, provider, function_title, accessible_functions, PLATFORM_PERMISSION_PROVIDER_UPLOAD)
+        has_access = _check(user, provider, function_title, accessible_functions, PLATFORM_PERMISSION_WRITE)
         if not has_access:
             logger.warning("[can_upload_function] provider=%s user_id=%s | no access", provider.name, user.id)
         return has_access

--- a/gateway/api/use_cases/files/provider_delete.py
+++ b/gateway/api/use_cases/files/provider_delete.py
@@ -38,7 +38,7 @@ class FilesProviderDeleteUseCase:
         """
 
         provider = self.provider_repository.get_provider_by_name(name=provider_name)
-        if provider is None or not ProviderAccessPolicy.can_manage_files(
+        if provider is None or not ProviderAccessPolicy.can_write_files(
             user=user, provider=provider, function_title=function_title
         ):
             raise ProviderNotFoundException(provider_name)

--- a/gateway/api/use_cases/files/provider_download.py
+++ b/gateway/api/use_cases/files/provider_download.py
@@ -39,7 +39,7 @@ class FilesProviderDownloadUseCase:
         """
 
         provider = self.provider_repository.get_provider_by_name(name=provider_name)
-        if provider is None or not ProviderAccessPolicy.can_manage_files(
+        if provider is None or not ProviderAccessPolicy.can_read_files(
             user=user, provider=provider, function_title=function_title
         ):
             raise ProviderNotFoundException(provider_name)

--- a/gateway/api/use_cases/files/provider_list.py
+++ b/gateway/api/use_cases/files/provider_list.py
@@ -31,7 +31,7 @@ class FilesProviderListUseCase:
         """
 
         provider = self.provider_repository.get_provider_by_name(name=provider_name)
-        if provider is None or not ProviderAccessPolicy.can_manage_files(
+        if provider is None or not ProviderAccessPolicy.can_read_files(
             user=user, provider=provider, function_title=function_title
         ):
             raise ProviderNotFoundException(provider_name)

--- a/gateway/api/use_cases/files/provider_upload.py
+++ b/gateway/api/use_cases/files/provider_upload.py
@@ -38,7 +38,7 @@ class FilesProviderUploadUseCase:
         """
 
         provider = self.provider_repository.get_provider_by_name(name=provider_name)
-        if provider is None or not ProviderAccessPolicy.can_manage_files(
+        if provider is None or not ProviderAccessPolicy.can_write_files(
             user=user, provider=provider, function_title=function_title
         ):
             raise ProviderNotFoundException(provider_name)

--- a/gateway/api/use_cases/jobs/provider_list.py
+++ b/gateway/api/use_cases/jobs/provider_list.py
@@ -8,7 +8,7 @@ from api.domain.exceptions.provider_not_found_exception import ProviderNotFoundE
 from api.domain.exceptions.function_not_found_exception import FunctionNotFoundException
 from core.domain.authorization.function_access_result import FunctionAccessResult
 from core.model_managers.jobs import JobFilters
-from core.models import Job, PLATFORM_PERMISSION_PROVIDER_JOBS
+from core.models import Job, PLATFORM_PERMISSION_JOBS_READ
 from core.models import Program as Function
 from api.repositories.providers import ProviderRepository
 
@@ -64,7 +64,7 @@ class JobsProviderListUseCase:
         else:
             # Runtime API instances, granularity per function:
             # We get the function titles that the user has access to, and we use them to filter
-            provider_functions = accessible_functions.get_functions_by_provider(PLATFORM_PERMISSION_PROVIDER_JOBS)
+            provider_functions = accessible_functions.get_functions_by_provider(PLATFORM_PERMISSION_JOBS_READ)
             titles = provider_functions.get(filters.provider, set())
             if not titles:
                 # If the user can't access to any function, we hide the provider with a not found

--- a/gateway/api/use_cases/jobs/retrieve.py
+++ b/gateway/api/use_cases/jobs/retrieve.py
@@ -1,10 +1,12 @@
 """This module contains the usecase get_job"""
 
 import logging
+from typing import Optional
 from uuid import UUID
 from django.contrib.auth.models import AbstractUser
 from django.core.exceptions import ObjectDoesNotExist
 from api.domain.exceptions.job_not_found_exception import JobNotFoundException
+from core.domain.authorization.function_access_result import FunctionAccessResult
 from core.models import Job
 from api.access_policies.jobs import JobAccessPolicies
 from core.services.storage.result_storage import ResultStorage
@@ -15,7 +17,13 @@ logger = logging.getLogger("api.JobRetrieveUseCase")
 class JobRetrieveUseCase:
     """Use case for retrieving a single job."""
 
-    def execute(self, job_id: UUID, user: AbstractUser, with_result: bool) -> Job:
+    def execute(
+        self,
+        job_id: UUID,
+        user: AbstractUser,
+        with_result: bool,
+        accessible_functions: Optional[FunctionAccessResult] = None,
+    ) -> Job:
         """
         Retrieve job.
 
@@ -23,6 +31,8 @@ class JobRetrieveUseCase:
             job_id: id of the job to retrieve
             user: author of the job
             with_result: retrieve the job with out without the job result
+            accessible_functions: result from FunctionAccessClient; if None or
+                use_legacy_authorization=True, falls back to Django groups
 
         Returns:
             Job: job found
@@ -31,7 +41,7 @@ class JobRetrieveUseCase:
         if job is None:
             raise JobNotFoundException(str(job_id))
 
-        if not JobAccessPolicies.can_access(user, job):
+        if not JobAccessPolicies.can_access(user, job, accessible_functions=accessible_functions):
             raise JobNotFoundException(str(job_id))
 
         can_read_result = JobAccessPolicies.can_read_result(user, job)

--- a/gateway/api/v1/views/jobs/retrieve.py
+++ b/gateway/api/v1/views/jobs/retrieve.py
@@ -22,6 +22,7 @@ from api.use_cases.jobs.retrieve import JobRetrieveUseCase
 from api.v1.endpoint_decorator import endpoint
 from api.v1.exception_handler import endpoint_handle_exceptions
 from api.v1.views.swagger_utils import standard_error_responses
+from core.domain.authorization.function_access_result import FunctionAccessResult
 from core.models import Job
 
 logger = logging.getLogger("api.api.v1.views.jobs.retrieve")
@@ -149,7 +150,14 @@ def retrieve(request: Request, job_id: UUID) -> Response:
     with_result: bool = params.validated_data["with_result"]
 
     user = cast(AbstractUser, request.user)
-    job = JobRetrieveUseCase().execute(job_id, user, with_result)
+    accessible_functions = cast(FunctionAccessResult, request.auth.accessible_functions)
+    logger.info(
+        "[jobs-retrieve] user_id=%s job_id=%s accessible_functions=%s",
+        user.id,
+        job_id,
+        accessible_functions,
+    )
+    job = JobRetrieveUseCase().execute(job_id, user, with_result, accessible_functions=accessible_functions)
     logger.info(
         "[jobs-retrieve] user_id=%s job_id=%s program=%s | Job retrieved ok",
         user.id,

--- a/gateway/core/models.py
+++ b/gateway/core/models.py
@@ -25,13 +25,15 @@ RUN_PROGRAM_PERMISSION = "run_program"
 # Platform permissions (Runtime API instances access client)
 PLATFORM_PERMISSION_READ = "function.read"  # see function in catalog and retrieve its metadata
 PLATFORM_PERMISSION_RUN = "function.run"  # execute a new job of this function
-PLATFORM_PERMISSION_JOB_READ = "function.job.read"  # retrieve a specific job from this function (non-author access)
-PLATFORM_PERMISSION_USER_FILES = "function.files"  # list, download, upload and delete files in user space
+PLATFORM_PERMISSION_JOB_READ = "function-job.read"  # retrieve a specific job from this function (non-author access)
+PLATFORM_PERMISSION_USER_FILES = "function-files.read"  # list, download, upload and delete files in user space
 # Provider admin permissions
-PLATFORM_PERMISSION_PROVIDER_UPLOAD = "function.provider.upload"  # create or update this function's code
-PLATFORM_PERMISSION_PROVIDER_JOBS = "function.provider.jobs"  # list jobs from all users of this function
-PLATFORM_PERMISSION_PROVIDER_LOGS = "function.provider.logs"  # read provider-side logs of jobs from this function
-PLATFORM_PERMISSION_PROVIDER_FILES = "function.provider.files"  # list, download, upload, delete files in provider space
+PLATFORM_PERMISSION_PROVIDER_UPLOAD = "function.write"  # create or update this function's code
+PLATFORM_PERMISSION_PROVIDER_JOBS = "function-job.read"  # list jobs from all users of this function
+PLATFORM_PERMISSION_PROVIDER_LOGS = "function-provider-logs.read"  # read provider-side logs of jobs from this function
+PLATFORM_PERMISSION_PROVIDER_FILES = (
+    "function-provider-files.write"  # list, download, upload, delete files in provider space
+)
 
 
 def get_upload_path(instance, filename):

--- a/gateway/core/models.py
+++ b/gateway/core/models.py
@@ -25,15 +25,14 @@ RUN_PROGRAM_PERMISSION = "run_program"
 # Platform permissions (Runtime API instances access client)
 PLATFORM_PERMISSION_READ = "function.read"  # see function in catalog and retrieve its metadata
 PLATFORM_PERMISSION_RUN = "function.run"  # execute a new job of this function
-PLATFORM_PERMISSION_JOB_READ = "function-job.read"  # retrieve a specific job from this function (non-author access)
-PLATFORM_PERMISSION_USER_FILES = "function-files.read"  # list, download, upload and delete files in user space
+PLATFORM_PERMISSION_USER_FILES_READ = "function-files.read"  # list and download files in user space
+PLATFORM_PERMISSION_USER_FILES_WRITE = "function-files.write"  # upload and delete files in user space
 # Provider admin permissions
-PLATFORM_PERMISSION_PROVIDER_UPLOAD = "function.write"  # create or update this function's code
-PLATFORM_PERMISSION_PROVIDER_JOBS = "function-job.read"  # list jobs from all users of this function
+PLATFORM_PERMISSION_WRITE = "function.write"  # create or update this function's code
+PLATFORM_PERMISSION_JOBS_READ = "function-job.read"  # list or retrieve jobs from this function (non-author access)
 PLATFORM_PERMISSION_PROVIDER_LOGS = "function-provider-logs.read"  # read provider-side logs of jobs from this function
-PLATFORM_PERMISSION_PROVIDER_FILES = (
-    "function-provider-files.write"  # list, download, upload, delete files in provider space
-)
+PLATFORM_PERMISSION_PROVIDER_FILES_READ = "function-provider-files.read"  # list and download files in provider space
+PLATFORM_PERMISSION_PROVIDER_FILES_WRITE = "function-provider-files.write"  # upload and delete files in provider space
 
 
 def get_upload_path(instance, filename):

--- a/gateway/tests/api/access_policies/test_jobs.py
+++ b/gateway/tests/api/access_policies/test_jobs.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import User, Group
 
 from api.access_policies.jobs import JobAccessPolicies
 from core.domain.authorization.function_access_result import FunctionAccessResult
-from core.models import Program, Job, Provider, PLATFORM_PERMISSION_JOB_READ, PLATFORM_PERMISSION_PROVIDER_LOGS
+from core.models import Program, Job, Provider, PLATFORM_PERMISSION_JOBS_READ, PLATFORM_PERMISSION_PROVIDER_LOGS
 from tests.utils import create_function_access_result
 
 pytestmark = pytest.mark.django_db
@@ -70,12 +70,12 @@ class TestCanAccess:
         @pytest.mark.parametrize(
             "permissions,expected",
             [
-                ({PLATFORM_PERMISSION_JOB_READ}, True),
+                ({PLATFORM_PERMISSION_JOBS_READ}, True),
                 ({"other-permission"}, False),
             ],
         )
-        def test_access_depends_on_job_read_permission(self, job_author, permissions, expected):
-            """Access is granted if the entry includes PLATFORM_PERMISSION_JOB_READ for the function."""
+        def test_access_depends_on_provider_jobs_permission(self, job_author, permissions, expected):
+            """Access is granted if the entry includes PLATFORM_PERMISSION_JOBS_READ for the function."""
             admin = User.objects.create_user(username="admin_ext")
             provider = Provider.objects.create(name="ext-provider")
             program = Program.objects.create(title="fn", author=job_author, provider=provider)

--- a/gateway/tests/api/access_policies/test_providers.py
+++ b/gateway/tests/api/access_policies/test_providers.py
@@ -10,11 +10,11 @@ from core.domain.authorization.function_access_result import FunctionAccessResul
 from core.domain.business_models import BusinessModel
 from core.models import (
     Job,
-    PLATFORM_PERMISSION_JOB_READ,
-    PLATFORM_PERMISSION_PROVIDER_FILES,
-    PLATFORM_PERMISSION_PROVIDER_JOBS,
+    PLATFORM_PERMISSION_PROVIDER_FILES_READ,
+    PLATFORM_PERMISSION_PROVIDER_FILES_WRITE,
+    PLATFORM_PERMISSION_JOBS_READ,
     PLATFORM_PERMISSION_PROVIDER_LOGS,
-    PLATFORM_PERMISSION_PROVIDER_UPLOAD,
+    PLATFORM_PERMISSION_WRITE,
     Provider,
 )
 
@@ -40,12 +40,12 @@ class TestCanRetrieveJob:
     @pytest.mark.parametrize(
         "permissions,expected",
         [
-            ({PLATFORM_PERMISSION_JOB_READ}, True),
+            ({PLATFORM_PERMISSION_JOBS_READ}, True),
             (set(), False),
         ],
     )
     def test_grant(self, permissions, expected):
-        """Access depends on whether accessible_functions includes JOB_READ for the provider."""
+        """Access depends on whether accessible_functions includes PROVIDER_JOBS for the provider."""
         user = User.objects.create_user(username="client")
         provider = Provider.objects.create(name="provider")
         functions = [_entry("provider", permissions)] if permissions else []
@@ -108,12 +108,12 @@ class TestCanListJobs:
     @pytest.mark.parametrize(
         "permissions,expected",
         [
-            ({PLATFORM_PERMISSION_PROVIDER_JOBS}, True),
+            ({PLATFORM_PERMISSION_JOBS_READ}, True),
             (set(), False),
         ],
     )
     def test_grant(self, permissions, expected):
-        """Job list access is granted if the entry includes PLATFORM_PERMISSION_PROVIDER_JOBS."""
+        """Job list access is granted if the entry includes PLATFORM_PERMISSION_JOBS_READ."""
         user = User.objects.create_user(username="client")
         provider = Provider.objects.create(name="provider")
         functions = [_entry("provider", permissions)] if permissions else []
@@ -121,33 +121,50 @@ class TestCanListJobs:
         assert ProviderAccessPolicy.can_list_jobs(user, provider, "fnc", accessible) is expected
 
 
-class TestCanManageFiles:
+class TestCanReadFiles:
     @pytest.mark.parametrize(
         "permissions,expected",
         [
-            ({PLATFORM_PERMISSION_PROVIDER_FILES}, True),
+            ({PLATFORM_PERMISSION_PROVIDER_FILES_READ}, True),
             (set(), False),
         ],
     )
     def test_grant(self, permissions, expected):
-        """File management access is granted if the entry includes PLATFORM_PERMISSION_PROVIDER_FILES."""
+        """File read access is granted if the entry includes PLATFORM_PERMISSION_PROVIDER_FILES_READ."""
         user = User.objects.create_user(username="client")
         provider = Provider.objects.create(name="provider")
         functions = [_entry("provider", permissions)] if permissions else []
         accessible = FunctionAccessResult(use_legacy_authorization=False, functions=functions)
-        assert ProviderAccessPolicy.can_manage_files(user, provider, "fnc", accessible) is expected
+        assert ProviderAccessPolicy.can_read_files(user, provider, "fnc", accessible) is expected
+
+
+class TestCanWriteFiles:
+    @pytest.mark.parametrize(
+        "permissions,expected",
+        [
+            ({PLATFORM_PERMISSION_PROVIDER_FILES_WRITE}, True),
+            (set(), False),
+        ],
+    )
+    def test_grant(self, permissions, expected):
+        """File write access is granted if the entry includes PLATFORM_PERMISSION_PROVIDER_FILES_WRITE."""
+        user = User.objects.create_user(username="client")
+        provider = Provider.objects.create(name="provider")
+        functions = [_entry("provider", permissions)] if permissions else []
+        accessible = FunctionAccessResult(use_legacy_authorization=False, functions=functions)
+        assert ProviderAccessPolicy.can_write_files(user, provider, "fnc", accessible) is expected
 
 
 class TestCanUploadFunction:
     @pytest.mark.parametrize(
         "permissions,expected",
         [
-            ({PLATFORM_PERMISSION_PROVIDER_UPLOAD}, True),
+            ({PLATFORM_PERMISSION_WRITE}, True),
             (set(), False),
         ],
     )
     def test_grant(self, permissions, expected):
-        """Function upload access is granted if the entry includes PLATFORM_PERMISSION_PROVIDER_UPLOAD."""
+        """Function upload access is granted if the entry includes PLATFORM_PERMISSION_WRITE."""
         user = User.objects.create_user(username="client")
         provider = Provider.objects.create(name="provider")
         functions = [_entry("provider", permissions)] if permissions else []

--- a/gateway/tests/api/test_job.py
+++ b/gateway/tests/api/test_job.py
@@ -17,7 +17,7 @@ from core.domain.authorization.function_access_entry import FunctionAccessEntry
 from core.domain.authorization.function_access_result import FunctionAccessResult
 from core.domain.business_models import BusinessModel
 from core.model_managers.job_events import JobEventContext, JobEventOrigin, JobEventType
-from core.models import Job, JobEvent, PLATFORM_PERMISSION_PROVIDER_JOBS, Program, Provider, RuntimeJob
+from core.models import Job, JobEvent, PLATFORM_PERMISSION_JOBS_READ, Program, Provider, RuntimeJob
 
 
 @pytest.mark.django_db
@@ -279,7 +279,7 @@ class TestJobApi:
         entry = FunctionAccessEntry(
             provider_name="default",
             function_title="Docker-Image-Program",
-            permissions={PLATFORM_PERMISSION_PROVIDER_JOBS},
+            permissions={PLATFORM_PERMISSION_JOBS_READ},
             business_model=BusinessModel.SUBSIDIZED,
         )
         accessible = FunctionAccessResult(use_legacy_authorization=False, functions=[entry])
@@ -307,91 +307,6 @@ class TestJobApi:
 
         assert jobs_response.status_code == status.HTTP_404_NOT_FOUND
         assert jobs_response.data.get("message") == "Provider default doesn't exist."
-
-    def test_job_detail(self, settings):
-        """Tests job detail authorized."""
-        shutil.copytree(self._fake_media_path, settings.MEDIA_ROOT, dirs_exist_ok=True)
-        self._authorize("test_user")
-
-        jobs_response = self.client.get(
-            reverse("v1:retrieve", args=["8317718f-5c0d-4fb6-9947-72e480b8a348"]),
-            format="json",
-        )
-        assert jobs_response.status_code == status.HTTP_200_OK
-        assert jobs_response.data.get("result") == '{"ultimate": 42}'
-        assert jobs_response.data.get("business_model") == BusinessModel.SUBSIDIZED
-
-    def test_job_detail_without_result_param(self):
-        """Tests job detail authorized."""
-        self._authorize("test_user")
-
-        jobs_response = self.client.get(
-            reverse("v1:retrieve", args=["8317718f-5c0d-4fb6-9947-72e480b8a348"]) + "?with_result=false",
-            format="json",
-        )
-        assert jobs_response.status_code == status.HTTP_200_OK
-        assert jobs_response.data.get("result") is None
-        assert jobs_response.data.get("business_model") == BusinessModel.SUBSIDIZED
-
-    def test_job_detail_without_result_file(self):
-        """Tests job detail authorized."""
-        self._authorize("test_user")
-
-        jobs_response = self.client.get(
-            reverse("v1:retrieve", args=["57fc2e4d-267f-40c6-91a3-38153272e764"]),
-            format="json",
-        )
-        assert jobs_response.status_code == status.HTTP_200_OK
-        assert jobs_response.data.get("result") == '{"somekey":1}'
-
-    def test_job_provider_detail(self):
-        """Tests job detail authorized."""
-        self._authorize("test_user_2")
-
-        jobs_response = self.client.get(
-            reverse("v1:retrieve", args=["1a7947f9-6ae8-4e3d-ac1e-e7d608deec86"]),
-            format="json",
-        )
-        assert jobs_response.status_code == status.HTTP_200_OK
-        assert jobs_response.data.get("status") == "QUEUED"
-        assert jobs_response.data.get("result") is None
-
-    def test_not_authorized_job_detail(self):
-        """Tests job detail fails trying to access to other user job."""
-        self._authorize("test_user")
-
-        jobs_response = self.client.get(
-            reverse("v1:retrieve", args=["1a7947f9-6ae8-4e3d-ac1e-e7d608deec84"]),
-            format="json",
-        )
-        assert jobs_response.status_code == status.HTTP_404_NOT_FOUND
-
-    def test_job_result_uses_author_username(self, settings):
-        """
-        Tests that job results are retrieved using job.author.username,
-        not the requesting user's username. This ensures results are read
-        from the correct storage path where they were saved.
-
-        Note: Currently can_read_result() only allows authors to read results,
-        but this test validates the correct behavior if permissions change in
-        the future to allow provider admins to read results.
-        """
-        shutil.copytree(self._fake_media_path, settings.MEDIA_ROOT, dirs_exist_ok=True)
-
-        # Get a job created by test_user (author=1)
-        job = Job.objects.get(pk="8317718f-5c0d-4fb6-9947-72e480b8a348")
-        assert job.author.username == "test_user"
-
-        # Verify results file exists in author's directory
-        result_storage = ResultStorage(job.author.username)
-        result = result_storage.get(str(job.id))
-        assert result is not None
-
-        # If we incorrectly used a different user's username, we wouldn't find it
-        different_user = User.objects.get(username="test_user_2")
-        wrong_result_storage = ResultStorage(different_user.username)
-        wrong_result = wrong_result_storage.get(str(job.id))
-        assert wrong_result is None  # Should not find result in wrong path
 
     def test_job_save_result(self, settings):
         """Tests job results save."""
@@ -1049,5 +964,141 @@ class TestJobApi:
             {"type": JobEventType.ERROR},
             format="json",
         )
-
         assert job_event_response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+class TestRetrieveJob:
+    """Tests for the v1:retrieve endpoint grouped by authorization path."""
+
+    _fake_media_path = os.path.normpath(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "resources", "fake_media")
+    )
+
+    @pytest.fixture(autouse=True)
+    def _load_fixtures(self, tmp_path, settings):
+        from django.core.management import call_command
+
+        call_command("loaddata", "tests/fixtures/fixtures.json")
+        settings.MEDIA_ROOT = str(tmp_path)
+
+    @pytest.fixture()
+    def authorize(self):
+        """Returns a callable that authenticates an APIClient and returns it."""
+        client = APIClient()
+
+        def _authorize(username, accessible_functions=FunctionAccessResult(use_legacy_authorization=True)):
+            user, _ = User.objects.get_or_create(username=username)
+            token = MagicMock()
+            token.accessible_functions = accessible_functions
+            client.force_authenticate(user=user, token=token)
+            return client
+
+        return _authorize
+
+    def test_author_retrieves_with_result(self, authorize, settings):
+        """Job author can retrieve their own job including the result."""
+        shutil.copytree(self._fake_media_path, settings.MEDIA_ROOT, dirs_exist_ok=True)
+        client = authorize("test_user")
+
+        response = client.get(reverse("v1:retrieve", args=["8317718f-5c0d-4fb6-9947-72e480b8a348"]), format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data.get("result") == '{"ultimate": 42}'
+        assert response.data.get("business_model") == BusinessModel.SUBSIDIZED
+
+    def test_author_retrieves_without_result_param(self, authorize):
+        """?with_result=false returns the job without the result field."""
+        client = authorize("test_user")
+
+        response = client.get(
+            reverse("v1:retrieve", args=["8317718f-5c0d-4fb6-9947-72e480b8a348"]) + "?with_result=false",
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data.get("result") is None
+        assert response.data.get("business_model") == BusinessModel.SUBSIDIZED
+
+    def test_author_retrieves_inline_result(self, authorize):
+        """Author retrieves a job whose result is stored inline in the DB."""
+        client = authorize("test_user")
+
+        response = client.get(reverse("v1:retrieve", args=["57fc2e4d-267f-40c6-91a3-38153272e764"]), format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data.get("result") == '{"somekey":1}'
+
+    def test_result_read_from_authors_storage(self, settings):
+        """Result is read from the job author's storage path, not the requesting user's."""
+        shutil.copytree(self._fake_media_path, settings.MEDIA_ROOT, dirs_exist_ok=True)
+
+        job = Job.objects.get(pk="8317718f-5c0d-4fb6-9947-72e480b8a348")
+        assert job.author.username == "test_user"
+
+        result_storage = ResultStorage(job.author.username)
+        assert result_storage.get(str(job.id)) is not None
+
+        different_user = User.objects.get(username="test_user_2")
+        wrong_result_storage = ResultStorage(different_user.username)
+        assert wrong_result_storage.get(str(job.id)) is None
+
+    class TestLegacyGroups:
+        def test_provider_admin_can_retrieve(self, authorize):
+            """Provider admin (via Django groups) can retrieve a provider job they don't own."""
+            # job_author != requester: admin accesses a job created by a different user
+            job_author = User.objects.create_user(username="job_author_legacy")
+            requester = User.objects.get(username="test_user_2")  # belongs to default-group (admin)
+            provider = Provider.objects.get(name="default")
+            program = Program.objects.create(title="fn", author=job_author, provider=provider)
+            job = Job.objects.create(author=job_author, program=program, status=Job.QUEUED)
+
+            client = authorize("test_user_2")
+            response = client.get(reverse("v1:retrieve", args=[job.id]), format="json")
+            assert response.status_code == status.HTTP_200_OK
+            assert response.data.get("status") == "QUEUED"
+
+        def test_non_admin_cannot_retrieve(self, authorize):
+            """User not in any admin group cannot retrieve a provider job they don't own."""
+            # job_author != requester: test_user is not in default-group
+            job_author = User.objects.create_user(username="job_author_non_admin")
+            provider = Provider.objects.get(name="default")
+            program = Program.objects.create(title="fn", author=job_author, provider=provider)
+            job = Job.objects.create(author=job_author, program=program, status=Job.QUEUED)
+
+            client = authorize("test_user")  # not in default-group
+            response = client.get(reverse("v1:retrieve", args=[job.id]), format="json")
+            assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    class TestRuntimeInstances:
+        def test_jobs_read_permission_grants_access(self, authorize):
+            """PLATFORM_PERMISSION_JOBS_READ grants retrieve access to a job the requester doesn't own."""
+            # job_author != requester: test_user has JOBS_READ for the function but is not the author
+            job_author = User.objects.create_user(username="job_author_rt_ok")
+            provider = Provider.objects.get(name="default")
+            program = Program.objects.create(title="fn", author=job_author, provider=provider)
+            job = Job.objects.create(author=job_author, program=program, status=Job.QUEUED)
+
+            entry = FunctionAccessEntry(
+                provider_name="default",
+                function_title="fn",
+                permissions={PLATFORM_PERMISSION_JOBS_READ},
+                business_model=BusinessModel.SUBSIDIZED,
+            )
+            accessible = FunctionAccessResult(use_legacy_authorization=False, functions=[entry])
+            client = authorize("test_user", accessible_functions=accessible)
+
+            response = client.get(reverse("v1:retrieve", args=[job.id]), format="json")
+            assert response.status_code == status.HTTP_200_OK
+            assert response.data.get("status") == "QUEUED"
+
+        def test_no_permission_denies_access(self, authorize):
+            """No PLATFORM_PERMISSION_JOBS_READ → 404 for a job the requester doesn't own."""
+            # job_author != requester: test_user has no permissions for the function
+            job_author = User.objects.create_user(username="job_author_rt_deny")
+            provider = Provider.objects.get(name="default")
+            program = Program.objects.create(title="fn", author=job_author, provider=provider)
+            job = Job.objects.create(author=job_author, program=program, status=Job.QUEUED)
+
+            accessible = FunctionAccessResult(use_legacy_authorization=False, functions=[])
+            client = authorize("test_user", accessible_functions=accessible)
+
+            response = client.get(reverse("v1:retrieve", args=[job.id]), format="json")
+            assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -19,8 +19,8 @@ from core.model_managers.job_events import JobEventContext, JobEventOrigin, JobE
 from core.models import (
     Job,
     JobEvent,
-    PLATFORM_PERMISSION_PROVIDER_JOBS,
-    PLATFORM_PERMISSION_PROVIDER_UPLOAD,
+    PLATFORM_PERMISSION_JOBS_READ,
+    PLATFORM_PERMISSION_WRITE,
     PLATFORM_PERMISSION_READ,
     PLATFORM_PERMISSION_RUN,
     Program,
@@ -1276,12 +1276,12 @@ class TestProgramApiRuntimeInstances:
         @pytest.mark.parametrize(
             "permissions,expected_status",
             [
-                ({PLATFORM_PERMISSION_PROVIDER_UPLOAD}, status.HTTP_200_OK),
+                ({PLATFORM_PERMISSION_WRITE}, status.HTTP_200_OK),
                 (set(), status.HTTP_404_NOT_FOUND),
             ],
         )
         def test_upload_provider_function(self, client, authorize, permissions, expected_status):
-            """upload() checks PLATFORM_PERMISSION_PROVIDER_UPLOAD in accessible_functions."""
+            """upload() checks PLATFORM_PERMISSION_WRITE in accessible_functions."""
             TestUtils.get_or_create_provider(provider="my-provider")
             authorize("runtime-user", create_function_access_result("my-provider", "my-func", permissions))
 
@@ -1317,12 +1317,12 @@ class TestProgramApiRuntimeInstances:
         @pytest.mark.parametrize(
             "permissions,expected_job_count",
             [
-                ({PLATFORM_PERMISSION_PROVIDER_JOBS}, 2),  # provider admin sees all jobs
+                ({PLATFORM_PERMISSION_JOBS_READ}, 2),  # provider admin sees all jobs
                 (set(), 1),  # regular user sees only own job
             ],
         )
         def test_get_jobs(self, client, authorize, permissions, expected_job_count):
-            """get_jobs() checks PLATFORM_PERMISSION_PROVIDER_JOBS in accessible_functions."""
+            """get_jobs() checks PLATFORM_PERMISSION_JOBS_READ in accessible_functions."""
             program = TestUtils.create_program(program_title="my-func", author="func-author", provider="my-provider")
             user, _ = User.objects.get_or_create(username="runtime-user")
             other_user, _ = User.objects.get_or_create(username="other-user")

--- a/gateway/tests/api/use_cases/jobs/test_provider_list.py
+++ b/gateway/tests/api/use_cases/jobs/test_provider_list.py
@@ -8,7 +8,7 @@ from api.domain.exceptions.function_not_found_exception import FunctionNotFoundE
 from api.domain.exceptions.provider_not_found_exception import ProviderNotFoundException
 from api.use_cases.jobs.provider_list import JobsProviderListUseCase
 from core.model_managers.jobs import JobFilters
-from core.models import Job, PLATFORM_PERMISSION_PROVIDER_JOBS, Program, Provider
+from core.models import Job, PLATFORM_PERMISSION_JOBS_READ, Program, Provider
 from tests.utils import create_function_access_result
 
 pytestmark = pytest.mark.django_db
@@ -130,14 +130,14 @@ class TestListJobs:
         @pytest.mark.parametrize(
             "permissions,expected_total",
             [
-                ({PLATFORM_PERMISSION_PROVIDER_JOBS}, 2),
+                ({PLATFORM_PERMISSION_JOBS_READ}, 2),
                 ({"other-permission"}, None),
             ],
         )
         def test_access_depends_on_provider_jobs_permission(
             self, user, provider, function, jobs, permissions, expected_total
         ):
-            """Only PLATFORM_PERMISSION_PROVIDER_JOBS grants access; any other permission hides the provider."""
+            """Only PLATFORM_PERMISSION_JOBS_READ grants access; any other permission hides the provider."""
             filters = JobFilters(provider="my-provider")
             accessible = create_function_access_result("my-provider", "my-function", permissions)
             if expected_total is None:
@@ -173,9 +173,7 @@ class TestListJobs:
             """Filter by function name returns only that function's jobs;
             a function not in DB raises FunctionNotFoundException even if access is granted."""
             filters = JobFilters(provider="my-provider", function=function_filter)
-            accessible = create_function_access_result(
-                "my-provider", function_filter, {PLATFORM_PERMISSION_PROVIDER_JOBS}
-            )
+            accessible = create_function_access_result("my-provider", function_filter, {PLATFORM_PERMISSION_JOBS_READ})
             if expected is FunctionNotFoundException:
                 with pytest.raises(FunctionNotFoundException):
                     JobsProviderListUseCase().execute(user=user, filters=filters, accessible_functions=accessible)

--- a/gateway/tests/api/use_cases/jobs/test_retrieve.py
+++ b/gateway/tests/api/use_cases/jobs/test_retrieve.py
@@ -1,6 +1,7 @@
 """Unit tests for JobRetrieveUseCase."""
 
 import pytest
+import uuid
 from django.contrib.auth.models import Group, User
 
 from api.domain.exceptions.job_not_found_exception import JobNotFoundException
@@ -60,7 +61,6 @@ class TestJobRetrieveUseCase:
 
     def test_not_found_raises_exception(self, author):
         """Non-existent job ID raises JobNotFoundException."""
-        import uuid
 
         with pytest.raises(Job.DoesNotExist):
             JobRetrieveUseCase().execute(uuid.uuid4(), author, with_result=False)

--- a/gateway/tests/api/use_cases/jobs/test_retrieve.py
+++ b/gateway/tests/api/use_cases/jobs/test_retrieve.py
@@ -1,0 +1,109 @@
+"""Unit tests for JobRetrieveUseCase."""
+
+import pytest
+from django.contrib.auth.models import Group, User
+
+from api.domain.exceptions.job_not_found_exception import JobNotFoundException
+from api.use_cases.jobs.retrieve import JobRetrieveUseCase
+from core.domain.authorization.function_access_result import FunctionAccessResult
+from core.models import Job, PLATFORM_PERMISSION_JOBS_READ, Program, Provider
+from tests.utils import create_function_access_result
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture()
+def author():
+    return User.objects.create_user(username="author")
+
+
+@pytest.fixture()
+def other_user():
+    return User.objects.create_user(username="other")
+
+
+@pytest.fixture()
+def provider():
+    return Provider.objects.create(name="my-provider")
+
+
+@pytest.fixture()
+def provider_with_admin(provider, other_user):
+    g = Group.objects.create(name="my-provider-group")
+    other_user.groups.add(g)
+    provider.admin_groups.add(g)
+    return provider
+
+
+@pytest.fixture()
+def serverless_job(author):
+    program = Program.objects.create(title="my-function", author=author)
+    return Job.objects.create(author=author, program=program)
+
+
+@pytest.fixture()
+def provider_job(author, provider):
+    program = Program.objects.create(title="my-function", author=author, provider=provider)
+    return Job.objects.create(author=author, program=program)
+
+
+class TestJobRetrieveUseCase:
+    def test_author_can_retrieve_own_job(self, author, serverless_job):
+        """Job author can always retrieve their own job."""
+        job = JobRetrieveUseCase().execute(serverless_job.id, author, with_result=False)
+        assert job.id == serverless_job.id
+
+    def test_non_author_cannot_retrieve_serverless_job(self, other_user, serverless_job):
+        """Non-author cannot retrieve a serverless job (no provider, no permission path)."""
+        with pytest.raises(JobNotFoundException):
+            JobRetrieveUseCase().execute(serverless_job.id, other_user, with_result=False)
+
+    def test_not_found_raises_exception(self, author):
+        """Non-existent job ID raises JobNotFoundException."""
+        import uuid
+
+        with pytest.raises(Job.DoesNotExist):
+            JobRetrieveUseCase().execute(uuid.uuid4(), author, with_result=False)
+
+    class TestLegacyGroups:
+        def test_provider_admin_can_retrieve(self, other_user, provider_job, provider_with_admin):
+            """Provider admin (via Django groups) can retrieve jobs from their provider."""
+            job = JobRetrieveUseCase().execute(provider_job.id, other_user, with_result=False)
+            assert job.id == provider_job.id
+
+        def test_non_admin_cannot_retrieve(self, other_user, provider_job):
+            """User without admin group cannot retrieve a provider job they don't own."""
+            with pytest.raises(JobNotFoundException):
+                JobRetrieveUseCase().execute(provider_job.id, other_user, with_result=False)
+
+    class TestRuntimeInstances:
+        @pytest.mark.parametrize(
+            "permissions,should_raise",
+            [
+                ({PLATFORM_PERMISSION_JOBS_READ}, False),
+                ({"other-permission"}, True),
+                (set(), True),
+            ],
+        )
+        def test_access_depends_on_jobs_read_permission(self, author, other_user, provider, permissions, should_raise):
+            """Non-author access requires PLATFORM_PERMISSION_JOBS_READ for the function."""
+            program = Program.objects.create(title="fn", author=author, provider=provider)
+            job = Job.objects.create(author=author, program=program)
+            accessible = create_function_access_result("my-provider", "fn", permissions)
+
+            if should_raise:
+                with pytest.raises(JobNotFoundException):
+                    JobRetrieveUseCase().execute(job.id, other_user, with_result=False, accessible_functions=accessible)
+            else:
+                result = JobRetrieveUseCase().execute(
+                    job.id, other_user, with_result=False, accessible_functions=accessible
+                )
+                assert result.id == job.id
+
+        def test_author_always_succeeds_regardless_of_accessible_functions(self, author, provider_job):
+            """Author can always retrieve their job even with empty accessible_functions."""
+            accessible = FunctionAccessResult(use_legacy_authorization=False, functions=[])
+            job = JobRetrieveUseCase().execute(
+                provider_job.id, author, with_result=False, accessible_functions=accessible
+            )
+            assert job.id == provider_job.id

--- a/gateway/tests/api/use_cases/jobs/test_retrieve.py
+++ b/gateway/tests/api/use_cases/jobs/test_retrieve.py
@@ -78,27 +78,27 @@ class TestJobRetrieveUseCase:
 
     class TestRuntimeInstances:
         @pytest.mark.parametrize(
-            "permissions,should_raise",
+            "permissions,grant",
             [
-                ({PLATFORM_PERMISSION_JOBS_READ}, False),
-                ({"other-permission"}, True),
-                (set(), True),
+                ({PLATFORM_PERMISSION_JOBS_READ}, True),
+                ({"other-permission"}, False),
+                (set(), False),
             ],
         )
-        def test_access_depends_on_jobs_read_permission(self, author, other_user, provider, permissions, should_raise):
+        def test_access_depends_on_jobs_read_permission(self, author, other_user, provider, permissions, grant):
             """Non-author access requires PLATFORM_PERMISSION_JOBS_READ for the function."""
             program = Program.objects.create(title="fn", author=author, provider=provider)
             job = Job.objects.create(author=author, program=program)
             accessible = create_function_access_result("my-provider", "fn", permissions)
 
-            if should_raise:
-                with pytest.raises(JobNotFoundException):
-                    JobRetrieveUseCase().execute(job.id, other_user, with_result=False, accessible_functions=accessible)
-            else:
+            if grant:
                 result = JobRetrieveUseCase().execute(
                     job.id, other_user, with_result=False, accessible_functions=accessible
                 )
                 assert result.id == job.id
+            else:
+                with pytest.raises(JobNotFoundException):
+                    JobRetrieveUseCase().execute(job.id, other_user, with_result=False, accessible_functions=accessible)
 
         def test_author_always_succeeds_regardless_of_accessible_functions(self, author, provider_job):
             """Author can always retrieve their job even with empty accessible_functions."""

--- a/gateway/tests/core/domain/authorization/test_function_access_result.py
+++ b/gateway/tests/core/domain/authorization/test_function_access_result.py
@@ -2,7 +2,7 @@
 
 from core.domain.authorization.function_access_entry import FunctionAccessEntry
 from core.domain.authorization.function_access_result import FunctionAccessResult
-from core.models import PLATFORM_PERMISSION_RUN, PLATFORM_PERMISSION_READ, PLATFORM_PERMISSION_PROVIDER_JOBS
+from core.models import PLATFORM_PERMISSION_RUN, PLATFORM_PERMISSION_READ, PLATFORM_PERMISSION_JOBS_READ
 
 
 def _entry(provider_name, function_title, permissions, business_model="SUBSIDIZED"):
@@ -28,12 +28,12 @@ def test_get_function():
 
 def test_has_permission_for_provider():
     entries = [
-        _entry("prov", "func1", {PLATFORM_PERMISSION_PROVIDER_JOBS}),
+        _entry("prov", "func1", {PLATFORM_PERMISSION_JOBS_READ}),
         _entry("prov", "func2", {PLATFORM_PERMISSION_READ}),
     ]
     result = FunctionAccessResult(use_legacy_authorization=False, functions=entries)
-    assert result.has_permission_for_provider("prov", PLATFORM_PERMISSION_PROVIDER_JOBS) is True
-    assert result.has_permission_for_provider("prov", PLATFORM_PERMISSION_PROVIDER_JOBS) is True
+    assert result.has_permission_for_provider("prov", PLATFORM_PERMISSION_JOBS_READ) is True
+    assert result.has_permission_for_provider("prov", PLATFORM_PERMISSION_JOBS_READ) is True
     assert result.has_permission_for_provider("prov", PLATFORM_PERMISSION_RUN) is False
 
 


### PR DESCRIPTION
### Summary

Rename and restructure Runtime API permission constants to match the IBM Cloud style following the pattern `item.action`

  | Old | New |
  |-----|-----|
  | `function.read` | unchanged |
  | `function.run` | unchanged |
  | `function.provider.upload` | `function.write` |
  | `function.job.read` + `function.provider.jobs` | `function-job.read` (combined) covers list and retrieve |
  | `function.provider.logs` | `function-provider-logs.read` |
  | `function.files` | `function-files.read` (list and download) |
  |                           | `function-files.write`(upload and delete) |
  | `function.provider.files` | `function-provider-files.read` (list and download) |
  |                                          | `function-provider-files.write` (upload and delete) |

### Details and comments

Since `function.job.read` + `function.provider.jobs` are now combined, and only `function.provider.jobs` had the auth (the list), this PR also enables the authentication for the `JobRetrieveUseCase` (endpoint `v1/views/jobs/retrieve.py`) with the new Runtime API /functions endpoint and the `function.job.read` permission.