### PR TITLE
Fix COS endpoint URL: use direct instead of private

### DIFF
--- a/gateway/core/ibm_cloud/clients.py
+++ b/gateway/core/ibm_cloud/clients.py
@@ -50,7 +50,7 @@ from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 IAM_PROD_URL = "https://iam.cloud.ibm.com"
 IAM_TEST_URL = "https://iam.test.cloud.ibm.com"
 
-COS_URL_TEMPLATE = "https://s3.private.{region}.cloud-object-storage.appdomain.cloud"
+COS_URL_TEMPLATE = "https://s3.direct.{region}.cloud-object-storage.appdomain.cloud"
 COS_PUBLIC_URL_TEMPLATE = "https://s3.{region}.cloud-object-storage.appdomain.cloud"
 CODE_ENGINE_URL_TEMPLATE = "https://api.{region}.codeengine.cloud.ibm.com/v2"
 

--- a/gateway/core/ibm_cloud/cos/cos_client.py
+++ b/gateway/core/ibm_cloud/cos/cos_client.py
@@ -74,8 +74,8 @@ class COSClient:
             client_provider: Initialized IBM Cloud client provider.
             credentials: HMAC credentials for S3-compatible access.
             bucket_region: Bucket endpoint region. Defaults to the provider region.
-            endpoint_url: Override the COS S3 endpoint URL. Use the private endpoint
-                (e.g. ``https://s3.private.us-east.cloud-object-storage.appdomain.cloud``)
+            endpoint_url: Override the COS S3 endpoint URL. Use the direct endpoint
+                (e.g. ``https://s3.direct.us-east.cloud-object-storage.appdomain.cloud``)
                 when running inside IBM Cloud to avoid public internet egress.
             max_threads: Multipart transfer concurrency limit.
         """

--- a/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_job_cos_unit.py
+++ b/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_job_cos_unit.py
@@ -232,10 +232,10 @@ def test_cos_raises_when_ce_secret_not_found() -> None:
 def test_cos_endpoint_url_from_config_passed_to_cos_client() -> None:
     """cos_config['cos_endpoint_url'] is forwarded to COSClient as endpoint_url."""
     mock_job = MagicMock()
-    private_url = "https://s3.private.us-east.cloud-object-storage.appdomain.cloud"
+    direct_url = "https://s3.direct.us-east.cloud-object-storage.appdomain.cloud"
     mock_job.cos_config = {
         "hmac_secret_name": "my-secret",
-        "cos_endpoint_url": private_url,
+        "cos_endpoint_url": direct_url,
     }
     mock_job.project_id = "proj-id"
     mock_job.client_provider.config.region = "us-south"
@@ -251,7 +251,7 @@ def test_cos_endpoint_url_from_config_passed_to_cos_client() -> None:
         mock_cos_cls.return_value.get_object_bytes.return_value = b"data"
         job_cos.get_object_bytes(bucket_name="b", key="k")
 
-    assert mock_cos_cls.call_args.kwargs["endpoint_url"] == private_url
+    assert mock_cos_cls.call_args.kwargs["endpoint_url"] == direct_url
 
 
 def test_cos_raises_when_ce_secret_missing_fields() -> None:

--- a/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_job_cos_unit.py
+++ b/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_job_cos_unit.py
@@ -222,41 +222,6 @@ def test_get_cos_client_raises_when_ce_secret_not_found() -> None:
             get_cos_client(project)
 
 
-def test_cos_endpoint_url_from_config_passed_to_cos_client() -> None:
-    """cos_config['cos_endpoint_url'] is forwarded to COSClient as endpoint_url."""
-    mock_job = MagicMock()
-    direct_url = "https://s3.direct.us-east.cloud-object-storage.appdomain.cloud"
-    mock_job.cos_config = {
-        "hmac_secret_name": "my-secret",
-        "cos_endpoint_url": direct_url,
-    }
-    mock_job.project_id = "proj-id"
-    mock_job.client_provider.config.region = "us-south"
-    job_cos = JobCOS(mock_job)
-
-    mock_secret = MagicMock()
-    mock_secret.data = {"access_key_id": "ak123", "secret_access_key": "sk456"}
-
-    with (
-        patch("core.ibm_cloud.code_engine.fleets.cos.SecretsAndConfigmapsApi") as mock_api_cls,
-        patch("core.ibm_cloud.code_engine.fleets.cos.COSClient") as mock_cos_cls,
-    ):
-        mock_api_cls.return_value.get_secret.return_value = mock_secret
-        mock_cos_cls.return_value.get_object_bytes.return_value = b"data"
-        job_cos.get_object_bytes(bucket_name="b", key="k")
-
-    assert mock_cos_cls.call_args.kwargs["endpoint_url"] == direct_url
-
-
-def test_cos_raises_when_ce_secret_missing_fields() -> None:
-    """Public methods raise ValueError when CE secret lacks required HMAC fields."""
-    mock_job = MagicMock()
-    mock_job.cos_config = {"hmac_secret_name": "incomplete-secret"}
-    mock_job.project_id = "proj-id"
-    mock_job.client_provider.config.region = "us-south"
-    job_cos = JobCOS(mock_job)
-
-
 def test_get_cos_client_raises_when_ce_secret_missing_fields() -> None:
     """get_cos_client() raises ValueError when CE secret lacks required HMAC fields."""
     project = _make_mock_project()

--- a/gateway/tests/core/services/ibm_cloud/cos/test_cos_client_unit.py
+++ b/gateway/tests/core/services/ibm_cloud/cos/test_cos_client_unit.py
@@ -52,7 +52,7 @@ def test_endpoint_url_forwarded_to_provider() -> None:
     mock_provider = MagicMock()
     mock_provider.config.region = "us-south"
     creds = CosHmacCredentials(access_key_id="ak", secret_access_key="sk")
-    custom_url = "https://s3.private.us-east.cloud-object-storage.appdomain.cloud"
+    custom_url = "https://s3.direct.us-east.cloud-object-storage.appdomain.cloud"
 
     client = COSClient(
         client_provider=mock_provider,

--- a/gateway/tests/core/services/ibm_cloud/test_clients_unit.py
+++ b/gateway/tests/core/services/ibm_cloud/test_clients_unit.py
@@ -186,7 +186,7 @@ def test_get_cos_hmac_client_cache_hit_and_miss() -> None:
 def test_get_cos_hmac_client_uses_custom_endpoint_url() -> None:
     """When endpoint_url is supplied it is used as the S3 endpoint, not the region-derived URL."""
     with patched_provider() as provider:
-        custom_url = "https://s3.private.us-east.cloud-object-storage.appdomain.cloud"
+        custom_url = "https://s3.direct.us-east.cloud-object-storage.appdomain.cloud"
         provider.get_cos_hmac_client(
             access_key_id="ak",
             secret_access_key="sk",
@@ -199,11 +199,13 @@ def test_get_cos_hmac_client_cache_differentiates_by_endpoint_url() -> None:
     """Different endpoint URLs for the same credentials produce distinct cached clients."""
     with patched_provider() as provider:
         url_public = "https://s3.us-east.cloud-object-storage.appdomain.cloud"
-        url_private = "https://s3.private.us-east.cloud-object-storage.appdomain.cloud"
+        url_direct = "https://s3.direct.us-east.cloud-object-storage.appdomain.cloud"
 
         client_pub = provider.get_cos_hmac_client(access_key_id="ak", secret_access_key="sk", endpoint_url=url_public)
-        client_priv = provider.get_cos_hmac_client(access_key_id="ak", secret_access_key="sk", endpoint_url=url_private)
+        client_direct = provider.get_cos_hmac_client(
+            access_key_id="ak", secret_access_key="sk", endpoint_url=url_direct
+        )
         client_pub2 = provider.get_cos_hmac_client(access_key_id="ak", secret_access_key="sk", endpoint_url=url_public)
 
-        assert client_pub is not client_priv
+        assert client_pub is not client_direct
         assert client_pub is client_pub2


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The `COS_URL_TEMPLATE` was using the `s3.private` endpoint, which is incompatible with our network policies configured for the `s3.direct` endpoint. This caused fleet jobs to fail on staging after the latest merge from main.


### Details and comments

