### PR TITLE
(do not merge) Integration test for log size truncation (PR #2179)

### DIFF
--- a/docker-compose-fleets-test.yaml
+++ b/docker-compose-fleets-test.yaml
@@ -30,6 +30,7 @@ x-gateway-env: &gateway-env
   CE_COS_INSTANCE_NAME: test-cos-instance
   CE_COS_KEY_NAME: test-cos-key
   FLEETS_GATEWAY_HOST: http://gateway:8000
+  FUNCTIONS_LOGS_SIZE_LIMIT: "51200"  # 50 KB for log truncation tests
   # Explicit opt-out of OTEL span export (default is "0" — set for clarity).
   OTEL_ENABLED: "0"
 

--- a/gateway/core/ibm_cloud/code_engine/fleets/utils.py
+++ b/gateway/core/ibm_cloud/code_engine/fleets/utils.py
@@ -180,6 +180,7 @@ def build_run_env_variables(
             "ARGUMENTS_PATH": paths.container_arguments_path,
             "RESULTS_PATH": paths.container_result_path,
             "LOG_FLUSH_INTERVAL_SECONDS": str(flush_interval),
+            "LOG_SIZE_LIMIT_BYTES": str(settings.FUNCTIONS_LOGS_SIZE_LIMIT),
         }
     )
     if paths.container_private_log_path is not None:

--- a/gateway/templates/fleet_custom_job_wrapper.tmpl
+++ b/gateway/templates/fleet_custom_job_wrapper.tmpl
@@ -18,6 +18,9 @@ set -eu
 # Upload period (seconds) between local -> COS copies. Defaults to 15s.
 INTERVAL="${LOG_FLUSH_INTERVAL_SECONDS:-15}"
 
+# Maximum bytes of log content uploaded to COS. Defaults to 50 MB.
+LOG_SIZE_LIMIT_BYTES="${LOG_SIZE_LIMIT_BYTES:-52428800}"
+
 # Local working file. Append-only, fast, never read by COS during the run.
 LOCAL_PUBLIC="/tmp/public.log"
 
@@ -31,6 +34,44 @@ file_size() {
   stat -c %s "$1" 2>/dev/null || echo -1
 }
 
