### PR TITLE
Arguments storage fleets

### DIFF
--- a/gateway/core/services/runners/fleets_runner.py
+++ b/gateway/core/services/runners/fleets_runner.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import io
 import json
 import logging
 import re
@@ -36,7 +35,6 @@ from core.ibm_cloud.code_engine.fleets.utils import (
     build_run_env_variables,
     build_run_volume_mounts,
 )
-from core.services.storage import get_arguments_storage
 
 logger = logging.getLogger("FleetsRunner")
 
@@ -247,7 +245,6 @@ class FleetsRunner(AbstractRunner):
                         "run_commands": run_commands,
                     }
                 )
-                _retry_on_rate_limit(lambda: self._upload_arguments_to_cos(paths))
                 _retry_on_rate_limit(lambda: self._upload_artifact_to_cos(paths))
                 logger.info(
                     "COS configured for job [%s]: user_key=[%s] provider_key=[%s]",
@@ -546,41 +543,10 @@ class FleetsRunner(AbstractRunner):
             "provider_job_prefix": provider_job_prefix,
             "user_log_key": f"{user_job_prefix}/{LOG_FILENAME}",
             "provider_log_key": f"{provider_job_prefix}/{LOG_FILENAME}",
-            "user_arguments_key": f"{user_job_prefix}/arguments.json",
             "user_mount_path": "/data",
             "provider_mount_path": "/function_data",
             "provider_logs_mount_path": "/provider_logs",
         }
