### PR TITLE
Fix list of files

### DIFF
--- a/gateway/core/services/storage/file_storage_fleets.py
+++ b/gateway/core/services/storage/file_storage_fleets.py
@@ -5,6 +5,7 @@ This module handle the access to the files store
 from dataclasses import dataclass
 from io import BytesIO
 import logging
+import os
 from typing import Iterator, Optional, Tuple
 from wsgiref.util import FileWrapper
 
@@ -93,7 +94,7 @@ class FileStorageFleets:
                 self._user_bucket,
                 self._public_folder_key,
             )
-            return files
+            return [os.path.basename(f) for f in files]
         except ClientError as e:
             code = e.response.get("Error", {}).get("Code", "")
             if code in self.NOT_FOUND_CODES:
@@ -137,7 +138,7 @@ class FileStorageFleets:
                 self._provider_bucket,
                 self._private_folder_key,
             )
-            return files
+            return [os.path.basename(f) for f in files]
         except ClientError as e:
             code = e.response.get("Error", {}).get("Code", "")
             if code in self.NOT_FOUND_CODES:

--- a/gateway/tests/core/services/storage/test_file_storage_fleets.py
+++ b/gateway/tests/core/services/storage/test_file_storage_fleets.py
@@ -84,10 +84,13 @@ class TestFileStorageFleets:
     # ── get_public_files ───────────────────────────────────────────────────────
 
     def test_get_public_files_returns_list(self, function):
-        """get_public_files() returns list of file names."""
+        """get_public_files() returns bare file names stripped of the COS key prefix."""
         storage = FileStorageFleets("alice", function)
         mock_cos = MagicMock()
-        mock_cos.list_keys.return_value = ["file1.txt", "file2.txt"]
+        mock_cos.list_keys.return_value = [
+            "users/alice/custom_functions/my-program/data/file1.txt",
+            "users/alice/custom_functions/my-program/data/file2.txt",
+        ]
 
         with patch(_COS_MODULE, return_value=mock_cos):
             result = storage.get_public_files()
@@ -112,10 +115,13 @@ class TestFileStorageFleets:
     # ── get_private_files ──────────────────────────────────────────────────────
 
     def test_get_private_files_returns_list(self, function_with_provider):
-        """get_private_files() returns list of file names for provider functions."""
+        """get_private_files() returns bare file names stripped of the COS key prefix."""
         storage = FileStorageFleets("alice", function_with_provider)
         mock_cos = MagicMock()
-        mock_cos.list_keys.return_value = ["private1.txt", "private2.txt"]
+        mock_cos.list_keys.return_value = [
+            "providers/good-partner/my-program/data/private1.txt",
+            "providers/good-partner/my-program/data/private2.txt",
+        ]
 
         with patch(_COS_MODULE, return_value=mock_cos):
             result = storage.get_private_files()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR is pretty simple, it just fix the output from the list and provider-list end-points for fleets to only return the name of the files not the full path. Example:

```
['providers/provider-name/function-title/data/file.txt'] 
```

to just:

```
['file.txt'] 
```