### PR TITLE
Restore filter horizontal fields in backoffice

### DIFF
--- a/gateway/api/admin.py
+++ b/gateway/api/admin.py
@@ -43,6 +43,7 @@ class ProviderAdmin(admin.ModelAdmin):
     """ProviderAdmin."""
 
     search_fields = ["name"]
+    filter_horizontal = ["admin_groups"]
 
 
 @admin.register(Program)
@@ -52,7 +53,8 @@ class ProgramAdmin(admin.ModelAdmin):
     search_fields = ["title", "author__username"]
     list_filter = ["provider", "type", "runner", "disabled"]
     exclude = ["env_vars"]
-    autocomplete_fields = ["author", "provider", "instances", "trial_instances"]
+    filter_horizontal = ["instances", "trial_instances"]
+    autocomplete_fields = ["author", "provider"]
     change_form_template = "program/change_form.html"
 
     list_display = [


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes a problem introduced in #2100 where we removed fields with `filter_horizontal` in favor of `autocomplete` fields. Here we basically restored those specifically fields letting the problematic ones as they are to not impact the improvement in the performance.