### PR TITLE
Replace CE API-based is_active() with fleet id check

### DIFF
--- a/gateway/core/services/runners/fleets_runner.py
+++ b/gateway/core/services/runners/fleets_runner.py
@@ -17,7 +17,6 @@ import logging
 import re
 import tarfile
 import time
-from collections import OrderedDict
 from io import BytesIO
 
 from django.conf import settings
@@ -39,30 +38,6 @@ from core.ibm_cloud.code_engine.fleets.utils import (
 )
 
 logger = logging.getLogger("FleetsRunner")
-
-
-class TTLCache:
-    """Fixed-size cache with per-entry TTL, evicting oldest entries when full."""
-
-    def __init__(self, maxsize: int = 1000, ttl: float = 30) -> None:
-        self._store: OrderedDict[str, tuple] = OrderedDict()
-        self._maxsize = maxsize
-        self._ttl = ttl
-
-    def get(self, key: str):
-        """Return cached value if present and not expired, else ``None``."""
-        entry = self._store.get(key)
-        if entry and (time.monotonic() - entry[1]) < self._ttl:
-            return entry[0]
-        self._store.pop(key, None)
-        return None
-
-    def put(self, key: str, value) -> None:
-        """Store a value, evicting the oldest entry if the cache is full."""
-        self._store.pop(key, None)
-        if len(self._store) >= self._maxsize:
-            self._store.popitem(last=False)
-        self._store[key] = (value, time.monotonic())
 
 
 def _retry_on_rate_limit(fn, retries=3, delays=(0.5, 1.0, 2.0)):
@@ -96,8 +71,6 @@ class FleetsRunner(AbstractRunner):
     recreated automatically when the cached IAM token is rotated.
     """
 
-    _is_active_cache = TTLCache(maxsize=1000, ttl=30)
-
     def __init__(self, job: Job) -> None:
         """Initialize the runner.
 
@@ -129,27 +102,16 @@ class FleetsRunner(AbstractRunner):
         """No-op — FleetHandler is a stateless REST client."""
 
     def is_active(self) -> bool:
-        """Return ``True`` if the fleet has moved past pending.
+        """Return ``True`` if the fleet was created.
 
-        A fleet is active once the worker has claimed the task — meaning
-        COS logs may start appearing. Uses ``status()`` which reads COS
-        task state without hitting the CE API.
+        A non-None ``fleet_id`` means ``submit()`` succeeded and the fleet
+        exists in Code Engine — sufficient for ``status()`` and ``stop()``
+        to proceed.
 
         Returns:
-            ``True`` when the fleet is running or has completed, ``False`` otherwise.
+            ``True`` when the job has a fleet_id, ``False`` otherwise.
         """
-        if not self.job.fleet_id:
-            return False
-
-        cached = self._is_active_cache.get(self.job.fleet_id)
-        if cached is not None:
-            return cached
-
-        current_status = self.status()
-        active = current_status is not None and current_status != Job.PENDING
-        if active:
-            self._is_active_cache.put(self.job.fleet_id, True)
-        return active
+        return self.job.fleet_id is not None
 
     def submit(self) -> None:
         """Submit the job as a Code Engine fleet.

--- a/gateway/core/services/runners/fleets_runner.py
+++ b/gateway/core/services/runners/fleets_runner.py
@@ -129,13 +129,14 @@ class FleetsRunner(AbstractRunner):
         """No-op — FleetHandler is a stateless REST client."""
 
     def is_active(self) -> bool:
-        """Return ``True`` if the fleet exists in Code Engine.
+        """Return ``True`` if the fleet has moved past pending.
 
-        Results are cached for 30 seconds (class-level :class:`TTLCache`)
-        to avoid redundant API calls when the scheduler polls frequently.
+        A fleet is active once the worker has claimed the task — meaning
+        COS logs may start appearing. Uses ``status()`` which reads COS
+        task state without hitting the CE API.
 
         Returns:
