### PR TITLE
Add pyproject.toml to gateway and tests

### DIFF
--- a/gateway/core/ibm_cloud/code_engine/ce_client/rest.py
+++ b/gateway/core/ibm_cloud/code_engine/ce_client/rest.py
@@ -104,7 +104,7 @@ class RESTClientObject(object):
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 proxy_url=configuration.proxy,
-                **addition_pool_args
+                **addition_pool_args,
             )
         else:
             self.pool_manager = urllib3.PoolManager(
@@ -114,7 +114,7 @@ class RESTClientObject(object):
                 ca_certs=ca_certs,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
-                **addition_pool_args
+                **addition_pool_args,
             )
 
     def request(

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "qiskit-serverless-gateway"
+version = "0.1.0"
+requires-python = ">=3.11"

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -2,3 +2,6 @@
 name = "qiskit-serverless-gateway"
 version = "0.1.0"
 requires-python = ">=3.11"
+
+[tool.black]
+line-length = 120

--- a/gateway/tests/core/services/runners/test_fleets_runner.py
+++ b/gateway/tests/core/services/runners/test_fleets_runner.py
@@ -490,16 +490,18 @@ def test_get_result_from_cos_returns_json_string():
     runner._cos.get_object_bytes.return_value = b'{"status": "ok"}'  # pylint: disable=protected-access
     runner._project.cos_bucket_user_data_name = "user-bucket"  # pylint: disable=protected-access
 
-    with patch.object(runner, "_is_cos_configured", return_value=True), patch.object(
-        runner, "_get_fleet_name", return_value="fleet-name"
-    ), patch.object(
-        runner,
-        "_build_cos_paths",
-        return_value={
-            "user_job_prefix": "users/1/provider_functions/p/t/jobs/j",
-            "user_function_prefix": "users/1/provider_functions/p/t",
-            "provider_function_prefix": "providers/p/t",
-        },
+    with (
+        patch.object(runner, "_is_cos_configured", return_value=True),
+        patch.object(runner, "_get_fleet_name", return_value="fleet-name"),
+        patch.object(
+            runner,
+            "_build_cos_paths",
+            return_value={
+                "user_job_prefix": "users/1/provider_functions/p/t/jobs/j",
+                "user_function_prefix": "users/1/provider_functions/p/t",
+                "provider_function_prefix": "providers/p/t",
+            },
+        ),
     ):
         result = runner.get_result_from_cos()
 
@@ -512,9 +514,11 @@ def test_get_result_from_cos_returns_none_on_exception():
     runner._project.cos_bucket_user_data_name = "user-bucket"  # pylint: disable=protected-access
     runner._cos.get_object_bytes.side_effect = RuntimeError("COS error")  # pylint: disable=protected-access
 
-    with patch.object(runner, "_is_cos_configured", return_value=True), patch.object(
-        runner, "_get_fleet_name", return_value="fleet-name"
-    ), patch.object(runner, "_build_cos_paths", return_value={"user_job_prefix": "u/jobs/j"}):
+    with (
+        patch.object(runner, "_is_cos_configured", return_value=True),
+        patch.object(runner, "_get_fleet_name", return_value="fleet-name"),
+        patch.object(runner, "_build_cos_paths", return_value={"user_job_prefix": "u/jobs/j"}),
+    ):
         result = runner.get_result_from_cos()
 
     assert result is None

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -2,3 +2,6 @@
 name = "qiskit-serverless-tests"
 version = "0.1.0"
 requires-python = ">=3.11"
+
+[tool.black]
+line-length = 120

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "qiskit-serverless-tests"
+version = "0.1.0"
+requires-python = ">=3.11"


### PR DESCRIPTION
#### Summary

Add minimal `pyproject.toml` files to `gateway/` and `tests/` to declare them as independent Python subprojects.

#### Comments and details

`gateway/` and `tests/` are already independent Python projects (each has its own virtual environment, dependencies, and tox configuration...) but nothing in the repository declared them as such. A `pyproject.toml` is the standard marker for a Python subproject boundary, and it is recognized by VSCode, PyCharm, linters, type checkers, and other tooling to automatically scope interpreter resolution to the correct subdirectory.

Both files are intentionally minimal (`name`, `version`, `requires-python` only). The existing development workflow is completely unaffected: tox continues to use `tox.ini` and `requirements.txt` as before. The `skipsdist = true` setting in both `tox.ini` files ensures tox does not attempt to install the package even with `pyproject.toml` present.