### PR TITLE
Scheduler logs improvements

### DIFF
--- a/gateway/core/utils.py
+++ b/gateway/core/utils.py
@@ -223,10 +223,10 @@ def check_logs(logs: Union[str, None], job) -> str:
 
     if logs_size > max_bytes:
         logger.warning(
-            "Job %s is exceeding the maximum size for logs %s MB > %s MB.",
+            "Job %s is exceeding the maximum size for logs %.1f MB > %.1f MB.",
             job.id,
-            logs_size,
-            max_bytes,
+            logs_size / (1024**2),
+            max_bytes / (1024**2),
         )
 
         # truncate logs discarding older

--- a/gateway/scheduler/tasks/update_jobs_statuses.py
+++ b/gateway/scheduler/tasks/update_jobs_statuses.py
@@ -123,7 +123,7 @@ class UpdateJobsStatuses(SchedulerTask):
                 if job.status == Job.SUCCEEDED:
                     self._record_execution_duration(job)
 
-        if not is_fleets_job:
+        if not is_fleets_job and not job.in_terminal_state():
             try:
                 logs = runner.logs()
             except RunnerError:

--- a/gateway/tests/core/test_utils.py
+++ b/gateway/tests/core/test_utils.py
@@ -1,0 +1,82 @@
+# This code is part of a Qiskit project.
+#
+# (C) IBM 2026
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Unit tests for core.utils.check_logs."""
+
+import logging
+from unittest.mock import Mock
+
+import pytest
+from django.conf import settings
+
+from core.models import Job
+from core.utils import check_logs
+
+
+def _make_job(status=Job.RUNNING, job_id="test-job-id"):
+    job = Mock()
+    job.id = job_id
+    job.status = status
+    return job
+
+
+def test_check_logs_returns_empty_for_none():
+    assert check_logs(None, _make_job()) == ""
+
+
+def test_check_logs_returns_empty_for_empty_string():
+    assert check_logs("", _make_job()) == ""
+
+
+def test_check_logs_returns_logs_unchanged_when_within_limit():
+    logs = "a" * (settings.FUNCTIONS_LOGS_SIZE_LIMIT - 1)
+    assert check_logs(logs, _make_job()) == logs
+
+
+def test_check_logs_failed_job_default_message():
+    """A FAILED job with no logs gets a default error message."""
+    job = _make_job(status=Job.FAILED)
+    result = check_logs(None, job)
+    assert "failed due to an internal error" in result
+
+
+def test_check_logs_truncates_oversized_logs():
+    """Logs exceeding the size limit are truncated, keeping the newest (tail) content."""
+    max_bytes = settings.FUNCTIONS_LOGS_SIZE_LIMIT
+    logs = "a" * (max_bytes + 100)
+    result = check_logs(logs, _make_job())
+    assert result.startswith("[Logs exceeded")
+    # The truncated body is the last max_bytes characters of the original
+    assert result.endswith("a" * max_bytes)
+
+
+def test_check_logs_warning_shows_mb_not_raw_bytes(caplog):
+    """The oversized-log warning must show human-readable MB values, not raw byte counts.
+
+    Regression test: before the fix the format string used %s with raw byte values,
+    producing messages like '1157317193 MB > 52428800 MB' instead of '~1103.6 MB > 50.0 MB'.
+    """
+    max_bytes = settings.FUNCTIONS_LOGS_SIZE_LIMIT
+    logs = "x" * (max_bytes + 1)
+
+    with caplog.at_level(logging.WARNING, logger="core"):
+        check_logs(logs, _make_job())
+
+    assert caplog.records, "Expected a warning to be logged"
+    message = caplog.records[0].getMessage()
+
+    # The raw byte count must not appear — it would be a 8-digit+ integer with no decimal
+    assert str(max_bytes) not in message
+    assert str(max_bytes + 1) not in message
+    # The value must be expressed in MB (float with one decimal place)
+    expected_mb = f"{(max_bytes + 1) / (1024 ** 2):.1f} MB"
+    assert expected_mb in message

--- a/gateway/tests/scheduler/test_update_jobs_statuses.py
+++ b/gateway/tests/scheduler/test_update_jobs_statuses.py
@@ -41,61 +41,125 @@ def _make_fleets_job(status=Job.RUNNING, fleet_id="fleet-123"):
     return job
 
 
-def test_fleets_result_retrieved_from_cos_on_terminal_state():
-    """update_job_status() saves COS result to job.result when Fleets job reaches terminal state."""
-    task = _make_task()
-    job = _make_fleets_job()
-    job.in_terminal_state.return_value = True
-
-    mock_runner = MagicMock()
-    mock_runner.status.return_value = Job.SUCCEEDED
-    mock_runner.get_result_from_cos.return_value = '{"counts": {"00": 512}}'
-
-    with (
-        patch(f"{_MOD}.get_runner", return_value=mock_runner),
-        patch(f"{_MOD}.check_job_timeout", return_value=False),
-        patch(f"{_MOD}.JobEvent"),
-    ):
-        task.update_job_status(job)
-
-    mock_runner.get_result_from_cos.assert_called_once()
-    assert job.result == '{"counts": {"00": 512}}'
+def _make_ray_job(status=Job.RUNNING):
+    job = MagicMock(spec=Job)
+    job.runner = Program.RAY
+    job.compute_resource = MagicMock()
+    job.gpu = False
+    job.status = status
+    job.logs = ""
+    job.env_vars = "{}"
+    job.sub_status = None
+    job.in_terminal_state.return_value = False
+    job.SUCCEEDED = Job.SUCCEEDED
+    job.FAILED = Job.FAILED
+    return job
 
 
-def test_fleets_result_skipped_when_cos_returns_none():
-    """update_job_status() leaves job.result unchanged when get_result_from_cos returns None."""
-    task = _make_task()
-    job = _make_fleets_job()
-    job.in_terminal_state.return_value = True
-    job.result = "previous-result"
+class TestFleetsJobStatusUpdate:
+    """Tests for update_job_status() with Fleets jobs."""
 
-    mock_runner = MagicMock()
-    mock_runner.status.return_value = Job.SUCCEEDED
-    mock_runner.get_result_from_cos.return_value = None
+    def test_result_retrieved_from_cos_on_terminal_state(self):
+        """Saves COS result to job.result when Fleets job reaches terminal state."""
+        task = _make_task()
+        job = _make_fleets_job()
+        job.in_terminal_state.return_value = True
 
-    with (
-        patch(f"{_MOD}.get_runner", return_value=mock_runner),
-        patch(f"{_MOD}.check_job_timeout", return_value=False),
-        patch(f"{_MOD}.JobEvent"),
-    ):
-        task.update_job_status(job)
+        mock_runner = MagicMock()
+        mock_runner.status.return_value = Job.SUCCEEDED
+        mock_runner.get_result_from_cos.return_value = '{"counts": {"00": 512}}'
 
-    assert job.result == "previous-result"
+        with (
+            patch(f"{_MOD}.get_runner", return_value=mock_runner),
+            patch(f"{_MOD}.check_job_timeout", return_value=False),
+            patch(f"{_MOD}.JobEvent"),
+        ):
+            task.update_job_status(job)
+
+        mock_runner.get_result_from_cos.assert_called_once()
+        assert job.result == '{"counts": {"00": 512}}'
+
+    def test_result_skipped_when_cos_returns_none(self):
+        """Leaves job.result unchanged when get_result_from_cos returns None."""
+        task = _make_task()
+        job = _make_fleets_job()
+        job.in_terminal_state.return_value = True
+        job.result = "previous-result"
+
+        mock_runner = MagicMock()
+        mock_runner.status.return_value = Job.SUCCEEDED
+        mock_runner.get_result_from_cos.return_value = None
+
+        with (
+            patch(f"{_MOD}.get_runner", return_value=mock_runner),
+            patch(f"{_MOD}.check_job_timeout", return_value=False),
+            patch(f"{_MOD}.JobEvent"),
+        ):
+            task.update_job_status(job)
+
+        assert job.result == "previous-result"
+
+    def test_cos_error_is_swallowed(self):
+        """Logs a warning and continues if get_result_from_cos raises."""
+        task = _make_task()
+        job = _make_fleets_job()
+        job.in_terminal_state.return_value = True
+
+        mock_runner = MagicMock()
+        mock_runner.status.return_value = Job.SUCCEEDED
+        mock_runner.get_result_from_cos.side_effect = RuntimeError("COS unavailable")
+
+        with (
+            patch(f"{_MOD}.get_runner", return_value=mock_runner),
+            patch(f"{_MOD}.check_job_timeout", return_value=False),
+            patch(f"{_MOD}.JobEvent"),
+        ):
+            task.update_job_status(job)  # should not raise
 
 
-def test_fleets_result_cos_error_is_swallowed():
-    """update_job_status() logs a warning and continues if get_result_from_cos raises."""
-    task = _make_task()
-    job = _make_fleets_job()
-    job.in_terminal_state.return_value = True
+class TestRayJobStatusUpdate:
+    """Tests for update_job_status() with Ray jobs."""
 
-    mock_runner = MagicMock()
-    mock_runner.status.return_value = Job.SUCCEEDED
-    mock_runner.get_result_from_cos.side_effect = RuntimeError("COS unavailable")
+    def test_logs_fetched_once_on_terminal_state(self):
+        """runner.logs() is called exactly once when a Ray job transitions to a terminal state.
 
