### PR TITLE
Fix COS presigned URLs to use public endpoint

### DIFF
--- a/gateway/core/ibm_cloud/cos/cos_client.py
+++ b/gateway/core/ibm_cloud/cos/cos_client.py
@@ -37,6 +37,8 @@ from typing import TYPE_CHECKING, Any
 from ibm_boto3.s3.transfer import TransferConfig
 from ibm_botocore.exceptions import ClientError
 
+from core.ibm_cloud.clients import COS_PUBLIC_URL_TEMPLATE
+
 if TYPE_CHECKING:
     from core.ibm_cloud.clients import IBMCloudClientProvider
 
@@ -85,6 +87,7 @@ class COSClient:
         self._endpoint_url = endpoint_url
         self._max_threads = max_threads
         self._s3: Any = None
+        self._s3_pub: Any = None
         self._transfer_config: TransferConfig | None = None
 
     @property
@@ -98,6 +101,23 @@ class COSClient:
                 endpoint_url=self._endpoint_url,
             )
         return self._s3
+
+    @property
+    def _s3_presigned(self) -> Any:
+        """Return cached S3 client configured with the public endpoint, for presigned URL generation.
+
+        Presigned URLs are handed to external callers who cannot reach private
+        (``s3.direct.*``) endpoints, so this client always uses the public URL.
+        """
+        if self._s3_pub is None:
+            public_url = COS_PUBLIC_URL_TEMPLATE.format(region=self._bucket_region)
+            self._s3_pub = self._provider.get_cos_hmac_client(
+                access_key_id=self._credentials.access_key_id,
+                secret_access_key=self._credentials.secret_access_key,
+                bucket_region=self._bucket_region,
+                endpoint_url=public_url,
+            )
+        return self._s3_pub
 
     @property
     def _transfer(self) -> TransferConfig:
@@ -425,7 +445,7 @@ class COSClient:
         Returns:
             Presigned URL string.
         """
-        return self._s3_hmac.generate_presigned_url(
+        return self._s3_presigned.generate_presigned_url(
             "get_object",
             Params={"Bucket": bucket, "Key": key},
             ExpiresIn=expiry,

--- a/gateway/tests/core/services/ibm_cloud/cos/test_cos_client_unit.py
+++ b/gateway/tests/core/services/ibm_cloud/cos/test_cos_client_unit.py
@@ -255,3 +255,37 @@ def test_generate_presigned_url_default_expiry() -> None:
 
     _, kwargs = mock_s3.generate_presigned_url.call_args
     assert kwargs["ExpiresIn"] == 3600
+
+
+def test_generate_presigned_url_uses_public_endpoint() -> None:
+    """generate_presigned_url() embeds the public COS endpoint in the URL, even when the
+    client was initialized with a private endpoint."""
+    from ibm_boto3 import client as ibm_boto3_client
+    from core.ibm_cloud.clients import COS_PUBLIC_URL_TEMPLATE
+
+    public_url = COS_PUBLIC_URL_TEMPLATE.format(region="us-east")
+
+    def _make_real_s3(*, endpoint_url, **_kwargs):
+        return ibm_boto3_client(
+            "s3",
+            aws_access_key_id="AKIAIOSFODNN7EXAMPLE",
+            aws_secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            endpoint_url=endpoint_url,
+            region_name="us-east",
+        )
+
+    mock_provider = MagicMock()
+    mock_provider.config.region = "us-east"
+    mock_provider.get_cos_hmac_client.side_effect = _make_real_s3
+
+    private_url = "https://s3.direct.us-east.cloud-object-storage.appdomain.cloud"
+    client = COSClient(
+        client_provider=mock_provider,
+        credentials=CosHmacCredentials(access_key_id="ak", secret_access_key="sk"),
+        bucket_region="us-east",
+        endpoint_url=private_url,
+    )
+
+    url = client.generate_presigned_url(bucket="my-bucket", key="some/key")
+
+    assert url.startswith(public_url)


### PR DESCRIPTION
Presigned URLs generated by the gateway in `/log` and `/result` were embedding the private COS endpoint (`s3.direct.{region}...`), which is only reachable from within IBM Cloud. ServerlessClient can't access to this url.

`generate_presigned_url` now uses a dedicated S3 client (`_s3_presigned`) always configured with the public COS endpoint (`s3.{region}...`). The existing `_s3_hmac` client is unchanged and continues to use whichever endpoint is configured via `CE_COS_USE_PUBLIC_ENDPOINT` for internal gateway operations.
