### PR TITLE
Consolidate fleets env var construction into single function

### DIFF
--- a/gateway/core/ibm_cloud/code_engine/fleets/utils.py
+++ b/gateway/core/ibm_cloud/code_engine/fleets/utils.py
@@ -28,7 +28,7 @@ Example::
     mounts = build_run_volume_mounts(
         mounts=[("/output", "my-pds", "user/job-1")]
     )
-    env = build_run_env_variables(paths)
+    env = build_run_env_variables(paths, decrypted_env_vars)
     cmds = build_run_commands(app_run_commands=["python", "main.py"])
 """
 
@@ -149,56 +149,43 @@ def build_run_volume_mounts(
 
 def build_run_env_variables(
     paths: FleetJobPaths,
-    extra: list[dict[str, str]] | None = None,
+    stored_env_vars: dict[str, str | None],
 ) -> list[dict[str, str]]:
-    """
-    Build environment variables used by the logging wrapper command.
+    """Build the complete environment variable list for the Fleets container.
+
+    Starts with decrypted stored job env vars as the base, then overlays
+    system vars derived from paths. System vars always win on collision since
+    they define the container's filesystem layout. New vars added at job
+    creation time flow through automatically.
 
     Args:
         paths: Pre-computed paths for the job (from :func:`build_job_paths`).
-        extra: Additional environment variable definitions appended after the
-            ones built by this function.
+        stored_env_vars: Decrypted env vars dict from ``job.env_vars``.
 
     Returns:
-        Environment variable definitions for ``run_env_variables``.
+        List of env var dicts in Code Engine format
+        ``[{"type": "literal", "name": "...", "value": "..."}]``.
+        Empty values are excluded.
     """
+    env = dict(stored_env_vars)
+
+    gateway_host = getattr(settings, "FLEETS_GATEWAY_HOST", None)
+    if gateway_host:
+        env["ENV_JOB_GATEWAY_HOST"] = gateway_host
+
     flush_interval = getattr(settings, "FLEETS_LOG_FLUSH_INTERVAL_SECONDS", 15)
-    system_vars = [
+    env.update(
         {
-            "type": "literal",
-            "name": "PUBLIC_LOG_PATH",
-            "value": paths.container_public_log_path,
-        },
-        {
-            "type": "literal",
-            "name": "ARGUMENTS_PATH",
-            "value": paths.container_arguments_path,
-        },
-        {
-            "type": "literal",
-            "name": "RESULTS_PATH",
-            "value": paths.container_result_path,
-        },
-        {
-            "type": "literal",
-            "name": "LOG_FLUSH_INTERVAL_SECONDS",
-            "value": str(flush_interval),
-        },
-    ]
-
+            "PUBLIC_LOG_PATH": paths.container_public_log_path,
+            "ARGUMENTS_PATH": paths.container_arguments_path,
+            "RESULTS_PATH": paths.container_result_path,
+            "LOG_FLUSH_INTERVAL_SECONDS": str(flush_interval),
+        }
+    )
     if paths.container_private_log_path is not None:
-        system_vars.append(
-            {
-                "type": "literal",
-                "name": "PRIVATE_LOG_PATH",
-                "value": paths.container_private_log_path,
-            }
-        )
+        env["PRIVATE_LOG_PATH"] = paths.container_private_log_path
 