-    with (
-        patch(f"{_MOD}.get_runner", return_value=mock_runner),
-        patch(f"{_MOD}.check_job_timeout", return_value=False),
-        patch(f"{_MOD}.JobEvent"),
-    ):
-        task.update_job_status(job)  # should not raise
+        Regression test: before the fix, logs were fetched twice — once in the terminal-state
+        handler (to save them) and again unconditionally for the "no resources" check, doubling
+        peak memory usage and causing OOM on large log payloads.
+        """
+        task = _make_task()
+        job = _make_ray_job()
+        job.in_terminal_state.return_value = True
+
+        mock_runner = MagicMock()
+        mock_runner.status.return_value = Job.SUCCEEDED
+        mock_runner.logs.return_value = "some logs"
+
+        with (
+            patch(f"{_MOD}.get_runner", return_value=mock_runner),
+            patch(f"{_MOD}.check_job_timeout", return_value=False),
+            patch(f"{_MOD}.save_logs_to_storage"),
+            patch(f"{_MOD}.JobEvent"),
+        ):
+            task.update_job_status(job)
+
+        assert mock_runner.logs.call_count == 1
+
+    def test_logs_fetched_for_running_job(self):
+        """runner.logs() is called once for a still-RUNNING Ray job (the "no resources" check)."""
+        task = _make_task()
+        job = _make_ray_job()
+        job.in_terminal_state.return_value = False
+
+        mock_runner = MagicMock()
+        mock_runner.status.return_value = Job.RUNNING
+        mock_runner.logs.return_value = "some logs"
+
+        with (
+            patch(f"{_MOD}.get_runner", return_value=mock_runner),
+            patch(f"{_MOD}.check_job_timeout", return_value=False),
+            patch(f"{_MOD}.JobEvent"),
+        ):
+            task.update_job_status(job)
+
+        assert mock_runner.logs.call_count == 1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

While debugging recent scheduler incidents, I found that `runner.logs()` is called twice per scheduler iteration when a Ray job transitions to a terminal state: once in the terminal-state handler to save the logs (line 109 of `update_jobs_statuses.py`), and again unconditionally for the "no resources" string check (line 126).

It looks like this oversight was introduced in #1942, when the `if job_handler:` was replaced with a`runner.logs()` call. And well, it is a redundant fetch.

Also fixes a display bug that printed raw byte counts labelled as "MB" (e.g. `1157317193 MB > 52428800 MB` instead of `~1103.6 MB > 50.0 MB`).

### Details and comments

Added regression tests and tests for log utilities:

- `TestRayJobStatusUpdate::test_logs_fetched_once_on_terminal_state`: regression tests that asserts `runner.logs()` is called exactly once for a terminal-state transition. Fails against the unfixed code (`call_count == 2`).
- `TestRayJobStatusUpdate::test_logs_fetched_for_running_job`: ensures the "no resources" check still runs for non-terminal jobs.
- `TestCheckLogs`: new unit tests for `core.utils.check_logs`, including a regression test for the MB display fix.