+# Copies src to dst, capping output at LOG_SIZE_LIMIT_BYTES.
+# When the source exceeds the limit the last LOG_SIZE_LIMIT_BYTES bytes are
+# kept and a header line is prepended — mirroring check_logs in core.utils.
+# Optional third argument: already-known source size, to avoid a second stat.
+upload_log() {
+  local src="$1" dst="$2"
+  local size="${3:-$(file_size "$src")}"
+  [ "$size" -lt 0 ] && return 0
+  if [ "$size" -gt "$LOG_SIZE_LIMIT_BYTES" ]; then
+    local mb=$(( LOG_SIZE_LIMIT_BYTES / 1048576 ))
+    { printf '[Logs exceeded maximum allowed size (%s MB). Logs have been truncated, discarding the oldest entries first.]\n' "$mb"
+      tail -c "$LOG_SIZE_LIMIT_BYTES" "$src"
+    } > "$dst" 2>/dev/null
+  else
+    cp "$src" "$dst" 2>/dev/null
+  fi
+}
+
+# Shrinks a local log file in-place to the last LOG_SIZE_LIMIT_BYTES bytes,
+# keeping the same inode so any open write fd (awk) remains valid.
+#
+# Mechanism: `truncate -s 0` zeros the file without changing the inode; awk's
+# next O_APPEND write lands at offset 0. Then `cat >>` restores the saved tail.
+# The brief race window between the two operations is harmless: a few lines
+# written by awk may appear before the restored tail in the file, which is
+# acceptable for a log. This keeps /tmp bounded to ~2x LOG_SIZE_LIMIT_BYTES.
+truncate_local() {
+  local file="$1"
+  local size
+  size=$(file_size "$file")
+  [ "$size" -le "$LOG_SIZE_LIMIT_BYTES" ] && return 0
+  local tmp="${file}.shrink"
+  tail -c "$LOG_SIZE_LIMIT_BYTES" "$file" > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 0; }
+  truncate -s 0 "$file" 2>/dev/null || { rm -f "$tmp"; return 0; }
+  cat "$tmp" >> "$file" 2>/dev/null || true
+  rm -f "$tmp"
+}
+
 # Periodically copies the local log to COS, skipping no-op PUTs when the app
 # is silent. Sets UPLOADER_PID so flush_final can stop it on exit.
 start_uploader() {
@@ -40,8 +81,11 @@ start_uploader() {
       sleep "$INTERVAL"
       cur=$(file_size "$LOCAL_PUBLIC")
       if [ "$cur" != "$last_log_size" ]; then
-        # New lines written since last upload — push to COS.
-        cp "$LOCAL_PUBLIC" "$PUBLIC_LOG_PATH" 2>/dev/null && last_log_size=$cur || true
+        # New lines written since last upload — push to COS, then shrink local.
+        if upload_log "$LOCAL_PUBLIC" "$PUBLIC_LOG_PATH" "$cur"; then
+          truncate_local "$LOCAL_PUBLIC"
+          last_log_size=$(file_size "$LOCAL_PUBLIC")
+        fi
       fi
     done
   ) &
@@ -53,7 +97,7 @@ start_uploader
 # unconditional copy so the log on COS reflects the very last lines.
 flush_final() {
   kill "$UPLOADER_PID" 2>/dev/null || true
-  cp "$LOCAL_PUBLIC" "$PUBLIC_LOG_PATH" 2>/dev/null || true
+  upload_log "$LOCAL_PUBLIC" "$PUBLIC_LOG_PATH" || true
 }
 trap 'flush_final' EXIT TERM INT
 

--- a/gateway/templates/fleet_provider_job_wrapper.tmpl
+++ b/gateway/templates/fleet_provider_job_wrapper.tmpl
@@ -28,6 +28,9 @@ set -eu
 # Upload period (seconds) between local -> COS copies. Defaults to 15s.
 INTERVAL="${LOG_FLUSH_INTERVAL_SECONDS:-15}"
 
+# Maximum bytes of log content uploaded to COS. Defaults to 50 MB.
+LOG_SIZE_LIMIT_BYTES="${LOG_SIZE_LIMIT_BYTES:-52428800}"
+
 # Local working files. Append-only, fast, never read by COS during the run.
 LOCAL_PUBLIC="/tmp/public.log"
 LOCAL_PRIVATE="/tmp/private.log"
@@ -76,6 +79,44 @@ file_size() {
   stat -c %s "$1" 2>/dev/null || echo -1
 }
 
+# Copies src to dst, capping output at LOG_SIZE_LIMIT_BYTES.
+# When the source exceeds the limit the last LOG_SIZE_LIMIT_BYTES bytes are
+# kept and a header line is prepended, mirroring check_logs in core.utils.
+# Optional third argument: already-known source size, to avoid a second stat.
+upload_log() {
+  local src="$1" dst="$2"
+  local size="${3:-$(file_size "$src")}"
+  [ "$size" -lt 0 ] && return 0
+  if [ "$size" -gt "$LOG_SIZE_LIMIT_BYTES" ]; then
+    local mb=$(( LOG_SIZE_LIMIT_BYTES / 1048576 ))
+    { printf '[Logs exceeded maximum allowed size (%s MB). Logs have been truncated, discarding the oldest entries first.]\n' "$mb"
+      tail -c "$LOG_SIZE_LIMIT_BYTES" "$src"
+    } > "$dst" 2>/dev/null
+  else
+    cp "$src" "$dst" 2>/dev/null
+  fi
+}
+
+# Shrinks a local log file in-place to the last LOG_SIZE_LIMIT_BYTES bytes,
+# keeping the same inode so any open write fd (awk) remains valid.
+#
+# Mechanism: `truncate -s 0` zeros the file without changing the inode; awk's
+# next O_APPEND write lands at offset 0. Then `cat >>` restores the saved tail.
+# The brief race window between the two operations is harmless: a few lines
+# written by awk may appear before the restored tail in the file, which is
+# acceptable for a log. This keeps /tmp bounded to ~2x LOG_SIZE_LIMIT_BYTES.
+truncate_local() {
+  local file="$1"
+  local size
+  size=$(file_size "$file")
+  [ "$size" -le "$LOG_SIZE_LIMIT_BYTES" ] && return 0
+  local tmp="${file}.shrink"
+  tail -c "$LOG_SIZE_LIMIT_BYTES" "$file" > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 0; }
+  truncate -s 0 "$file" 2>/dev/null || { rm -f "$tmp"; return 0; }
+  cat "$tmp" >> "$file" 2>/dev/null || true
+  rm -f "$tmp"
+}
+
 # Periodically copies both local logs to COS, skipping no-op PUTs when the
 # app is silent or no line has matched the public filter.
 # Sets UPLOADER_PID so flush_final can stop it on exit.