-
-    def _upload_arguments_to_cos(self, paths: dict[str, str]) -> None:
-        """Upload job arguments from local storage to the COS user bucket.
-
-        Reads from :class:`ArgumentsStorage` and uploads to
-        ``{user_job_prefix}/arguments.json`` so the SDK's
-        ``get_arguments()`` finds them at ``/data/arguments.json``
-        (via the ``ARGUMENTS_PATH`` env var).
-        Unwraps a single-key ``{"arguments": ...}`` envelope if present.
-
-        Args:
-            paths: Dict from :meth:`_build_cos_paths`.
-        """
-        storage = get_arguments_storage(self.job)
-        content = storage.get() or "{}"
-
-        try:
-            parsed = json.loads(content)
-            if isinstance(parsed, dict) and list(parsed.keys()) == ["arguments"]:
-                content = json.dumps(parsed["arguments"])
-        except (json.JSONDecodeError, TypeError):
-            pass
-
-        user_bucket = self._project.cos_bucket_user_data_name
-        self._get_cos().upload_fileobj(
-            fileobj=io.BytesIO(content.encode("utf-8")),
-            bucket_name=user_bucket,
-            key=paths["user_arguments_key"],
-        )
-        logger.info("Uploaded arguments for job [%s] to %s/%s", self.job.id, user_bucket, paths["user_arguments_key"])
 
     def _upload_artifact_to_cos(self, paths: dict[str, str]) -> None:
         """Extract the program artifact tar and upload files to COS.

--- a/gateway/core/services/storage/__init__.py
+++ b/gateway/core/services/storage/__init__.py
@@ -2,6 +2,7 @@
 
 from core.models import Job, Program
 from core.services.storage.arguments_storage import ArgumentsStorage
+from core.services.storage.arguments_storage_fleets import FleetsArgumentsStorage
 from core.services.storage.arguments_storage_ray import RayArgumentsStorage
 
 
@@ -20,6 +21,5 @@ def get_arguments_storage(job: Job) -> ArgumentsStorage:
     if job.program.runner == Program.RAY:
         return RayArgumentsStorage(job)
     if job.program.runner == Program.FLEETS:
-        # Replace with FleetsArgumentsStorage once implemented
-        return RayArgumentsStorage(job)
+        return FleetsArgumentsStorage(job)
     raise ValueError(f"Unknown runner type: {job.program.runner}")

--- a/gateway/core/services/storage/arguments_storage_fleets.py
+++ b/gateway/core/services/storage/arguments_storage_fleets.py
@@ -25,6 +25,7 @@ class FleetsArgumentsStorage(ArgumentsStorage):
             raise ValueError(f"Job '{job.id}' has no CodeEngineProject assigned")
 
         self._job_id = str(job.id)
+        self._user_id = job.author.id
         self._project = job.code_engine_project
 
         bucket = job.code_engine_project.cos_bucket_user_data_name
@@ -57,7 +58,8 @@ class FleetsArgumentsStorage(ArgumentsStorage):
             key=self._arguments_key,
         )
         logger.info(
-            "[save] job_id=%s bucket=%s key=%s Arguments saved to COS",
+            "[save] user_id=%s job_id=%s bucket=%s key=%s Arguments saved to COS",
+            self._user_id,
             self._job_id,
             self._bucket,
             self._arguments_key,
@@ -68,5 +70,10 @@ class FleetsArgumentsStorage(ArgumentsStorage):
             data = self._get_cos().get_object_bytes(bucket_name=self._bucket, key=self._arguments_key)
             return data.decode("utf-8") if data else None
         except Exception:  # pylint: disable=broad-exception-caught
-            logger.warning("[get] job_id=%s Could not retrieve arguments from COS", self._job_id)
+            logger.warning(
+                "[get] user_id=%s job_id=%s key=%s Could not retrieve arguments from COS",
+                self._user_id,
+                self._job_id,
+                self._arguments_key,
+            )
             return None

--- a/gateway/core/services/storage/arguments_storage_fleets.py
+++ b/gateway/core/services/storage/arguments_storage_fleets.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import io
 import logging
-from typing import Optional
 
 from core.ibm_cloud import get_cos_client
 from core.models import Job
@@ -58,15 +57,5 @@ class FleetsArgumentsStorage(ArgumentsStorage):
             self._arguments_key,
         )
 
-    def get(self) -> Optional[str]:
-        try:
-            data = get_cos_client(self._project).get_object_bytes(bucket_name=self._bucket, key=self._arguments_key)
-            return data.decode("utf-8") if data else None
-        except Exception:  # pylint: disable=broad-exception-caught
-            logger.warning(
-                "[get] user_id=%s job_id=%s key=%s Could not retrieve arguments from COS",
-                self._user_id,
-                self._job_id,
-                self._arguments_key,
-            )
-            return None
+    def get(self) -> str | None:
+        raise NotImplementedError

--- a/gateway/core/services/storage/arguments_storage_fleets.py
+++ b/gateway/core/services/storage/arguments_storage_fleets.py
@@ -57,7 +57,7 @@ class FleetsArgumentsStorage(ArgumentsStorage):
             key=self._arguments_key,
         )
         logger.info(
-            "Arguments for job [%s] saved to COS at %s/%s",
+            "[save] job_id=%s bucket=%s key=%s Arguments saved to COS",
             self._job_id,
             self._bucket,
             self._arguments_key,
@@ -68,5 +68,5 @@ class FleetsArgumentsStorage(ArgumentsStorage):
             data = self._get_cos().get_object_bytes(bucket_name=self._bucket, key=self._arguments_key)
             return data.decode("utf-8") if data else None
         except Exception:  # pylint: disable=broad-exception-caught
-            logger.warning("Could not retrieve arguments for job [%s] from COS", self._job_id)
+            logger.warning("[get] job_id=%s Could not retrieve arguments from COS", self._job_id)
             return None

--- a/gateway/core/services/storage/arguments_storage_fleets.py
+++ b/gateway/core/services/storage/arguments_storage_fleets.py
@@ -1,19 +1,72 @@
 """Fleets implementation of arguments storage."""
 
-from typing import Optional
+from __future__ import annotations
+
+import io
+import logging
+from typing import TYPE_CHECKING, Optional
 
 from core.models import Job
 from core.services.storage.arguments_storage import ArgumentsStorage
 
+if TYPE_CHECKING:
+    from core.ibm_cloud.code_engine.fleets.cos import JobCOS
+
+logger = logging.getLogger("core.FleetsArgumentsStorage")
+
 
 class FleetsArgumentsStorage(ArgumentsStorage):
-    """Handles the storage and retrieval of user arguments for Fleets jobs."""
+    """Handles the storage and retrieval of user arguments for Fleets jobs via COS."""
+
+    ARGUMENTS_FILENAME = "arguments.json"
 
     def __init__(self, job: Job) -> None:
-        self._job_id = str(job.id)
+        if not job.code_engine_project:
+            raise ValueError(f"Job '{job.id}' has no CodeEngineProject assigned")
 
-    def get(self) -> Optional[str]:
-        raise NotImplementedError
+        self._job_id = str(job.id)
+        self._project = job.code_engine_project
+
+        bucket = job.code_engine_project.cos_bucket_user_data_name
+        if not bucket:
+            raise ValueError(
+                f"CodeEngineProject '{self._project.project_name}' has no cos_bucket_user_data_name configured"
+            )
+        self._bucket = bucket
+
+        username = job.author.username
+        provider_name = job.program.provider.name if job.program.provider else None
+        program_title = job.program.title
+
+        if provider_name:
+            path = f"users/{username}/provider_functions/{provider_name}/{program_title}/jobs/{self._job_id}"
+        else:
+            path = f"users/{username}/custom_functions/{program_title}/jobs/{self._job_id}"
+
+        self._arguments_key = f"{path}/{self.ARGUMENTS_FILENAME}"
+
+    def _get_cos(self) -> "JobCOS":
+        from core.ibm_cloud import get_cos_client  # pylint: disable=import-outside-toplevel
+
+        return get_cos_client(self._project)
 
     def save(self, arguments: str) -> None:
-        raise NotImplementedError
+        self._get_cos().upload_fileobj(
+            fileobj=io.BytesIO(arguments.encode("utf-8")),
+            bucket_name=self._bucket,
+            key=self._arguments_key,
+        )
+        logger.info(
+            "Arguments for job [%s] saved to COS at %s/%s",
+            self._job_id,
+            self._bucket,
+            self._arguments_key,
+        )
+
+    def get(self) -> Optional[str]:
+        try:
+            data = self._get_cos().get_object_bytes(bucket_name=self._bucket, key=self._arguments_key)
+            return data.decode("utf-8") if data else None
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.warning("Could not retrieve arguments for job [%s] from COS", self._job_id)
+            return None

--- a/gateway/core/services/storage/arguments_storage_fleets.py
+++ b/gateway/core/services/storage/arguments_storage_fleets.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 import io
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
+from core.ibm_cloud import get_cos_client
 from core.models import Job
 from core.services.storage.arguments_storage import ArgumentsStorage
-
-if TYPE_CHECKING:
-    from core.ibm_cloud.code_engine.fleets.cos import JobCOS
 
 logger = logging.getLogger("core.FleetsArgumentsStorage")
 
@@ -46,13 +44,8 @@ class FleetsArgumentsStorage(ArgumentsStorage):
 
         self._arguments_key = f"{path}/{self.ARGUMENTS_FILENAME}"
 
-    def _get_cos(self) -> "JobCOS":
-        from core.ibm_cloud import get_cos_client  # pylint: disable=import-outside-toplevel
-
-        return get_cos_client(self._project)
-
     def save(self, arguments: str) -> None:
-        self._get_cos().upload_fileobj(
+        get_cos_client(self._project).upload_fileobj(
             fileobj=io.BytesIO(arguments.encode("utf-8")),
             bucket_name=self._bucket,
             key=self._arguments_key,
@@ -67,7 +60,7 @@ class FleetsArgumentsStorage(ArgumentsStorage):
 
     def get(self) -> Optional[str]:
         try:
-            data = self._get_cos().get_object_bytes(bucket_name=self._bucket, key=self._arguments_key)
+            data = get_cos_client(self._project).get_object_bytes(bucket_name=self._bucket, key=self._arguments_key)
             return data.decode("utf-8") if data else None
         except Exception:  # pylint: disable=broad-exception-caught
             logger.warning(

--- a/gateway/tests/api/test_compute_profile.py
+++ b/gateway/tests/api/test_compute_profile.py
@@ -5,11 +5,21 @@ from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
+from unittest.mock import patch
 
-from core.models import CodeEngineProject, Job, Program
+from core.models import Job, Program
 from tests.utils import TestUtils
 
 pytestmark = pytest.mark.django_db
+
+_STORAGE_MOD = "core.services.storage.arguments_storage_fleets.FleetsArgumentsStorage.save"
+
+
+@pytest.fixture(autouse=True)
+def mock_fleets_arguments_storage_save():
+    """Prevent FleetsArgumentsStorage.save() from calling COS in unit tests."""
+    with patch(_STORAGE_MOD):
+        yield
 
 
 @pytest.fixture
@@ -27,20 +37,13 @@ def user(api_client):
 @pytest.fixture
 def ce_project():
     """Create an active CodeEngineProject so select_ce_project() can find one."""
-    return CodeEngineProject.objects.create(
-        project_id="test-ce-project-id",
+    return TestUtils.get_or_create_ce_project(
         project_name="test-project",
-        region="us-east",
-        resource_group_id="rg-id",
-        subnet_pool_id="subnet-id",
-        pds_name_state="pds-state",
-        pds_name_users="pds-users",
-        pds_name_providers="pds-providers",
+        project_id="test-ce-project-id",
+        cos_bucket_user_data_name="user-bucket",
+        cos_bucket_provider_data_name="provider-bucket",
         cos_instance_name="cos-instance",
         cos_key_name="cos-key",
-        cos_bucket_user_data_name="bucket-user",
-        cos_bucket_provider_data_name="bucket-provider",
-        active=True,
     )
 
 

--- a/gateway/tests/core/services/runners/test_fleets_runner.py
+++ b/gateway/tests/core/services/runners/test_fleets_runner.py
@@ -257,10 +257,6 @@ def test_build_cos_paths_custom_function():
 
     assert paths["user_function_prefix"] == "users/alice/provider_functions/default/hello-world"
     assert paths["user_job_prefix"] == "users/alice/provider_functions/default/hello-world/jobs/job-aaa-111"
-    assert (
-        paths["user_arguments_key"]
-        == "users/alice/provider_functions/default/hello-world/jobs/job-aaa-111/arguments.json"
-    )
     assert paths["user_log_key"] == "users/alice/provider_functions/default/hello-world/jobs/job-aaa-111/logs.log"
     assert paths["provider_function_prefix"] == "providers/default/hello-world"
     assert paths["provider_job_prefix"] == "providers/default/hello-world/jobs/job-aaa-111"
@@ -283,10 +279,6 @@ def test_build_cos_paths_provider_function():
 
     assert paths["user_function_prefix"] == "users/alice/provider_functions/good-partner/sampler-v2"
     assert paths["user_job_prefix"] == "users/alice/provider_functions/good-partner/sampler-v2/jobs/job-bbb-222"
-    assert (
-        paths["user_arguments_key"]
-        == "users/alice/provider_functions/good-partner/sampler-v2/jobs/job-bbb-222/arguments.json"
-    )
     assert paths["user_log_key"] == "users/alice/provider_functions/good-partner/sampler-v2/jobs/job-bbb-222/logs.log"
     assert paths["provider_function_prefix"] == "providers/good-partner/sampler-v2"
     assert paths["provider_job_prefix"] == "providers/good-partner/sampler-v2/jobs/job-bbb-222"
@@ -631,25 +623,6 @@ def test_get_fleet_name_falls_back_on_exception():
     result = runner._get_fleet_name()  # pylint: disable=protected-access
 
     assert result == "job-job-uuid"
-
-
-def test_upload_arguments_to_cos_uploads_json():
-    """_upload_arguments_to_cos() reads ArgumentsStorage and uploads to COS."""
-    runner, mock_handler = _make_runner()
-    runner._project.cos_bucket_user_data_name = "user-bucket"  # pylint: disable=protected-access
-    runner.job.program.provider = None
-    runner.job.author.username = "testuser"
-
-    paths = {"user_arguments_key": "users/1/jobs/j/arguments.json"}
-
-    with patch(f"{_RUNNER_MOD}.get_arguments_storage") as mock_storage_cls:
-        mock_storage_cls.return_value.get.return_value = '{"backend_name": "ibm_sherbrooke"}'
-        runner._upload_arguments_to_cos(paths)  # pylint: disable=protected-access
-
-    runner._cos.upload_fileobj.assert_called_once()  # pylint: disable=protected-access
-    call_kwargs = runner._cos.upload_fileobj.call_args.kwargs  # pylint: disable=protected-access
-    assert call_kwargs["bucket_name"] == "user-bucket"
-    assert call_kwargs["key"] == "users/1/jobs/j/arguments.json"
 
 
 def test_build_gateway_env_vars_returns_formatted_list():

--- a/gateway/tests/core/services/storage/test_arguments_storage_fleets.py
+++ b/gateway/tests/core/services/storage/test_arguments_storage_fleets.py
@@ -1,0 +1,46 @@
+# This code is part of a Qiskit project.
+#
+# (C) IBM 2026
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for FleetsArgumentsStorage."""
+
+from unittest.mock import MagicMock
+
+from core.services.storage.arguments_storage_fleets import FleetsArgumentsStorage
+
+
+def _make_job(*, provider_name=None):
+    job = MagicMock()
+    job.id = "job-aaa-111"
+    job.author.username = "alice"
+    job.program.title = "my-program"
+    job.program.provider = MagicMock(name=provider_name) if provider_name else None
+    if provider_name:
+        job.program.provider.name = provider_name
+    job.code_engine_project.project_name = "test-project"
+    job.code_engine_project.cos_bucket_user_data_name = "user-bucket"
+    return job
+
+
+def test_arguments_key_custom_function():
+    """_arguments_key uses custom_functions path when program has no provider."""
+    storage = FleetsArgumentsStorage(_make_job())
+    assert storage._arguments_key == (  # pylint: disable=protected-access
+        "users/alice/custom_functions/my-program/jobs/job-aaa-111/arguments.json"
+    )
+
+
+def test_arguments_key_provider_function():
+    """_arguments_key uses provider_functions path when program has a provider."""
+    storage = FleetsArgumentsStorage(_make_job(provider_name="good-partner"))
+    assert storage._arguments_key == (  # pylint: disable=protected-access
+        "users/alice/provider_functions/good-partner/my-program/jobs/job-aaa-111/arguments.json"
+    )

