### PR TITLE
Extract job status metric into a dedicated task

### DIFF
--- a/gateway/scheduler/main.py
+++ b/gateway/scheduler/main.py
@@ -13,6 +13,7 @@ from scheduler.metrics.scheduler_metrics_collector import SchedulerMetrics
 from scheduler.kill_signal import KillSignal
 from scheduler.tasks.free_resources import FreeResources
 from scheduler.tasks.schedule_queued_jobs import ScheduleQueuedJobs
+from scheduler.tasks.update_job_status_counts import UpdateJobStatusCounts
 from scheduler.tasks.update_jobs_statuses import UpdateJobsStatuses
 
 logger = logging.getLogger("scheduler.main")
@@ -34,6 +35,7 @@ class Main:
         Config.add_defaults()
 
         self.tasks = [
+            UpdateJobStatusCounts(self.kill_signal, self.metrics),
             ScheduleQueuedJobs(self.kill_signal, self.metrics),
             UpdateJobsStatuses(self.kill_signal, self.metrics),
             FreeResources(self.kill_signal, self.metrics),

--- a/gateway/scheduler/tasks/schedule_queued_jobs.py
+++ b/gateway/scheduler/tasks/schedule_queued_jobs.py
@@ -6,8 +6,6 @@ import time
 from datetime import datetime, timezone
 
 from django.conf import settings
-from django.db.models import Count
-
 from concurrency.exceptions import RecordModifiedError
 
 from opentelemetry import trace
@@ -40,7 +38,6 @@ class ScheduleQueuedJobs(SchedulerTask):
             logger.warning("System in maintenance mode. Skipping new jobs schedule.")
             return
 
-        self._update_job_status_counts_metric()
         self._schedule_fleets_jobs()
         self._schedule_cpu_jobs()
         self._schedule_gpu_jobs()
@@ -165,23 +162,6 @@ class ScheduleQueuedJobs(SchedulerTask):
                     )
         if jobs:
             logger.info("%s jobs are scheduled for execution.", len(jobs))
-
-    def _update_job_status_counts_metric(self):
-        """Update job counts per status and provider (active states only)."""
-        statuses = [Job.QUEUED, Job.PENDING, Job.RUNNING]
-        rows = (
-            Job.objects.filter(status__in=statuses)
-            .values("status", "program__provider__name")
-            .annotate(count=Count("id"))
-        )
-        counts = {}
-        for row in rows:
-            status = row["status"]
-            provider = row["program__provider__name"] or "custom"
-            counts[(status, provider)] = row["count"]
-        self.metrics.clear_job_status_counts()
-        for (status, provider), count in counts.items():
-            self.metrics.set_job_status_count(count, status, provider)
 
     def add_queue_wait_time_metric(self, job: Job):
         """Add queue wait time metric."""

--- a/gateway/scheduler/tasks/update_job_status_counts.py
+++ b/gateway/scheduler/tasks/update_job_status_counts.py
@@ -1,0 +1,37 @@
+"""Update job status counts metric task."""
+
+import logging
+
+from django.db.models import Count
+
+from core.models import Job
+from scheduler.kill_signal import KillSignal
+from scheduler.metrics.scheduler_metrics_collector import SchedulerMetrics
+from .task import SchedulerTask
+
+logger = logging.getLogger("scheduler.UpdateJobStatusCounts")
+
+
+class UpdateJobStatusCounts(SchedulerTask):
+    """Update job counts per status and provider metrics."""
+
+    def __init__(self, kill_signal: KillSignal, metrics: SchedulerMetrics):
+        self.kill_signal = kill_signal
+        self.metrics = metrics
+
+    def run(self):
+        """Update job counts per status and provider (active states only)."""
+        statuses = [Job.QUEUED, Job.PENDING, Job.RUNNING]
+        rows = (
+            Job.objects.filter(status__in=statuses)
+            .values("status", "program__provider__name")
+            .annotate(count=Count("id"))
+        )
+        counts = {}
+        for row in rows:
+            status = row["status"]
+            provider = row["program__provider__name"] or "custom"
+            counts[(status, provider)] = row["count"]
+        self.metrics.clear_job_status_counts()
+        for (status, provider), count in counts.items():
+            self.metrics.set_job_status_count(count, status, provider)

--- a/gateway/tests/scheduler/test_update_job_status_counts.py
+++ b/gateway/tests/scheduler/test_update_job_status_counts.py
@@ -1,0 +1,34 @@
+"""Unit tests for UpdateJobStatusCounts."""
+
+from unittest.mock import MagicMock, patch, call
+
+from scheduler.tasks.update_job_status_counts import UpdateJobStatusCounts
+
+_MOD = "scheduler.tasks.update_job_status_counts"
+
+
+def _make_task():
+    kill_signal = MagicMock()
+    kill_signal.received = False
+    return UpdateJobStatusCounts(kill_signal=kill_signal, metrics=MagicMock())
+
+
+def test_job_status_counts_clears_and_sets_metrics():
+    """run() clears existing counts then sets one entry per (status, provider) pair."""
+    task = _make_task()
+
+    fake_rows = [
+        {"status": "QUEUED", "program__provider__name": "ibm", "count": 3},
+        {"status": "RUNNING", "program__provider__name": None, "count": 1},
+    ]
+
+    with patch(f"{_MOD}.Job") as MockJob:
+        MockJob.QUEUED = "QUEUED"
+        MockJob.PENDING = "PENDING"
+        MockJob.RUNNING = "RUNNING"
+        MockJob.objects.filter.return_value.values.return_value.annotate.return_value = fake_rows
+        task.run()
+
+    task.metrics.clear_job_status_counts.assert_called_once()
+    task.metrics.set_job_status_count.assert_any_call(3, "QUEUED", "ibm")
+    task.metrics.set_job_status_count.assert_any_call(1, "RUNNING", "custom")


### PR DESCRIPTION
### Summary

`ScheduleQueuedJobs` owns the `_update_job_status_counts_metric` function, which counts all jobs by status and provider regardless of runner type.

This PR moves that logic into a dedicated `UpdateJobStatusCounts` scheduler task, giving it a single clear responsibility.