@@ -87,13 +128,19 @@ start_uploader() {
       sleep "$INTERVAL"
       cur=$(file_size "$LOCAL_PUBLIC")
       if [ "$cur" != "$last_public_log_size" ]; then
-        # New public lines since last upload — push to COS.
-        cp "$LOCAL_PUBLIC" "$PUBLIC_LOG_PATH" 2>/dev/null && last_public_log_size=$cur || true
+        # New public lines since last upload — push to COS, then shrink local.
+        if upload_log "$LOCAL_PUBLIC" "$PUBLIC_LOG_PATH" "$cur"; then
+          truncate_local "$LOCAL_PUBLIC"
+          last_public_log_size=$(file_size "$LOCAL_PUBLIC")
+        fi
       fi
       cur=$(file_size "$LOCAL_PRIVATE")
       if [ "$cur" != "$last_private_log_size" ]; then
-        # New private lines since last upload — push to COS.
-        cp "$LOCAL_PRIVATE" "$PRIVATE_LOG_PATH" 2>/dev/null && last_private_log_size=$cur || true
+        # New private lines since last upload — push to COS, then shrink local.
+        if upload_log "$LOCAL_PRIVATE" "$PRIVATE_LOG_PATH" "$cur"; then
+          truncate_local "$LOCAL_PRIVATE"
+          last_private_log_size=$(file_size "$LOCAL_PRIVATE")
+        fi
       fi
     done
   ) &
@@ -105,13 +152,13 @@ start_uploader
 # unconditional copy of both logs, so COS reflects the very last lines.
 flush_final() {
   kill "$UPLOADER_PID" 2>/dev/null || true
-  cp "$LOCAL_PUBLIC" "$PUBLIC_LOG_PATH" 2>/dev/null || true
-  cp "$LOCAL_PRIVATE" "$PRIVATE_LOG_PATH" 2>/dev/null || true
+  upload_log "$LOCAL_PUBLIC" "$PUBLIC_LOG_PATH" || true
+  upload_log "$LOCAL_PRIVATE" "$PRIVATE_LOG_PATH" || true
 }
 trap 'flush_final' EXIT TERM INT
 
 # Runs the app and records its exit code to $EXIT_CODE_FILE.