-            ``True`` when the fleet is reachable, ``False`` otherwise.
+            ``True`` when the fleet is running or has completed, ``False`` otherwise.
         """
         if not self.job.fleet_id:
             return False
@@ -144,20 +145,11 @@ class FleetsRunner(AbstractRunner):
         if cached is not None:
             return cached
 
-        try:
-            self._ensure_connected()
-            self._get_handler().get_job_status(self.job.fleet_id)
+        current_status = self.status()
+        active = current_status is not None and current_status != Job.PENDING
+        if active:
             self._is_active_cache.put(self.job.fleet_id, True)
-            return True
-        except ApiException as ex:
-            if ex.status == 404:
-                self._is_active_cache.put(self.job.fleet_id, False)
-                return False
-            logger.warning("CE API error checking fleet [%s]: status=%s", self.job.fleet_id, ex.status)
-            return False
-        except Exception:  # pylint: disable=broad-exception-caught
-            logger.warning("Unable to verify fleet [%s] existence", self.job.fleet_id)
-            return False
+        return active
 
     def submit(self) -> None:
         """Submit the job as a Code Engine fleet.

--- a/gateway/tests/core/services/runners/test_fleets_runner.py
+++ b/gateway/tests/core/services/runners/test_fleets_runner.py
@@ -25,11 +25,6 @@ from core.services.runners.fleets_runner import FleetsRunner
 _RUNNER_MOD = "core.services.runners.fleets_runner"
 
 
-@pytest.fixture(autouse=True)
-def _clear_caches():
-    FleetsRunner._is_active_cache._store.clear()
-
-
 def _make_runner(fleet_id: str | None = None) -> tuple[FleetsRunner, MagicMock]:
     """Build a FleetsRunner wired to mock Job and FleetHandler.
 
@@ -137,17 +132,9 @@ def _make_submit_runner() -> tuple[FleetsRunner, MagicMock]:
     return runner, mock_handler
 
 
-def test_is_active_true_when_running():
-    """is_active() returns True when COS shows running state."""
+def test_is_active_true_when_fleet_id_set():
+    """is_active() returns True when job has a fleet_id."""
     runner, _ = _make_runner(fleet_id="fleet-123")
-    runner._cos.list_keys.return_value = ["ce/test-project-id/fleet-123/v2/queue/running/fleet-123-0/..."]
-    assert runner.is_active() is True
-
-
-def test_is_active_true_when_succeeded():
-    """is_active() returns True when COS shows succeeded state."""
-    runner, _ = _make_runner(fleet_id="fleet-123")
-    runner._cos.list_keys.return_value = ["ce/test-project-id/fleet-123/v2/queue/succeeded/0/fleet-123-0/..."]
     assert runner.is_active() is True
 
 
@@ -155,32 +142,6 @@ def test_is_active_false_when_no_fleet_id():
     """is_active() returns False when job.fleet_id is None."""
     runner, _ = _make_runner(fleet_id=None)
     assert runner.is_active() is False
-
-
-def test_is_active_false_when_pending():
-    """is_active() returns False when COS shows only pending state."""
-    runner, _ = _make_runner(fleet_id="fleet-123")
-    runner._cos.list_keys.return_value = ["ce/test-project-id/fleet-123/v2/queue/pending/000-00000-0/..."]
-    assert runner.is_active() is False
-
-
-def test_is_active_false_when_no_cos_keys():
-    """is_active() returns False when COS has no keys yet."""
-    runner, _ = _make_runner(fleet_id="fleet-123")
-    runner._cos.list_keys.return_value = []
-    assert runner.is_active() is False
-
-
-def test_is_active_uses_cache_on_second_call():
-    """is_active() uses cached result and doesn't call COS again."""
-    runner, _ = _make_runner(fleet_id="fleet-123")
-    runner._cos.list_keys.return_value = ["ce/test-project-id/fleet-123/v2/queue/running/fleet-123-0/..."]
-
-    assert runner.is_active() is True
-    runner._cos.list_keys.reset_mock()
-
-    assert runner.is_active() is True
-    runner._cos.list_keys.assert_not_called()
 
 
 def test_status_raises_runner_error_when_no_fleet_id():

