### PR TITLE
Fix FleetsResultStorage to read results from COS

### DIFF
--- a/gateway/core/services/storage/__init__.py
+++ b/gateway/core/services/storage/__init__.py
@@ -89,5 +89,5 @@ def get_result_storage(job: Job) -> ResultStorage:
     if job.program.runner == Program.RAY:
         return RayResultStorage(job)
     if job.program.runner == Program.FLEETS:
-        return RayResultStorage(job)
+        return FleetsResultStorage(job)
     raise ValueError(f"Unknown runner type: {job.program.runner}")

--- a/gateway/core/services/storage/result_storage.py
+++ b/gateway/core/services/storage/result_storage.py
@@ -1,16 +1,39 @@
+# This code is part of a Qiskit project.
+#
+# (C) IBM 2026
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 """Abstract base class for result storage."""
 
 from abc import ABC, abstractmethod
-from typing import Optional
 
 
 class ResultStorage(ABC):
-    """Abstract interface for job result storage."""
+    """Abstract interface for job result storage.
+
+    Subclasses implement backend-specific logic for reading and writing
+    job results (e.g. local filesystem for Ray, COS for Fleets).
+    """
 
     @abstractmethod
-    def get(self) -> Optional[str]:
-        """Retrieve the result for the job."""
+    def get(self) -> str | None:
+        """Retrieve the result for the job.
+
+        Returns:
+            The result string, or None if the result is not available.
+        """
 
     @abstractmethod
     def save(self, result: str) -> None:
-        """Persist the result for the job."""
+        """Persist the result for the job.
+
+        Args:
+            result: The result string to store.
+        """

--- a/gateway/core/services/storage/result_storage_fleets.py
+++ b/gateway/core/services/storage/result_storage_fleets.py
@@ -1,23 +1,108 @@
+# This code is part of a Qiskit project.
+#
+# (C) IBM 2026
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 """Fleets implementation of result storage."""
 
-from __future__ import annotations
+import logging
 
-from typing import Optional
+from ibm_botocore.exceptions import ClientError
 
+from core.ibm_cloud import get_cos_client
+from core.ibm_cloud.code_engine.fleets.utils import build_job_paths
 from core.models import Job
 from core.services.storage.result_storage import ResultStorage
 
+logger = logging.getLogger("core.FleetsResultStorage")
+
 
 class FleetsResultStorage(ResultStorage):
-    """Handles the storage and retrieval of user job results for Fleets jobs."""
+    """Handles the storage and retrieval of user job results for Fleets jobs.
+
+    Fleets jobs write results to COS via the RESULTS_PATH mount. This class
+    reads them back from the same COS location.
+    """
+
+    NOT_FOUND_CODES = {"404", "NoSuchKey", "NotFound"}
 
     def __init__(self, job: Job) -> None:
-        self._job_id = str(job.id)
+        """Initialize the storage with COS path information from the job.
 
-    def get(self) -> Optional[str]:
-        """Retrieve the result for this job."""
-        raise NotImplementedError
+        Args:
+            job: The Job instance to retrieve results for.
+
+        Raises:
+            ValueError: If the job has no CodeEngineProject assigned.
+        """
+        if not job.code_engine_project:
+            raise ValueError(f"Job '{job.id}' has no CodeEngineProject assigned")
+
+        self._job_id = str(job.id)
+        self._project = job.code_engine_project
+        paths = build_job_paths(job)
+        self._results_key = paths.cos_results_key
+        self._user_bucket = self._project.cos_bucket_user_data_name
+
+    def get(self) -> str | None:
+        """Retrieve the result for this job from COS.
+
+        Returns:
+            The UTF-8 decoded result string, or None if the result is not
+            available (not-found or COS error).
+        """
+        try:
+            content_bytes = get_cos_client(self._project).get_object_bytes(
+                bucket_name=self._user_bucket, key=self._results_key
+            )
+            logger.info(
+                "[get] job_id=%s | Result retrieved from COS at %s/%s",
+                self._job_id,
+                self._user_bucket,
+                self._results_key,
+            )
+            return content_bytes.decode("utf-8")
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in self.NOT_FOUND_CODES:
+                logger.warning(
+                    "[get] job_id=%s | Result not found in COS at %s/%s (code=%s)",
+                    self._job_id,
+                    self._user_bucket,
+                    self._results_key,
+                    code,
+                )
+                return None
+            logger.error(
+                "[get] job_id=%s | COS error %s: %s",
+                self._job_id,
+                code,
+                e,
+            )
+            return None
+        except UnicodeDecodeError as e:
+            logger.error(
+                "[get] job_id=%s | Failed to decode result: %s",
+                self._job_id,
+                e,
+            )
+            return None
 
     def save(self, result: str) -> None:
