### PR TITLE
Fix settings configuration

### DIFF
--- a/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
+++ b/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
@@ -121,10 +121,6 @@ spec:
               value: {{ .Values.application.auth.mechanism | quote }}
             - name: SETTINGS_AUTH_MOCK_TOKEN
               value: {{ .Values.application.auth.token.mock | quote }}
-            - name: QUANTUM_PLATFORM_API_BASE_URL
-              value: {{ .Values.application.auth.token.url | quote }}
-            - name: SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD
-              value: {{ .Values.application.auth.token.verificationField | quote }}
             - name: IAM_IBM_CLOUD_BASE_URL
               value: {{ .Values.application.auth.token.iamUrl | quote }}
             - name: IAM_IBM_CLOUD_CACHE_TTL

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -371,9 +371,8 @@ RUNTIME_API_CACHE_TTL = int(os.environ.get("RUNTIME_API_CACHE_TTL", "60"))
 
 IAM_IBM_CLOUD_BASE_URL = os.environ.get("IAM_IBM_CLOUD_BASE_URL") or "https://iam.test.cloud.ibm.com"
 IAM_IBM_CLOUD_CACHE_TTL = int(os.environ.get("IAM_IBM_CLOUD_CACHE_TTL", "60"))
-RESOURCE_CONTROLLER_IBM_CLOUD_BASE_URL = os.environ.get(
-    "RESOURCE_CONTROLLER_IBM_CLOUD_BASE_URL",
-    "https://resource-controller.test.cloud.ibm.com",
+RESOURCE_CONTROLLER_IBM_CLOUD_BASE_URL = (
+    os.environ.get("RESOURCE_CONTROLLER_IBM_CLOUD_BASE_URL") or "https://resource-controller.test.cloud.ibm.com"
 )
 RESOURCE_PLANS_ID_ALLOWED = os.environ.get("RESOURCE_PLANS_ID_ALLOWED", "").split(",")
 

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -218,7 +218,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # =============
 # AUTH SETTINGS
 # =============
-SETTINGS_AUTH_MECHANISM = os.environ.get("SETTINGS_AUTH_MECHANISM", "custom_token")
+SETTINGS_AUTH_MECHANISM = os.environ.get("SETTINGS_AUTH_MECHANISM") or "custom_token"
 ALL_AUTH_CLASSES_CONFIGURATION = {
     "custom_token": [
         "api.authentication.CustomTokenBackend",

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -258,24 +258,6 @@ SWAGGER_SETTINGS = {
 SITE_ID = 1
 SITE_HOST = os.environ.get("SITE_HOST", "http://localhost:8001" if IS_SCHEDULER else "http://localhost:8000")
 
-# custom token auth
-QUANTUM_PLATFORM_API_BASE_URL = os.environ.get("QUANTUM_PLATFORM_API_BASE_URL", None)
-# verification fields to check when returned from auth api
-# Example of checking multiple fields:
-#    For following verification data
-#    {
-#       "is_valid": true,
-#       "some": {
-#         "nested": {
-#           "field": true
-#         },
-#         "other": "bla"
-#       }
-#    }
-#   setting string will be:
-#    "SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD", "is_valid;some,nested,field"
-SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD = os.environ.get("SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD", None)
-
 # resources limitations
 LIMITS_JOBS_PER_USER = int(os.environ.get("LIMITS_JOBS_PER_USER", "2"))
 LIMITS_ACTIVE_JOBS_PER_USER = int(os.environ.get("LIMITS_ACTIVE_JOBS_PER_USER", "50"))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #2150 @avilches and I found an error in the environment variables configuration in `settings.py`:

```py
SETTINGS_AUTH_MECHANISM = os.environ.get("SETTINGS_AUTH_MECHANISM", "custom_token")
```

Basically this configuration doesn't set the variable to the default value when the value is "". To prevent this we changed the logic to:

```py
SETTINGS_AUTH_MECHANISM = os.environ.get("SETTINGS_AUTH_MECHANISM") or "custom_token"
```

Now the `or` keyword guarantees that `None` or `""` will always get the default value.

Along with these changes I removed `QUANTUM_PLATFORM_API_BASE_URL` and `SETTINGS_TOKEN_AUTH_VERIFICATION_FIELD` as they are not being used now (this will require also an update in the internal repository).