### PR TITLE
Functions trough instances: fixes

### DIFF
--- a/gateway/api/authentication.py
+++ b/gateway/api/authentication.py
@@ -69,7 +69,7 @@ class CustomTokenBackend(authentication.BaseAuthentication):
             public_access=public_access,
         ).execute()
 
-        accessible_functions = FunctionAccessClient().get_accessible_functions(crn)
+        accessible_functions = FunctionAccessClient().get_accessible_functions(crn, authorization_token)
         return quantum_user, CustomAuthentication(
             channel=channel,
             token=authorization_token.encode(),

--- a/gateway/api/clients/function_access_client.py
+++ b/gateway/api/clients/function_access_client.py
@@ -1,5 +1,6 @@
 """FunctionAccessClient."""
 
+import hashlib
 import logging
 
 import requests
@@ -28,7 +29,8 @@ class FunctionAccessClient:
         if not instance_crn:
             raise RuntimeFunctionsException("Missing instance_crn")
 
-        cache_key = f"accesible_functions:{instance_crn}"
+        api_key_hash = hashlib.sha256(api_key.encode()).hexdigest()
+        cache_key = f"accesible_functions:{instance_crn}:{api_key_hash}"
         cached = cache.get(cache_key)
         if cached is not None:
             return cached

--- a/gateway/api/clients/function_access_client.py
+++ b/gateway/api/clients/function_access_client.py
@@ -61,7 +61,6 @@ class FunctionAccessClient:
             raise RuntimeFunctionsException(f"Unexpected status {response.status_code} for CRN {instance_crn}")
 
         functions = []
-        print(response.text)
         for entry in response.json().get("functions", []):
             try:
                 function_entry = FunctionAccessEntry(

--- a/gateway/api/clients/function_access_client.py
+++ b/gateway/api/clients/function_access_client.py
@@ -18,7 +18,7 @@ logger = logging.getLogger("api.FunctionAccessClient")
 class FunctionAccessClient:
     """Client for retrieving accessible functions for a given instance CRN."""
 
-    def get_accessible_functions(self, instance_crn: str) -> FunctionAccessResult:
+    def get_accessible_functions(self, instance_crn: str, api_key: str) -> FunctionAccessResult:
         """Return all functions accessible to the given instance CRN with their permissions."""
         enabled = Config.get_bool(ConfigKey.RUNTIME_INSTANCES_API_ENABLED)
         base_url = settings.RUNTIME_API_BASE_URL
@@ -36,7 +36,7 @@ class FunctionAccessClient:
         try:
             response = requests.get(
                 f"{base_url}/api/v1/functions",
-                headers={"Service-CRN": instance_crn},
+                headers={"Service-CRN": instance_crn, "Authorization": f"apikey {api_key}"},
                 timeout=5,
             )
         except requests.RequestException as exc:
@@ -59,6 +59,7 @@ class FunctionAccessClient:
             raise RuntimeFunctionsException(f"Unexpected status {response.status_code} for CRN {instance_crn}")
 
         functions = []
+        print(response.text)
         for entry in response.json().get("functions", []):
             try:
                 function_entry = FunctionAccessEntry(

--- a/gateway/core/model_managers/functions.py
+++ b/gateway/core/model_managers/functions.py
@@ -41,11 +41,16 @@ class FunctionsQuerySet(QuerySet):
                 Required when accessible_functions is provided and use_legacy_authorization=False.
         """
         if accessible_functions and not accessible_functions.use_legacy_authorization:
+            # Runtime API /functions
             filter_function_names = accessible_functions.get_functions_by_provider(permission)
+            # Custom functions (provider=None) are always visible
+            # Provider functions are gated by instance permissions, even if the user is the author.
+            author_criteria = Q(author=author, provider=None)
             provider_criteria = Q()
             for pname, titles in filter_function_names.items():
                 provider_criteria |= Q(provider__name=pname, title__in=titles)
-            return self.filter(Q(author=author) | provider_criteria).distinct()
+            combined = author_criteria | provider_criteria if provider_criteria else author_criteria
+            return self.filter(combined).distinct()
 
         # Fallback: Django groups
         groups = Group.objects.filter(user=author, permissions__codename=legacy_permission_name)

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -354,9 +354,11 @@ GATEWAY_ALLOWLIST_CONFIG = str(os.environ.get("GATEWAY_ALLOWLIST_CONFIG", "api/v
 
 GATEWAY_GPU_JOBS_CONFIG = str(os.environ.get("GATEWAY_GPU_JOBS_CONFIG", "api/v1/gpu-jobs.json"))
 
-# authentication base url for qiskit runtime
+# Authentication base url for Qiskit Runtime
 QISKIT_IBM_URL = os.environ.get("QISKIT_IBM_URL", "https://cloud.ibm.com")
-RUNTIME_API_BASE_URL = os.environ.get("RUNTIME_API_BASE_URL")
+
+# Authentication Runtime API
+RUNTIME_API_BASE_URL = os.environ.get("RUNTIME_API_BASE_URL", "https://quantum.test.cloud.ibm.com")
 RUNTIME_API_CACHE_TTL = int(os.environ.get("RUNTIME_API_CACHE_TTL", "60"))
 
 # IBM Cloud

--- a/gateway/tests/api/clients/test_function_access_client.py
+++ b/gateway/tests/api/clients/test_function_access_client.py
@@ -19,7 +19,7 @@ def _enable_instances_api(monkeypatch):
 def test_returns_function_from_200_response(instances_server):
     instances_server.grant("ibm", "sampler", [PLATFORM_PERMISSION_RUN])
 
-    result = FunctionAccessClient().get_accessible_functions("crn:test:123")
+    result = FunctionAccessClient().get_accessible_functions("crn:test:123", "test-api-key")
 
     assert result.use_legacy_authorization is False
     entry = result.get_function("ibm", "sampler")
@@ -33,7 +33,7 @@ def test_returns_function_from_200_response(instances_server):
 def test_returns_empty_list_on_200_with_no_functions(instances_server):
     instances_server.reset()
 
-    result = FunctionAccessClient().get_accessible_functions("crn:test:456")
+    result = FunctionAccessClient().get_accessible_functions("crn:test:456", "test-api-key")
 
     assert result.use_legacy_authorization is False
     assert result.functions == []
@@ -43,13 +43,13 @@ def test_raises_on_server_error(instances_server):
     instances_server.error(500)
 
     with pytest.raises(RuntimeFunctionsException):
-        FunctionAccessClient().get_accessible_functions("crn:test:789")
+        FunctionAccessClient().get_accessible_functions("crn:test:789", "test-api-key")
 
 
 def test_returns_no_response_when_disabled(monkeypatch):
     monkeypatch.setattr("core.models.Config.get_bool", classmethod(lambda cls, key: False))
 
-    result = FunctionAccessClient().get_accessible_functions("crn:test:000")
+    result = FunctionAccessClient().get_accessible_functions("crn:test:000", "test-api-key")
 
     assert result.use_legacy_authorization is True
 
@@ -57,8 +57,8 @@ def test_returns_no_response_when_disabled(monkeypatch):
 def test_caches_successful_response(instances_server):
     instances_server.grant("ibm", "sampler", [PLATFORM_PERMISSION_RUN])
 
-    FunctionAccessClient().get_accessible_functions("crn:cache:hit")
-    result = FunctionAccessClient().get_accessible_functions("crn:cache:hit")
+    FunctionAccessClient().get_accessible_functions("crn:cache:hit", "test-api-key")
+    result = FunctionAccessClient().get_accessible_functions("crn:cache:hit", "test-api-key")
 
     assert instances_server.request_count == 1
     assert result.use_legacy_authorization is False
@@ -69,8 +69,8 @@ def test_does_not_cache_error_response(instances_server):
     instances_server.error(500)
 
     with pytest.raises(RuntimeFunctionsException):
-        FunctionAccessClient().get_accessible_functions("crn:cache:err")
+        FunctionAccessClient().get_accessible_functions("crn:cache:err", "test-api-key")
     with pytest.raises(RuntimeFunctionsException):
-        FunctionAccessClient().get_accessible_functions("crn:cache:err")
+        FunctionAccessClient().get_accessible_functions("crn:cache:err", "test-api-key")
 
     assert instances_server.request_count == 2

--- a/gateway/tests/core/model_managers/test_functions.py
+++ b/gateway/tests/core/model_managers/test_functions.py
@@ -83,6 +83,26 @@ class TestWithPermissionRuntimeInstances:
 
         assert provider_function not in result
 
+    def test_own_provider_function_excluded_when_permission_absent(self, author, provider):
+        """Provider function authored by the querying user is excluded when permission is absent.
+
+        Regression: Q(author=author) without provider=None would include provider functions
+        authored by the user regardless of instance permissions.
+        """
+        provider_function = Program.objects.create(title="my-provider-fn", author=author, provider=provider)
+        # accessible_functions has an entry for the function but with a different permission
+        accessible = make_result(provider.name, provider_function.title, {"function.write"})
+
+        result = list(
+            Program.objects.with_permission(
+                author=author,
+                accessible_functions=accessible,
+                permission=PLATFORM_PERMISSION_READ,
+            )
+        )
+
+        assert provider_function not in result
+
     def test_empty_functions_returns_only_own(self, author, other_user):
         """When accessible_functions has no entries, returns only own functions."""
         user_function = Program.objects.create(title="user-fn", author=author)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

1. Adds the api key to connect to Runtime API
2. Bugfix: the author of a provider function will only be able to see it if they have permissions, regardless of whether they are the author or not.

### Details

`with_permission()` used `Q(author=author)` as an unconditional filter in the runtime instances path, which matched both custom functions and provider functions authored by the requesting user. This caused a user to see provider functions they had uploaded regardless of whether their instance had `function.read` permission. The fix narrows that criterion to Q(author=author, provider=None): custom functions are always visible (they are not instance-gated), but provider functions are always subject to instance permissions, even when the user is their author.