--- a/gateway/tests/core/services/runners/test_fleets_runner.py
+++ b/gateway/tests/core/services/runners/test_fleets_runner.py
@@ -137,12 +137,18 @@ def _make_submit_runner() -> tuple[FleetsRunner, MagicMock]:
     return runner, mock_handler
 
 
-def test_is_active_true_when_fleet_exists():
-    """is_active() returns True when CE API confirms fleet exists."""
-    runner, mock_handler = _make_runner(fleet_id="fleet-123")
-    mock_handler.get_job_status.return_value = {"status": "running"}
+def test_is_active_true_when_running():
+    """is_active() returns True when COS shows running state."""
+    runner, _ = _make_runner(fleet_id="fleet-123")
+    runner._cos.list_keys.return_value = ["ce/test-project-id/fleet-123/v2/queue/running/fleet-123-0/..."]
     assert runner.is_active() is True
-    mock_handler.get_job_status.assert_called_once_with("fleet-123")
+
+
+def test_is_active_true_when_succeeded():
+    """is_active() returns True when COS shows succeeded state."""
+    runner, _ = _make_runner(fleet_id="fleet-123")
+    runner._cos.list_keys.return_value = ["ce/test-project-id/fleet-123/v2/queue/succeeded/0/fleet-123-0/..."]
+    assert runner.is_active() is True
 
 
 def test_is_active_false_when_no_fleet_id():
@@ -151,20 +157,30 @@ def test_is_active_false_when_no_fleet_id():
     assert runner.is_active() is False
 
 
-def test_is_active_false_when_fleet_not_found():
-    """is_active() returns False when CE API returns 404."""
-    runner, mock_handler = _make_runner(fleet_id="fleet-gone")
-    mock_handler.get_job_status.side_effect = ApiException(status=404, reason="Not Found")
+def test_is_active_false_when_pending():
+    """is_active() returns False when COS shows only pending state."""
+    runner, _ = _make_runner(fleet_id="fleet-123")
+    runner._cos.list_keys.return_value = ["ce/test-project-id/fleet-123/v2/queue/pending/000-00000-0/..."]
     assert runner.is_active() is False
 
 
-def test_is_active_false_on_connection_error():
-    """is_active() returns False when connection to CE fails."""
+def test_is_active_false_when_no_cos_keys():
+    """is_active() returns False when COS has no keys yet."""
     runner, _ = _make_runner(fleet_id="fleet-123")
-    runner._connected = False  # pylint: disable=protected-access
-    runner._handler = None  # pylint: disable=protected-access
-    with patch.object(runner, "connect", side_effect=Exception("connection failed")):
-        assert runner.is_active() is False
+    runner._cos.list_keys.return_value = []
+    assert runner.is_active() is False
+
+
+def test_is_active_uses_cache_on_second_call():
+    """is_active() uses cached result and doesn't call COS again."""
+    runner, _ = _make_runner(fleet_id="fleet-123")
+    runner._cos.list_keys.return_value = ["ce/test-project-id/fleet-123/v2/queue/running/fleet-123-0/..."]
+
+    assert runner.is_active() is True
+    runner._cos.list_keys.reset_mock()
+
+    assert runner.is_active() is True
+    runner._cos.list_keys.assert_not_called()
 
 
 def test_status_raises_runner_error_when_no_fleet_id():


### PR DESCRIPTION
## Summary

- `is_active()` now calls `self.status()` instead of the CE API
- A fleet is active once it moves past pending (worker claimed task, logs may appear)
- No CE API calls for activity checks — reuses COS-based status detection
- Cache still prevents repeated COS calls within 30s

## Depends on

- #2223 (COS-based fleet status detection)

## Test plan

- [x] 53 unit tests pass
- [x] Tests cover: running→True, succeeded→True, pending→False, no keys→False, cache hit
- [x] Pylint 10/10, black clean