-        """Persist the result for this job."""
-        raise NotImplementedError
+        """Not implemented — Fleets results are written by the SDK via RESULTS_PATH.
+
+        Args:
+            result: Unused. Present only to satisfy the abstract interface.
+
+        Raises:
+            NotImplementedError: Always raised. Fleets results are written
+                directly to COS by the SDK at RESULTS_PATH.
+        """
+        raise NotImplementedError("Fleets results are written by the SDK via RESULTS_PATH")

--- a/gateway/core/services/storage/result_storage_ray.py
+++ b/gateway/core/services/storage/result_storage_ray.py
@@ -1,8 +1,19 @@
+# This code is part of a Qiskit project.
+#
+# (C) IBM 2026
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 """Ray implementation of result storage."""
 
 import logging
 import os
-from typing import Optional
 
 from django.conf import settings
 
@@ -19,15 +30,29 @@ class RayResultStorage(ResultStorage):
     ENCODING = "utf-8"
 
     def __init__(self, job: Job) -> None:
+        """Initialize the storage with the user's results directory.
+
+        Args:
+            job: The Job instance to store/retrieve results for.
+        """
         self._job_id = str(job.id)
         self.user_results_directory = os.path.join(settings.MEDIA_ROOT, job.author.username, "results")
         os.makedirs(self.user_results_directory, exist_ok=True)
 
     def _get_result_path(self) -> str:
+        """Construct the full filesystem path for this job's result file.
+
+        Returns:
+            The absolute path to the result JSON file.
+        """
         return os.path.join(self.user_results_directory, f"{self._job_id}{self.RESULT_FILE_EXTENSION}")
 
-    def get(self) -> Optional[str]:
-        """Retrieve the result for this job."""
+    def get(self) -> str | None:
+        """Retrieve the result for this job from the local filesystem.
+
+        Returns:
+            The result string, or None if the file does not exist or cannot be read.
+        """
         result_path = self._get_result_path()
         if not os.path.exists(result_path):
             logger.info(
@@ -55,7 +80,11 @@ class RayResultStorage(ResultStorage):
             return None
 
     def save(self, result: str) -> None:
-        """Persist the result for this job."""
+        """Persist the result for this job to the local filesystem.
+
+        Args:
+            result: The result string to write to the file.
+        """
         result_path = self._get_result_path()
 
         with open(result_path, "w", encoding=self.ENCODING) as result_file:

--- a/gateway/tests/api/test_compute_profile.py
+++ b/gateway/tests/api/test_compute_profile.py
@@ -3,6 +3,7 @@
 import pytest
 from django.test import override_settings
 from django.urls import reverse
+from ibm_botocore.exceptions import ClientError
 from rest_framework import status
 from rest_framework.test import APIClient
 from unittest.mock import patch
@@ -13,13 +14,24 @@ from tests.utils import TestUtils
 pytestmark = pytest.mark.django_db
 
 _STORAGE_MOD = "core.services.storage.arguments_storage_fleets.FleetsArgumentsStorage.save"
+_RESULT_COS_MOD = "core.services.storage.result_storage_fleets.get_cos_client"
 
 
 @pytest.fixture(autouse=True)
-def mock_fleets_arguments_storage_save():
-    """Prevent FleetsArgumentsStorage.save() from calling COS in unit tests."""
+def mock_fleets_storage(mock_cos_client):
+    """Prevent Fleets storage classes from calling COS in unit tests."""
     with patch(_STORAGE_MOD):
         yield
+
+
+@pytest.fixture(autouse=True)
+def mock_cos_client():
+    """Mock get_cos_client to avoid COS calls during result retrieval."""
+    with patch(_RESULT_COS_MOD) as mock:
+        mock.return_value.get_object_bytes.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchKey", "Message": ""}}, "GetObject"
+        )
+        yield mock
 
 
 @pytest.fixture
