### PR TITLE
Fix mypy JsonType incompatibility in json request dicts

### DIFF
--- a/client/qiskit_serverless/core/clients/serverless_client.py
+++ b/client/qiskit_serverless/core/clients/serverless_client.py
@@ -394,7 +394,7 @@ class ServerlessClient(BaseClient):  # pylint: disable=too-many-public-methods
                     "Continuing without a QiskitRuntimeService."
                 )
                 service = None
-        data = {
+        data: dict[str, Any] = {
             "service": json.dumps(service, cls=QiskitObjectsEncoder),
         }
 

--- a/client/qiskit_serverless/core/job.py
+++ b/client/qiskit_serverless/core/job.py
@@ -327,7 +327,7 @@ def send_error(code: Union[str, int], message: str, exception: str, args: Option
     channel = os.environ.get(QISKIT_IBM_CHANNEL, None)
     url = f"{os.environ.get(ENV_JOB_GATEWAY_HOST)}/" f"api/{version}/jobs/{os.environ.get(ENV_JOB_ID_GATEWAY)}/event/"
 
-    request_json = {"type": "ERROR", "code": code, "message": message, "exception": exception}
+    request_json: dict[str, Any] = {"type": "ERROR", "code": code, "message": message, "exception": exception}
     if args:
         request_json["args"] = args
 


### PR DESCRIPTION
### Summary
CI is failing with:

```
Your code has been rated at 10.00/10

lint: commands[2]> mypy --install-types --non-interactive .
qiskit_serverless/core/job.py:336: error: Argument "json" to "post" has incompatible type "dict[str, str | int]"; expected "JsonType"  [arg-type]
Found 2 errors in 2 files (checked 44 source files)
qiskit_serverless/core/job.py:336: note: "dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
qiskit_serverless/core/job.py:336: note: Consider using "Mapping" instead, which is covariant in the value type
qiskit_serverless/core/clients/serverless_client.py:406: error: Argument "json" to "post" has incompatible type "dict[str, str]"; expected "JsonType"  [arg-type]
qiskit_serverless/core/clients/serverless_client.py:406: note: "dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
qiskit_serverless/core/clients/serverless_client.py:406: note: Consider using "Mapping" instead, which is covariant in the value type
lint: exit 1 (14.43 seconds) /home/runner/work/qiskit-serverless/qiskit-serverless/client> mypy --install-types --non-interactive . pid=2659
```

#### Workaround
Annotates two local dict variables with `dict[str, Any]` so mypy accepts them where `JsonType` is expected.

The `requests` library's `JsonType` requires a `Mapping[str, Any]`, but mypy treats `dict` as invariant — so `dict[str, str]` and `dict[str, str | int]` were rejected. Explicit `dict[str, Any]` annotations resolve this without changing runtime behavior.

Fixes:
- `qiskit_serverless/core/job.py` — `request_json` in `send_error()`
- `qiskit_serverless/core/clients/serverless_client.py` — `data` in `stop()`