### PR TITLE
Upload now returns the file name only

### DIFF
--- a/gateway/core/services/storage/file_storage_fleets.py
+++ b/gateway/core/services/storage/file_storage_fleets.py
@@ -391,7 +391,7 @@ class FileStorageFleets:
                 self._user_bucket,
                 key,
             )
-            return key
+            return file.name
         except ClientError as e:
             logger.error(
                 "[upload-public-file] user_id=%s function_id=%s | COS error %s: %s",
@@ -427,7 +427,7 @@ class FileStorageFleets:
                 self._provider_bucket,
                 key,
             )
-            return key
+            return file.name
         except ClientError as e:
             logger.error(
                 "[upload-private-file] user_id=%s function_id=%s | COS error %s: %s",

--- a/gateway/tests/core/services/storage/test_file_storage_fleets.py
+++ b/gateway/tests/core/services/storage/test_file_storage_fleets.py
@@ -283,7 +283,7 @@ class TestFileStorageFleets:
         with patch(_COS_MODULE, return_value=mock_cos):
             key = storage.upload_public_file(file)
 
-        assert "test.txt" in key
+        assert "test.txt" == key
         mock_cos.upload_fileobj.assert_called_once()
 
     def test_upload_public_file_raises_on_error(self, function):
@@ -308,7 +308,7 @@ class TestFileStorageFleets:
         with patch(_COS_MODULE, return_value=mock_cos):
             key = storage.upload_private_file(file)
 
-        assert "private.txt" in key
+        assert "private.txt" == key
         mock_cos.upload_fileobj.assert_called_once()
 
     def test_upload_private_file_raises_for_custom_function(self, function):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Hide internal organization path in upload return data.

### Details and comments