--- a/gateway/tests/core/services/storage/test_arguments_storage_fleets.py
+++ b/gateway/tests/core/services/storage/test_arguments_storage_fleets.py
@@ -12,35 +12,57 @@
 
 """Tests for FleetsArgumentsStorage."""
 
-from unittest.mock import MagicMock
+import pytest
 
+from core.models import Program
 from core.services.storage.arguments_storage_fleets import FleetsArgumentsStorage
+from tests.utils import TestUtils
 
 
-def _make_job(*, provider_name=None):
-    job = MagicMock()
-    job.id = "job-aaa-111"
-    job.author.username = "alice"
-    job.program.title = "my-program"
-    job.program.provider = MagicMock(name=provider_name) if provider_name else None
-    if provider_name:
-        job.program.provider.name = provider_name
-    job.code_engine_project.project_name = "test-project"
-    job.code_engine_project.cos_bucket_user_data_name = "user-bucket"
-    return job
+@pytest.mark.django_db
+class TestFleetsArgumentsStorage:
+    """Tests for FleetsArgumentsStorage path generation."""
 
+    @pytest.fixture
+    def ce_project(self):
+        return TestUtils.get_or_create_ce_project(
+            project_name="test-project",
+            project_id="test-ce-project-id",
+            cos_bucket_user_data_name="user-bucket",
+            cos_bucket_provider_data_name="provider-bucket",
+            cos_instance_name="cos-instance",
+            cos_key_name="cos-key",
+        )
 