-# Must run in a subshell so set+e does not leak to the outer script.
+# Must run in a subshell so set +e does not leak to the outer script.
 run_app() {
   set +e
   {{ app_cmd }}

--- a/tests/fleets/source_files/entrypoint_large_log.py
+++ b/tests/fleets/source_files/entrypoint_large_log.py
@@ -1,0 +1,24 @@
+"""Entrypoint that generates log output exceeding the configured size limit."""
+
+from qiskit_serverless import get_arguments, save_result
+
+
+def main():
+    """Write numbered lines totaling ~150KB, well beyond the 50KB test limit."""
+    args = get_arguments()
+    target_bytes = args.get("target_bytes", 150000)
+
+    written = 0
+    line_num = 0
+    while written < target_bytes:
+        line_num += 1
+        line = f"[public] LOG_LINE_{line_num:06d} padding={'x' * 60}"
+        print(line)
+        written += len(line) + 1
+
+    print(f"[public] FINAL_LINE total_lines={line_num} total_bytes={written}")
+    save_result({"total_lines": line_num, "total_bytes": written, "status": "completed"})
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fleets/test_fleets_jobs.py
+++ b/tests/fleets/test_fleets_jobs.py
@@ -124,6 +124,7 @@ def _assert_manifest(pg_conn, minio_client, job_id, is_provider=False):
     assert env["PUBLIC_LOG_PATH"] == "/data/logs.log"
     assert env["RESULTS_PATH"] == "/data/results.json"
     assert "LOG_FLUSH_INTERVAL_SECONDS" in env
+    assert "LOG_SIZE_LIMIT_BYTES" in env
 
     if is_provider:
         assert "PRIVATE_LOG_PATH" in env, "Provider jobs must have PRIVATE_LOG_PATH"
@@ -428,3 +429,58 @@ class TestFleetsJobs:
         result = job.result(wait=False)
         assert result["received_args"] == {}, f"Expected empty args, got {result['received_args']}"
         assert result["status"] == "completed"
+
+    def test_run_fleets_job_log_truncation(self, serverless_client, pg_conn, minio_client, unique_title):
+        """Submit a job that exceeds LOG_SIZE_LIMIT_BYTES and verify truncation."""
+        fn = QiskitFunction(
+            title=unique_title,
+            entrypoint="entrypoint_large_log.py",
+            working_dir=resources_path,
+            runner="fleets",
+        )
+        serverless_client.upload(fn)
+        fn = serverless_client.function(unique_title)
+        job = fn.run(target_bytes=150000)
+        logger.info("job_id=%s submitted (large log test)", job.job_id)
+        job_id, client_status = _wait_for_terminal(job, timeout=180)
+        logger.info("job %s terminal: %s", job_id, client_status)
+
+        assert client_status == "DONE", f"Expected DONE but got {client_status}"
+
+        user_logs = job.logs()
+        assert (
+            "[Logs exceeded maximum allowed size" in user_logs
+        ), f"Truncation header not found in logs (len={len(user_logs)})"
+        assert "discarding the oldest entries first.]" in user_logs
+        assert "FINAL_LINE" in user_logs, "Final output line should survive truncation"
+        assert "LOG_LINE_000001" not in user_logs, "First log line should have been truncated"
+
+        cur = pg_conn.cursor()
+        cur.execute(
+            "SELECT u.username FROM auth_user u " "JOIN api_job j ON j.author_id = u.id WHERE j.id = %s",
+            (job_id,),
+        )
+        username = cur.fetchone()[0]
+        cur.execute(
+            "SELECT title FROM api_program WHERE id = " "(SELECT program_id FROM api_job WHERE id = %s)",
+            (job_id,),
+        )
+        program_title = cur.fetchone()[0]
+        cur.close()
+
+        log_key = f"users/{username}/custom_functions/{program_title}/jobs/{job_id}/logs.log"
+        obj = wait_for_s3_object(minio_client, "user-data-bucket", log_key)
+        cos_log_content = obj["Body"].read().decode()
+        cos_log_size = len(cos_log_content)
+
+        limit = 51200
+        max_allowed = limit + 200
+        logger.info("COS log size: %d bytes (limit=%d)", cos_log_size, limit)
+        assert cos_log_size <= max_allowed, f"COS log ({cos_log_size} bytes) exceeds limit+overhead ({max_allowed})"
+        assert (
+            cos_log_size > limit * 0.9
+        ), f"COS log ({cos_log_size} bytes) unexpectedly small — truncation may not have occurred"
+
+        assert "[Logs exceeded maximum allowed size" in cos_log_content
+        assert "FINAL_LINE" in cos_log_content
+        assert "LOG_LINE_000001" not in cos_log_content


### PR DESCRIPTION
## Summary

- Cherry-picks commit `536ed3a5` from PR #2179 (log size limiting in fleet wrappers)
- Adds an end-to-end integration test that verifies back-truncation works correctly
- Sets `FUNCTIONS_LOGS_SIZE_LIMIT=51200` (50 KB) in the test docker-compose so the truncation test runs fast without affecting existing tests

## What the test does

Submits a fleet job that generates ~150KB of numbered log output against the 50KB limit, then verifies:
- Truncation header is present in both API response and COS object
- Newest log lines (`FINAL_LINE`) are preserved (back-truncation keeps tail)
- Oldest log lines (`LOG_LINE_000001`) are discarded
- COS object size is bounded to ~limit + header overhead

## Test plan

- [ ] Run `./run-fleets-test.sh` — all 7 tests pass
- [ ] Existing tests unaffected (they produce <1KB of logs, well under 50KB limit)
- [ ] New `test_run_fleets_job_log_truncation` validates truncation end-to-end