### PR TITLE
Remove gateway /result fallback from save_result

### DIFF
--- a/client/qiskit_serverless/core/job.py
+++ b/client/qiskit_serverless/core/job.py
@@ -398,58 +398,20 @@ def save_result(result: Dict[str, Any]):
         result: data that will be accessible from job handler `.result()` method.
     """
 
-    version = os.environ.get(ENV_GATEWAY_PROVIDER_VERSION)
-    if version is None:
-        version = GATEWAY_PROVIDER_VERSION_DEFAULT
-
-    token = os.environ.get(ENV_JOB_GATEWAY_TOKEN)
-    if token is None:
-        logging.warning(
-            "Results will be saved as logs since "
-            "there is no information about the "
-            "authorization token in the environment."
-        )
-        logging.info("Result: %s", result)
-        result_record = json.dumps(result or {}, cls=QiskitObjectsEncoder)
-        print(f"\nSaved Result:{result_record}:End Saved Result\n")
-        return False
-
-    instance = os.environ.get(ENV_JOB_GATEWAY_INSTANCE, None)
-    channel = os.environ.get(QISKIT_IBM_CHANNEL, None)
-
     if not is_jsonable(result, cls=QiskitObjectsEncoder):
         logging.warning("Object passed is not json serializable.")
         return False
-    try:
-        # trying to save via mounted path
-        result_path = _get_result_path()
 
+    result_path = _get_result_path()
+    try:
         with open(result_path, "w", encoding="utf-8") as result_file:
             result_file.write(json.dumps(result or {}, cls=QiskitObjectsEncoder))
 
-        logging.info(
-            "[save] job_id=%s | Result saved ok %s",
-            ENV_JOB_ID_GATEWAY,
-            result_path,
-        )
+        logging.info("[save] job_id=%s | Result saved ok %s", ENV_JOB_ID_GATEWAY, result_path)
         return True
     except Exception as e:  # pylint: disable=broad-exception-caught
-        logging.warning("There was an error saving result via mounted path: %s", e)
-        url = (
-            f"{os.environ.get(ENV_JOB_GATEWAY_HOST)}/"
-            f"api/{version}/jobs/{os.environ.get(ENV_JOB_ID_GATEWAY)}/result/"
-        )
-        response = requests.post(
-            url,
-            data={"result": json.dumps(result or {}, cls=QiskitObjectsEncoder)},
-            headers=get_headers(token=token, instance=instance, channel=channel),
-            timeout=REQUESTS_TIMEOUT,
-        )
-        if not response.ok:
-            sanitized = response.text.replace("\n", "").replace("\r", "")
-            logging.warning("Something went wrong: %s", sanitized)
-
-    return response.ok
+        logging.info("[save] job_id=%s | Error saving results %s: %ss", ENV_JOB_ID_GATEWAY, result_path, e)
+        return False
 
 
 def update_status(status: str):

--- a/client/tests/core/test_job.py
+++ b/client/tests/core/test_job.py
@@ -30,6 +30,7 @@ from qiskit_serverless.core.constants import (
     ENV_JOB_GATEWAY_TOKEN,
     ENV_JOB_GATEWAY_INSTANCE,
     ENV_ACCESS_TRIAL,
+    RESULTS_PATH,
 )
 from qiskit_serverless.core.job import (
     Job,
@@ -103,20 +104,21 @@ class ResponseMockWithRuntimeJobs:
 class TestJob:
     """TestJob."""
 
-    def test_save_result(self, job_env_variables):
+    def test_save_result(self, job_env_variables, tmp_path, monkeypatch):
         """Tests job save result."""
         _ = job_env_variables
 
-        url = f"{os.environ.get(ENV_JOB_GATEWAY_HOST)}/" f"api/v1/jobs/{os.environ.get(ENV_JOB_ID_GATEWAY)}/result/"
-        with requests_mock.Mocker() as mocker:
-            mocker.post(url)
-            result = save_result(
-                {
-                    "numpy_array": np.random.random((4, 2)),
-                    "quantum_circuit": random_circuit(3, 2),
-                }
-            )
-            assert result is True
+        result_file = tmp_path / "result.json"
+        monkeypatch.setenv(RESULTS_PATH, str(result_file))
+
+        result = save_result(
+            {
+                "numpy_array": np.random.random((4, 2)),
+                "quantum_circuit": random_circuit(3, 2),
+            }
+        )
+        assert result is True
+        assert result_file.exists()
 
     @patch("requests.patch", Mock(return_value=ResponseMock()))
     def test_update_sub_status(self, job_env_variables):


### PR DESCRIPTION
PR #2124 updated the client to always write results to the path set in `RESULTS_PATH`, which is mounted COS storage provided by the runner (Ray or Fleets). However, the `save_result` function kept a try/except that fell back to calling the gateway `/result` endpoint if the file write failed.

This PR removes that fallback. The gateway endpoint remains available for partner functions that have not yet migrated to the new client, but the client itself should only write to COS. Keeping the fallback defeats the purpose of the file-based approach and keeps a dependency on a deprecated code path.

The test for `save_result` is updated to match: it now sets `RESULTS_PATH` to a temp file and asserts the result is written there, instead of mocking an HTTP POST to the gateway.