-def test_arguments_key_custom_function():
-    """_arguments_key uses custom_functions path when program has no provider."""
-    storage = FleetsArgumentsStorage(_make_job())
-    assert storage._arguments_key == (  # pylint: disable=protected-access
-        "users/alice/custom_functions/my-program/jobs/job-aaa-111/arguments.json"
-    )
+    @pytest.fixture
+    def job(self, ce_project):
+        program = TestUtils.create_program(
+            program_title="my-program",
+            author="alice",
+            runner=Program.FLEETS,
+        )
+        return TestUtils.create_job(author="alice", program=program, code_engine_project=ce_project)
 
+    @pytest.fixture
+    def job_with_provider(self, ce_project):
+        program = TestUtils.create_program(
+            program_title="my-program",
+            author="alice",
+            provider="good-partner",
+            runner=Program.FLEETS,
+        )
+        return TestUtils.create_job(author="alice", program=program, code_engine_project=ce_project)
 
-def test_arguments_key_provider_function():
-    """_arguments_key uses provider_functions path when program has a provider."""
-    storage = FleetsArgumentsStorage(_make_job(provider_name="good-partner"))
-    assert storage._arguments_key == (  # pylint: disable=protected-access
-        "users/alice/provider_functions/good-partner/my-program/jobs/job-aaa-111/arguments.json"
-    )
+    def test_arguments_key_custom_function(self, job):
+        """_arguments_key uses custom_functions path when program has no provider."""
+        storage = FleetsArgumentsStorage(job)
+        assert storage._arguments_key == (  # pylint: disable=protected-access
+            f"users/alice/custom_functions/my-program/jobs/{job.id}/arguments.json"
+        )
+
+    def test_arguments_key_provider_function(self, job_with_provider):
+        """_arguments_key uses provider_functions path when program has a provider."""
+        storage = FleetsArgumentsStorage(job_with_provider)
+        assert storage._arguments_key == (  # pylint: disable=protected-access
+            f"users/alice/provider_functions/good-partner/my-program/jobs/{job_with_provider.id}/arguments.json"
+        )

