### PR TITLE
Fix scheduler marking jobs FAILED on CE API rate limit

### DIFF
--- a/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
+++ b/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
@@ -41,6 +41,10 @@ class UpdateFleetsJobsStatuses(SchedulerTask):
             self.to_terminal(job, Job.FAILED)
             return False
 
+        if new_status is None:
+            logger.debug("job_id=%s status poll returned None (rate-limited), skipping update", job.id)
+            return False
+
         if new_status == Job.SUCCEEDED:
             self.to_terminal(job, Job.SUCCEEDED)
             self._record_execution_duration(job)

--- a/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
+++ b/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
@@ -114,6 +114,42 @@ class TestUpdateJobStatus:
 
         mock_running.assert_not_called()
 
+    def test_none_status_skips_update_and_returns_false(self):
+        task = _make_task()
+        job = _make_fleets_job(status=Job.RUNNING)
+
+        mock_runner = MagicMock()
+        mock_runner.status.return_value = None
+
+        with (
+            patch(f"{_MOD}.get_runner", return_value=mock_runner),
+            patch.object(task, "to_terminal") as mock_terminal,
+            patch.object(task, "to_running") as mock_running,
+        ):
+            result = task.update_job_status(job)
+
+        assert result is False
+        mock_terminal.assert_not_called()
+        mock_running.assert_not_called()
+        assert job.status == Job.RUNNING
+
+    def test_none_status_preserves_pending_state(self):
+        task = _make_task()
+        job = _make_fleets_job(status=Job.PENDING)
+
+        mock_runner = MagicMock()
+        mock_runner.status.return_value = None
+
+        with (
+            patch(f"{_MOD}.get_runner", return_value=mock_runner),
+            patch.object(task, "to_terminal") as mock_terminal,
+        ):
+            result = task.update_job_status(job)
+
+        assert result is False
+        mock_terminal.assert_not_called()
+        assert job.status == Job.PENDING
+
     def test_unknown_status_calls_to_terminal_failed(self):
         task = _make_task()
         job = _make_fleets_job(status=Job.RUNNING)


### PR DESCRIPTION
## Summary

- When the CE API returns 429 (Too Many Requests), `FleetsRunner.status()` correctly returns `None` to signal "retry later"
- `UpdateFleetsJobsStatuses.update_job_status()` didn't handle `None` — it fell into the `else` branch which called `to_terminal(job, Job.FAILED)` with "Unknown new job status: None"
- This permanently killed jobs that were actually running fine in Code Engine

## Fix

Added a `None` guard before the status if/elif chain. When status is `None`, the job stays in its current state and will be retried on the next scheduler cycle.

## Test plan

- [x] Added `test_none_status_skips_update_and_returns_false` — RUNNING job stays RUNNING
- [x] Added `test_none_status_preserves_pending_state` — PENDING job stays PENDING
- [x] All 16 scheduler tests pass
- [x] Pylint 10/10, black clean, 89% coverage