### PR TITLE
Base64-encode Python wrapper in fleet run_commands

### DIFF
--- a/gateway/core/ibm_cloud/code_engine/fleets/utils.py
+++ b/gateway/core/ibm_cloud/code_engine/fleets/utils.py
@@ -34,6 +34,7 @@ Example::
 
 from __future__ import annotations
 
+import base64
 import json
 from dataclasses import dataclass
 from typing import Optional
@@ -221,7 +222,12 @@ def build_run_commands(
     template_name = "fleet_provider_job_wrapper.py" if is_provider_function else "fleet_custom_job_wrapper.py"
     script = get_template(template_name).render({"app_cmd": app_cmd})
 
-    return ["python3", "-c", script]
+    # The Python wrapper is too large for CE's run_commands REGEXP validation.
+    # The bash wrappers that preceded it were short enough, but the Python
+    # implementation (#2181) exceeds the per-element limit. Base64-encode to
+    # produce a short, alphanumeric command string.
+    encoded = base64.b64encode(script.encode()).decode()
+    return ["python3", "-c", f"import base64;exec(base64.b64decode('{encoded}'))"]
 
 
 def build_custom_job_paths(job: Job) -> FleetJobPaths:

--- a/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_fleet_handler.py
+++ b/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_fleet_handler.py
@@ -806,13 +806,22 @@ def test_build_run_env_variables_log_size_limit_from_settings():
     assert by_name["LOG_SIZE_LIMIT_BYTES"] == "1048576"
 
 
+def _decode_run_commands(result: list[str]) -> str:
+    """Decode the base64-encoded wrapper script from run_commands."""
+    import base64
+
+    assert result[0] == "python3"
+    assert result[1] == "-c"
+    # Extract base64 payload from: import base64;exec(base64.b64decode('...'))
+    cmd = result[2]
+    b64_payload = cmd.split("'")[1]
+    return base64.b64decode(b64_payload).decode()
+
+
 def test_build_run_commands_public_only():
     """build_run_commands renders the custom-job template (single public log)."""
     result = build_run_commands(app_run_commands=["python", "main.py"])
-    script = result[2]
-    assert result[0] == "python3"
-    assert result[1] == "-c"
-    assert "python" in script
+    script = _decode_run_commands(result)
     assert "PUBLIC_LOG_PATH" in script
     assert "PRIVATE_LOG_PATH" not in script
     assert "mkfifo" not in script
@@ -830,7 +839,7 @@ def test_build_run_commands_with_private_log():
         app_run_commands=["python", "main.py"],
         is_provider_function=True,
     )
-    script = result[2]
+    script = _decode_run_commands(result)
     assert "PUBLIC_LOG_PATH" in script
     assert "PRIVATE_LOG_PATH" in script
 
@@ -838,6 +847,6 @@ def test_build_run_commands_with_private_log():
 def test_build_run_commands_app_cmd_not_html_escaped():
     """build_run_commands keeps shell metacharacters intact (no HTML autoescape)."""
     result = build_run_commands(app_run_commands=["sh", "-c", "echo a && echo b"])
-    # Shell quoting from shlex must survive Django rendering as-is.
-    assert "&amp;" not in result[2]
-    assert "&&" in result[2]
+    script = _decode_run_commands(result)
+    assert "&amp;" not in script
+    assert "&&" in script


### PR DESCRIPTION
## Summary
- The Python log wrappers (#2181) replaced the original short bash scripts with ~6800-char Python scripts passed inline via `run_commands`
- This exceeds the CE Fleets API per-element REGEXP validation limit that the shorter bash wrappers never triggered
- Base64-encode the rendered script and decode at container startup

## Test plan
- [x] Unit tests updated to decode base64 before asserting on script content
- [x] Verified end-to-end: fleet submitted successfully and completed with DONE status