-    # Add the job env vars without overwriting the system vars
-    system_names = {v["name"] for v in system_vars}
-    user_vars = [e for e in (extra or []) if e["name"] not in system_names]
-    return system_vars + user_vars
+    return [{"type": "literal", "name": k, "value": v} for k, v in env.items() if v]
 
 
 def build_run_commands(

--- a/gateway/core/services/runners/fleets_runner.py
+++ b/gateway/core/services/runners/fleets_runner.py
@@ -201,7 +201,9 @@ class FleetsRunner(AbstractRunner):
                 paths = build_job_paths(self.job)
 
                 run_volume_mounts = build_run_volume_mounts_for_job(paths, self._project)
-                run_env_variables = build_run_env_variables(paths, self._build_job_env_vars())
+                stored_env_vars = json.loads(self.job.env_vars)
+                stored_env_vars = decrypt_env_vars(stored_env_vars)
+                run_env_variables = build_run_env_variables(paths, stored_env_vars)
                 run_commands = build_run_commands(
                     app_run_commands=["python", paths.container_entrypoint],
                     is_provider_function=self.job.program.provider is not None,
@@ -466,14 +468,6 @@ class FleetsRunner(AbstractRunner):
         if self._cos is None:
             self._cos = get_cos_client(self._project)
         return self._cos
-
-    def _build_job_env_vars(self) -> list[dict[str, str]]:
-        """Extract job env vars so the container can call save_result() and use Qiskit Runtime."""
-        env = json.loads(self.job.env_vars)
-        env = decrypt_env_vars(env)
-        env["ENV_JOB_GATEWAY_HOST"] = settings.FLEETS_GATEWAY_HOST
-
-        return [{"type": "literal", "name": k, "value": v} for k, v in env.items() if v]
 
     def _upload_artifact_to_cos(self, paths: FleetJobPaths) -> None:
         """Extract the program artifact tar and upload files to COS.

--- a/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_fleet_handler.py
+++ b/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_fleet_handler.py
@@ -170,7 +170,8 @@ def test_submit_job_with_builder_extra_fields(mock_fleets_api_cls, project_id, b
                 container_private_log_path=None,
                 container_arguments_path="/output/arguments.json",
                 container_result_path="/output/results.json",
-            )
+            ),
+            {},
         ),
         "run_commands": build_run_commands(app_run_commands=["python", "main.py"]),
     }
@@ -691,58 +692,100 @@ def _make_paths(public_log_path="/output/logs.log", private_log_path=None, argum
     )
 
 
-def test_build_run_env_variables_public_only():
-    """build_run_env_variables returns PUBLIC_LOG_PATH, ARGUMENTS_PATH and RESULTS_PATH without PRIVATE_LOG_PATH."""
-    result = build_run_env_variables(_make_paths())
-    names = {e["name"] for e in result}
-    assert "PRIVATE_LOG_PATH" not in names
-    assert "PUBLIC_LOG_PATH" in names
-    assert "ARGUMENTS_PATH" in names
-    assert "RESULTS_PATH" in names
-    assert "LOG_FLUSH_INTERVAL_SECONDS" in names
+def test_build_run_env_variables_passes_through_stored_vars():
+    """build_run_env_variables passes stored env vars through to output."""
+    stored = {"ENV_JOB_GATEWAY_TOKEN": "tok", "CUSTOM_VAR": "custom"}
+    result = build_run_env_variables(_make_paths(), stored)
+    by_name = {e["name"]: e["value"] for e in result}
+    assert by_name["ENV_JOB_GATEWAY_TOKEN"] == "tok"
+    assert by_name["CUSTOM_VAR"] == "custom"
+    assert all(e["type"] == "literal" for e in result)
 
 
-def test_build_run_env_variables_with_private_path():
-    """build_run_env_variables exposes PRIVATE_LOG_PATH when container_private_log_path is set."""
+def test_build_run_env_variables_overlays_system_vars():
+    """build_run_env_variables includes system vars derived from paths."""
+    result = build_run_env_variables(_make_paths(), {})
+    by_name = {e["name"]: e["value"] for e in result}
+    assert by_name["PUBLIC_LOG_PATH"] == "/output/logs.log"
+    assert by_name["ARGUMENTS_PATH"] == "/output/arguments.json"
+    assert by_name["RESULTS_PATH"] == "/output/results.json"
+    assert by_name["LOG_FLUSH_INTERVAL_SECONDS"] == "15"
+    assert "PRIVATE_LOG_PATH" not in by_name
+
+
+def test_build_run_env_variables_system_vars_override_stored():
+    """build_run_env_variables system vars override stored vars with the same name."""
+    stored = {"ARGUMENTS_PATH": "/old/stale/path", "RESULTS_PATH": "/old/results.json"}
+    result = build_run_env_variables(_make_paths(arguments_path="/data/arguments.json"), stored)
+    names = [e["name"] for e in result]
+    assert len(names) == len(set(names)), f"Duplicate env var names: {names}"
+    by_name = {e["name"]: e["value"] for e in result}
+    assert by_name["ARGUMENTS_PATH"] == "/data/arguments.json"
+    assert by_name["RESULTS_PATH"] == "/output/results.json"
+
+
+def test_build_run_env_variables_no_duplicates():
+    """build_run_env_variables produces no duplicate env var names."""
+    stored = {"PUBLIC_LOG_PATH": "/old", "RESULTS_PATH": "/old/r.json", "MY_VAR": "v"}
+    result = build_run_env_variables(_make_paths(), stored)
+    names = [e["name"] for e in result]
+    assert len(names) == len(set(names))
+
+
+def test_build_run_env_variables_excludes_empty_values():
+    """build_run_env_variables excludes entries with empty or falsy values."""
+    stored = {"KEEP": "yes", "DROP": "", "ALSO_DROP": None}
+    result = build_run_env_variables(_make_paths(), stored)
+    by_name = {e["name"]: e["value"] for e in result}
+    assert "KEEP" in by_name
+    assert "DROP" not in by_name
+    assert "ALSO_DROP" not in by_name
+
+
+def test_build_run_env_variables_with_private_log():
+    """build_run_env_variables includes PRIVATE_LOG_PATH when container_private_log_path is set."""
     result = build_run_env_variables(
-        _make_paths(
-            public_log_path="/public/logs.log",
-            private_log_path="/private/logs.log",
-        )
+        _make_paths(public_log_path="/public/logs.log", private_log_path="/private/logs.log"),
+        {},
     )
     by_name = {e["name"]: e["value"] for e in result}
     assert by_name["PUBLIC_LOG_PATH"] == "/public/logs.log"
     assert by_name["PRIVATE_LOG_PATH"] == "/private/logs.log"
 
 
-def test_build_run_env_variables_default_flush_interval():
-    """build_run_env_variables defaults LOG_FLUSH_INTERVAL_SECONDS to 15 when setting is absent."""
-    result = build_run_env_variables(_make_paths())
-    interval = next(e for e in result if e["name"] == "LOG_FLUSH_INTERVAL_SECONDS")
-    assert interval["value"] == "15"
+def test_build_run_env_variables_without_private_log():
+    """build_run_env_variables omits PRIVATE_LOG_PATH when container_private_log_path is None."""
+    result = build_run_env_variables(_make_paths(private_log_path=None), {})
+    names = {e["name"] for e in result}
+    assert "PRIVATE_LOG_PATH" not in names
+
+
+def test_build_run_env_variables_gateway_host_override():
+    """build_run_env_variables overrides ENV_JOB_GATEWAY_HOST from FLEETS_GATEWAY_HOST setting."""
+    stored = {"ENV_JOB_GATEWAY_HOST": "https://original.example.com"}
+    with patch("core.ibm_cloud.code_engine.fleets.utils.settings") as mock_settings:
+        mock_settings.FLEETS_GATEWAY_HOST = "https://fleets.example.com"
+        mock_settings.FLEETS_LOG_FLUSH_INTERVAL_SECONDS = 15
+        result = build_run_env_variables(_make_paths(), stored)
+    by_name = {e["name"]: e["value"] for e in result}
+    assert by_name["ENV_JOB_GATEWAY_HOST"] == "https://fleets.example.com"
+
+
+def test_build_run_env_variables_flush_interval_default():
+    """build_run_env_variables defaults LOG_FLUSH_INTERVAL_SECONDS to 15."""
+    result = build_run_env_variables(_make_paths(), {})
+    by_name = {e["name"]: e["value"] for e in result}
+    assert by_name["LOG_FLUSH_INTERVAL_SECONDS"] == "15"
 
 
 def test_build_run_env_variables_flush_interval_from_settings():
-    """build_run_env_variables reads LOG_FLUSH_INTERVAL_SECONDS from FLEETS_LOG_FLUSH_INTERVAL_SECONDS setting."""
+    """build_run_env_variables reads LOG_FLUSH_INTERVAL_SECONDS from settings."""
     with patch("core.ibm_cloud.code_engine.fleets.utils.settings") as mock_settings:
         mock_settings.FLEETS_LOG_FLUSH_INTERVAL_SECONDS = 42
-        result = build_run_env_variables(_make_paths())
-    interval = next(e for e in result if e["name"] == "LOG_FLUSH_INTERVAL_SECONDS")
-    assert interval["value"] == "42"
-
-
-def test_build_run_env_variables_arguments_path():
-    """build_run_env_variables includes ARGUMENTS_PATH from paths."""
-    result = build_run_env_variables(_make_paths(arguments_path="/data/arguments.json"))
+        mock_settings.FLEETS_GATEWAY_HOST = None
+        result = build_run_env_variables(_make_paths(), {})
     by_name = {e["name"]: e["value"] for e in result}
-    assert by_name["ARGUMENTS_PATH"] == "/data/arguments.json"
-
-
-def test_build_run_env_variables_results_path():
-    """build_run_env_variables includes RESULTS_PATH from paths."""
-    result = build_run_env_variables(_make_paths())
-    by_name = {e["name"]: e["value"] for e in result}
-    assert by_name["RESULTS_PATH"] == "/output/results.json"
+    assert by_name["LOG_FLUSH_INTERVAL_SECONDS"] == "42"
 
 
 def test_build_run_commands_public_only():

--- a/gateway/tests/core/services/runners/test_fleets_runner.py
+++ b/gateway/tests/core/services/runners/test_fleets_runner.py
@@ -568,60 +568,6 @@ def test_get_fleet_name_falls_back_on_exception():
     assert result == "job-job-uuid"
 
 
-def test_build_job_env_vars_returns_formatted_list():
-    """_build_job_env_vars() returns env vars formatted for Code Engine."""
-    runner, _ = _make_runner()
-    runner.job.env_vars = '{"KEY1": "val1", "KEY2": "val2"}'
-
-    with _patch_settings(FLEETS_GATEWAY_HOST=None), patch(f"{_RUNNER_MOD}.decrypt_env_vars", side_effect=lambda e: e):
-        result = runner._build_job_env_vars()  # pylint: disable=protected-access
-
-    assert {"type": "literal", "name": "KEY1", "value": "val1"} in result
-    assert {"type": "literal", "name": "KEY2", "value": "val2"} in result
-
-
-def test_build_job_env_vars_decrypts_tokens():
-    """_build_job_env_vars() passes env vars through decrypt_env_vars."""
-    runner, _ = _make_runner()
-    runner.job.env_vars = '{"QISKIT_IBM_TOKEN": "encrypted", "SOME_URL": "http://example.com"}'
-
-    decrypted = {"QISKIT_IBM_TOKEN": "decrypted", "SOME_URL": "http://example.com"}
-    with (
-        _patch_settings(FLEETS_GATEWAY_HOST=None),
-        patch(f"{_RUNNER_MOD}.decrypt_env_vars", return_value=decrypted) as mock_decrypt,
-    ):
-        result = runner._build_job_env_vars()  # pylint: disable=protected-access
-
-    mock_decrypt.assert_called_once_with({"QISKIT_IBM_TOKEN": "encrypted", "SOME_URL": "http://example.com"})
-    assert {"type": "literal", "name": "QISKIT_IBM_TOKEN", "value": "decrypted"} in result
-    assert {"type": "literal", "name": "SOME_URL", "value": "http://example.com"} in result
-
-
-def test_build_job_env_vars_filters_empty_values():
-    """_build_job_env_vars() excludes entries with empty or None values."""
-    runner, _ = _make_runner()
-    runner.job.env_vars = '{"KEEP": "value", "EMPTY": "", "NULL_VAL": null}'
-
-    def passthrough(e):
-        return e
-
-    with _patch_settings(FLEETS_GATEWAY_HOST=None), patch(f"{_RUNNER_MOD}.decrypt_env_vars", side_effect=passthrough):
-        result = runner._build_job_env_vars()  # pylint: disable=protected-access
-
-    assert result == [{"type": "literal", "name": "KEEP", "value": "value"}]
-
-
-def test_build_job_env_vars_empty_env_vars():
-    """_build_job_env_vars() returns an empty list when job has no env vars and no gateway host."""
-    runner, _ = _make_runner()
-    runner.job.env_vars = "{}"
-
-    with _patch_settings(FLEETS_GATEWAY_HOST=None), patch(f"{_RUNNER_MOD}.decrypt_env_vars", return_value={}):
-        result = runner._build_job_env_vars()  # pylint: disable=protected-access
-
-    assert result == []
-
-
 def test_submit_includes_gateway_env_vars():
     """submit() includes decrypted gateway env vars in the run_env_variables."""
     runner, mock_handler = _make_submit_runner()
@@ -644,22 +590,12 @@ def test_submit_includes_gateway_env_vars():
 
     call_kwargs = mock_handler.submit_job.call_args.kwargs
     env_list = call_kwargs["extra_fields"]["run_env_variables"]
-    assert {"type": "literal", "name": "MY_TOKEN", "value": "decrypted_secret"} in env_list
-    assert {"type": "literal", "name": "MY_URL", "value": "http://example.com"} in env_list
-
-
-def test_build_job_env_vars_includes_gateway_host():
-    """_build_job_env_vars() injects ENV_JOB_GATEWAY_HOST from settings.FLEETS_GATEWAY_HOST."""
-    runner, _ = _make_runner()
-    runner.job.env_vars = "{}"
-
-    with (
-        _patch_settings(FLEETS_GATEWAY_HOST="https://gateway.example.com"),
-        patch(f"{_RUNNER_MOD}.decrypt_env_vars", return_value={}),
-    ):
-        result = runner._build_job_env_vars()  # pylint: disable=protected-access
-
-    assert {"type": "literal", "name": "ENV_JOB_GATEWAY_HOST", "value": "https://gateway.example.com"} in result
+    by_name = {e["name"]: e["value"] for e in env_list}
+    assert by_name["MY_TOKEN"] == "decrypted_secret"
+    assert by_name["MY_URL"] == "http://example.com"
+    assert by_name["ARGUMENTS_PATH"] == "/data/arguments.json"
+    assert by_name["RESULTS_PATH"] == "/data/results.json"
+    assert by_name["PUBLIC_LOG_PATH"] == "/data/logs.log"
 
 
 def test_submit_arguments_path_set_exactly_once():


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Consolidate all container env var assembly into build_run_env_variables().


### Details and comments

- Move gateway host override and system var overlay into the builder
- Remove _build_job_env_vars() from fleets_runner.py
- Use dict.update() for transparent override (no hidden collision filtering)
- Caller does parse + decrypt, builder does the rest
- Update tests to match new signature