--- a/gateway/tests/utils.py
+++ b/gateway/tests/utils.py
@@ -13,7 +13,7 @@ from rest_framework.test import APIClient
 from core.domain.authorization.function_access_entry import FunctionAccessEntry
 from core.domain.authorization.function_access_result import FunctionAccessResult
 from core.domain.business_models import BusinessModel
-from core.models import Job, JobConfig, JobEvent, Program, Provider, ComputeResource
+from core.models import Job, JobConfig, JobEvent, Program, Provider, ComputeResource, CodeEngineProject
 from core.model_managers.job_events import JobEventOrigin, JobEventContext, JobEventType
 
 # literal for job status
@@ -140,6 +140,63 @@ class TestUtils:
             },
         )
         return compute_resource
+
+    @staticmethod
+    def get_or_create_ce_project(
+        project_name: str,
+        project_id: str,
+        region: str = "us-east",
+        active: bool = True,
+        resource_group_id: str = "rg-id",
+        subnet_pool_id: str = "subnet-id",
+        pds_name_state: str = "pds-state",
+        pds_name_users: str = "pds-users",
+        pds_name_providers: str = "pds-providers",
+        cos_bucket_user_data_name: str = None,
+        cos_bucket_provider_data_name: str = None,
+        cos_instance_name: str = None,
+        cos_key_name: str = None,
+    ) -> CodeEngineProject:
+        """Get or create a CodeEngineProject instance.
+
+        Retrieves an existing CodeEngineProject by project_name or creates a new one.
+
+        Args:
+            project_name: Unique name for the Code Engine project.
+            project_id: IBM Cloud project UUID.
+            region: IBM Cloud region. Default is "us-east".
+            active: Whether the project is active. Default is True.
+            resource_group_id: IBM Cloud resource group ID. Default is "rg-id".
+            subnet_pool_id: Subnet pool ID for network placement. Default is "subnet-id".
+            pds_name_state: PDS name for task state. Default is "pds-state".
+            pds_name_users: PDS name for user data. Default is "pds-users".
+            pds_name_providers: PDS name for provider data. Default is "pds-providers".
+            cos_bucket_user_data_name: COS bucket for user data. Default is None.
+            cos_bucket_provider_data_name: COS bucket for provider data. Default is None.
+            cos_instance_name: COS instance name. Default is None.
+            cos_key_name: COS HMAC key name. Default is None.
+
+        Returns:
+            CodeEngineProject instance.
+        """
+        ce_project, _ = CodeEngineProject.objects.get_or_create(
+            project_name=project_name,
+            defaults={
+                "project_id": project_id,
+                "region": region,
+                "active": active,
+                "resource_group_id": resource_group_id,
+                "subnet_pool_id": subnet_pool_id,
+                "pds_name_state": pds_name_state,
+                "pds_name_users": pds_name_users,
+                "pds_name_providers": pds_name_providers,
+                "cos_bucket_user_data_name": cos_bucket_user_data_name,
+                "cos_bucket_provider_data_name": cos_bucket_provider_data_name,
+                "cos_instance_name": cos_instance_name,
+                "cos_key_name": cos_key_name,
+            },
+        )
+        return ce_project
 
     @staticmethod
     def _humanize_permission_name(codename: str, model: str) -> str:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Arguments persistence for Fleets jobs was happening inside `FleetsRunner.submit()` at run time, which is the wrong place — it should happen at job-creation time via the `get_arguments_storage` factory, consistent with how Ray jobs work.

- Implement **FleetsArgumentsStorage**: COS-backed `save()` and `get()` with the arguments key built from the job's author, provider, program title, and job ID. Raises loudly if the project or bucket is missing, since a Fleets job always has a `CodeEngineProject` assigned by serializer time.

- Wire the factory: `get_arguments_storage` now routes `Program.FLEETS` to `FleetsArgumentsStorage` instead of the `RayArgumentsStorage` placeholder.

- Remove upload logic from FleetsRunner: `_upload_arguments_to_cos` and its call in `submit()` are deleted — the runner no longer owns this responsibility.

- Add TestUtils.get_or_create_ce_project(): Reusable helper following the existing `get_or_create_*` convention, replacing repeated inline `CodeEngineProject` creation across test files.

Co-authored-by: @korgan00