@@ -149,13 +161,14 @@ def test_compute_profile_validation_invalid_formats(api_client, program, profile
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_job_list_includes_compute_profile(api_client, user, program):
+def test_job_list_includes_compute_profile(api_client, user, program, ce_project):
     """Test that job list endpoint includes compute_profile."""
     # Create a job with compute_profile
     job = TestUtils.create_job(
         author=user,
         program=program,
         compute_profile="gx3d-24x120x1a100p",
+        code_engine_project=ce_project,
     )
 
     url = reverse("v1:jobs-list")
@@ -171,13 +184,14 @@ def test_job_list_includes_compute_profile(api_client, user, program):
     assert job_data.get("compute_profile") == "gx3d-24x120x1a100p"
 
 
-def test_job_detail_includes_compute_profile(api_client, user, program):
+def test_job_detail_includes_compute_profile(api_client, user, program, ce_project):
     """Test that job detail endpoint includes compute_profile."""
     # Create a job with compute_profile
     job = TestUtils.create_job(
         author=user,
         program=program,
         compute_profile="gx3d-24x120x1a100p",
+        code_engine_project=ce_project,
     )
 
     url = reverse("v1:retrieve", kwargs={"job_id": job.id})

--- a/gateway/tests/core/services/storage/test_result_storage_fleets.py
+++ b/gateway/tests/core/services/storage/test_result_storage_fleets.py
@@ -1,0 +1,164 @@
+# This code is part of a Qiskit project.
+#
+# (C) IBM 2026
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for FleetsResultStorage."""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from ibm_botocore.exceptions import ClientError
+
+from core.models import Program
+from core.services.storage import get_result_storage
+from core.services.storage.result_storage_fleets import FleetsResultStorage
+from tests.utils import TestUtils
+
+_COS_MODULE = "core.services.storage.result_storage_fleets.get_cos_client"
+
+
+def _make_client_error(code: str) -> ClientError:
+    """Create a ClientError with the given error code for testing.
+
+    Args:
+        code: The S3 error code (e.g. "NoSuchKey", "404", "AccessDenied").
+
+    Returns:
+        A ClientError instance with the specified code.
+    """
+    return ClientError({"Error": {"Code": code, "Message": ""}}, "GetObject")
+
+
+@pytest.mark.django_db
+class TestFleetsResultStorage:
+    """Tests for FleetsResultStorage."""
+
+    @pytest.fixture
+    def ce_project(self):
+        """Create a CodeEngineProject with test bucket names."""
+        return TestUtils.get_or_create_ce_project(
+            project_name="test-project",
+            project_id="test-ce-project-id",
+            cos_bucket_user_data_name="user-bucket",
+            cos_bucket_provider_data_name="provider-bucket",
+            cos_instance_name="cos-instance",
+            cos_key_name="cos-key",
+        )
+
+    @pytest.fixture
+    def job(self, ce_project):
+        """Create a fleets job with no provider (custom function)."""
+        program = TestUtils.create_program(
+            program_title="my-program",
+            author="alice",
+            runner=Program.FLEETS,
+        )
+        return TestUtils.create_job(author="alice", program=program, code_engine_project=ce_project)
+
+    @pytest.fixture
+    def job_with_provider(self, ce_project):
+        """Create a fleets job with a provider (provider function)."""
+        program = TestUtils.create_program(
+            program_title="my-program",
+            author="alice",
+            provider="good-partner",
+            runner=Program.FLEETS,
+        )
+        return TestUtils.create_job(author="alice", program=program, code_engine_project=ce_project)
+
+    def test_results_key_custom_function(self, job):
+        """_results_key uses custom_functions path when program has no provider."""
+        storage = FleetsResultStorage(job)
+        assert storage._results_key == (  # pylint: disable=protected-access
+            f"users/alice/custom_functions/my-program/jobs/{job.id}/results.json"
+        )
+
+    def test_results_key_provider_function(self, job_with_provider):
+        """_results_key uses provider_functions path when program has a provider."""
+        storage = FleetsResultStorage(job_with_provider)
+        assert storage._results_key == (  # pylint: disable=protected-access
+            f"users/alice/provider_functions/good-partner/my-program/jobs/{job_with_provider.id}/results.json"
+        )
+
+    def test_user_bucket_from_project(self, job):
+        """_user_bucket comes from the CodeEngineProject."""
+        storage = FleetsResultStorage(job)
+        assert storage._user_bucket == "user-bucket"  # pylint: disable=protected-access
+
+    def test_no_project_raises_value_error(self):
+        """FleetsResultStorage raises ValueError when job has no CodeEngineProject."""
+        program = TestUtils.create_program(program_title="orphan", author="bob", runner=Program.FLEETS)
+        job = TestUtils.create_job(author="bob", program=program)
+        with pytest.raises(ValueError, match="has no CodeEngineProject assigned"):
+            FleetsResultStorage(job)
+
+    def test_get_returns_content(self, job):
+        """get() returns decoded COS object content."""
+        storage = FleetsResultStorage(job)
+        mock_cos = MagicMock()
+        mock_cos.get_object_bytes.return_value = b'{"result": 42}'
+
+        with patch(_COS_MODULE, return_value=mock_cos) as mock_get_cos:
+            result = storage.get()
+
+        assert result == '{"result": 42}'
+        mock_get_cos.assert_called_once_with(job.code_engine_project)
+        mock_cos.get_object_bytes.assert_called_once_with(
+            bucket_name="user-bucket",
+            key=storage._results_key,  # pylint: disable=protected-access
+        )
+
+    def test_get_returns_none_on_not_found(self, job):
+        """get() returns None when COS object does not exist yet."""
+        storage = FleetsResultStorage(job)
+        mock_cos = MagicMock()
+        mock_cos.get_object_bytes.side_effect = _make_client_error("NoSuchKey")
+
+        with patch(_COS_MODULE, return_value=mock_cos):
+            result = storage.get()
+
+        assert result is None
+
+    def test_get_returns_none_on_404(self, job):
+        """get() returns None when COS returns a 404 error code."""
+        storage = FleetsResultStorage(job)
+        mock_cos = MagicMock()
+        mock_cos.get_object_bytes.side_effect = _make_client_error("404")
+
+        with patch(_COS_MODULE, return_value=mock_cos):
+            result = storage.get()
+
+        assert result is None
+
+    def test_get_returns_none_on_other_client_error(self, job, caplog):
+        """get() returns None and logs error on unexpected ClientError."""
+        storage = FleetsResultStorage(job)
+        mock_cos = MagicMock()
+        mock_cos.get_object_bytes.side_effect = _make_client_error("AccessDenied")
+
+        with caplog.at_level(logging.ERROR, logger="core.FleetsResultStorage"):
+            with patch(_COS_MODULE, return_value=mock_cos):
+                result = storage.get()
+
+        assert result is None
+        assert any("COS error AccessDenied" in record.message for record in caplog.records)
+
+    def test_save_raises_not_implemented(self, job):
+        """save() raises NotImplementedError — results are written by the SDK."""
+        storage = FleetsResultStorage(job)
+        with pytest.raises(NotImplementedError):
+            storage.save("some result")
+
+    def test_factory_returns_fleets_storage_for_fleet_job(self, job):
+        """get_result_storage returns FleetsResultStorage for FLEETS runner jobs."""
+        storage = get_result_storage(job)
+        assert isinstance(storage, FleetsResultStorage)


### PR DESCRIPTION
## Summary

- `FleetsResultStorage.get()` was `NotImplementedError` and the factory in `__init__.py` incorrectly returned `RayResultStorage` (reads from local filesystem) for fleets jobs
- Fleets jobs write results to COS via the `RESULTS_PATH` mount, so the gateway must read them back from COS — not from `MEDIA_ROOT`
- Implements `FleetsResultStorage.get()` following the same pattern as `FleetsLogsStorage` (uses `get_cos_client` + `build_job_paths`)

## What broke

PR #2174 (Result storage architecture) + PR #2124 (RESULT_PATH env var) changed `save_result()` in the SDK to write to a mounted file path instead of POSTing to the API. For fleets, this file is on the COS mount (`/data/results.json`). The `JobRetrieveUseCase` then calls `get_result_storage(job).get()`, which was using `RayResultStorage` — looking for the file at `MEDIA_ROOT/<user>/results/<job_id>.json` (gateway filesystem), where it doesn't exist.

## Changes

| File | Change |
|------|--------|
| `gateway/core/services/storage/result_storage_fleets.py` | Implement `get()` to read from COS |
| `gateway/core/services/storage/__init__.py` | Fix factory: return `FleetsResultStorage(job)` instead of `RayResultStorage(job)` |

## Test plan

- [x] Existing unit tests pass (`tests/core/services/storage/`, `tests/api/test_job.py`) — verified locally, 89 tests pass
- [x] Fleet integration tests can retrieve `job.result()` successfully