### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/client-verify.yaml
+++ b/.github/workflows/client-verify.yaml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false # keep running if one leg fails
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Security vulnerabilities must be privately reported by following our [Security P
 
 You'll need to install these tools on your development environment:
 
-1. [python](https://www.python.org/): the language qiskit-serverless is written in (Note that we currently support Python >=3.9,<=3.13).
+1. [python](https://www.python.org/): the language qiskit-serverless is written in (Note that we currently support Python >=10,<=3.13).
 1. [git](https://git-scm.com/): for source control
 1. [docker](https://docs.docker.com/engine/install/) or [podman](https://podman.io/): for building dev environment
 1. [kubectl](https://kubectl.docs.kubernetes.io/): for interacting with Kubernetes clusters

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Security vulnerabilities must be privately reported by following our [Security P
 
 You'll need to install these tools on your development environment:
 
-1. [python](https://www.python.org/): the language qiskit-serverless is written in (Note that we currently support Python >=10,<=3.13).
+1. [python](https://www.python.org/): the language qiskit-serverless is written in (Note that we currently support Python >=3.10,<=3.13).
 1. [git](https://git-scm.com/): for source control
 1. [docker](https://docs.docker.com/engine/install/) or [podman](https://podman.io/): for building dev environment
 1. [kubectl](https://kubectl.docs.kubernetes.io/): for interacting with Kubernetes clusters

--- a/client/README.md
+++ b/client/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/github/license/qiskit-community/quantum-prototype-template?label=License)](https://github.com/qiskit-community/quantum-prototype-template/blob/main/LICENSE.txt)
 [![Code style: Black](https://img.shields.io/badge/Code%20style-Black-000.svg)](https://github.com/psf/black)
 [![Python](https://img.shields.io/badge/Python-3.10--3.13-informational)](https://www.python.org/)
-[![Qiskit](https://img.shields.io/badge/Qiskit-%E2%89%A5%200.39.0-6133BD)](https://github.com/Qiskit/qiskit)
+[![Qiskit](https://img.shields.io/badge/Qiskit-%E2%89%A5%201.4.0-6133BD)](https://github.com/Qiskit/qiskit)
 
 # Qiskit Serverless client
 

--- a/client/README.md
+++ b/client/README.md
@@ -2,7 +2,7 @@
 [![Client verify process](https://github.com/Qiskit/qiskit-serverless/actions/workflows/client-verify.yaml/badge.svg)](https://github.com/Qiskit/qiskit-serverless/actions/workflows/client-verify.yaml)
 [![License](https://img.shields.io/github/license/qiskit-community/quantum-prototype-template?label=License)](https://github.com/qiskit-community/quantum-prototype-template/blob/main/LICENSE.txt)
 [![Code style: Black](https://img.shields.io/badge/Code%20style-Black-000.svg)](https://github.com/psf/black)
-[![Python](https://img.shields.io/badge/Python-3.9--3.13-informational)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/Python-3.10--3.13-informational)](https://www.python.org/)
 [![Qiskit](https://img.shields.io/badge/Qiskit-%E2%89%A5%200.39.0-6133BD)](https://github.com/Qiskit/qiskit)
 
 # Qiskit Serverless client

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qiskit-serverless"
 description = "An open-source SDK for resource management in quantum computing workflows."
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "Apache 2.0"}
 authors = [
     { name = "Qiskit Serverless Team", email = "qiskit@us.ibm.com" },
@@ -24,7 +24,6 @@ classifiers=[
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",
     "Operating System :: Microsoft :: Windows",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/client/tox.ini
+++ b/client/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.0
-envlist = py39, py310, py311, py312, py313, lint, coverage
+envlist = py310, py311, py312, py313, lint, coverage
 # CI: skip-next-line
 skipsdist = true
 # CI: skip-next-line

--- a/releasenotes/notes/drop-python-3-9-support-19ff2bdc207bfcac.yaml
+++ b/releasenotes/notes/drop-python-3-9-support-19ff2bdc207bfcac.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Python 3.9 has reached end-of-life and is no longer supported. The minimum
+    supported Python version is now ``3.10``. Users still on Python 3.9 should
+    upgrade before installing this release.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Python 3.9 reached end-of-life on October 5, 2025, but we didn't fully remove it from our pipelines/package, which is starting to cause issues now. This PR removes it from CI and updates the package's minimum required version.

### Details and comments
I already removed the Python 3.9 client check from the branch protection rules to make sure it doesn't cause issues with the merge.
