### PR TITLE
Add support for local builds in apple arm64

### DIFF
--- a/docker-compose.arm64.yaml
+++ b/docker-compose.arm64.yaml
@@ -1,0 +1,22 @@
+# Local-dev override for Apple Silicon (M-series) Macs.
+#
+# Use together with the base docker-compose.yaml:
+#
+#   docker build --platform linux/arm64 \
+#     -t custom-ray-node:0.32.0-arm64 -f ray-node/Dockerfile.arm64 .
+#   VERSION=0.32.0 docker compose -f docker-compose.yaml -f docker-compose.arm64.yaml up
+#
+# Runs ray-head as a NATIVE arm64 image (no QEMU) so Ray 2.55 startup is fast enough that its
+# default timeouts are satisfied and jobs no longer hang in QUEUED. gateway/scheduler/postgres
+# stay amd64 (Django/DB only, no Ray) and run under emulation; they reach ray-head over HTTP, so
+# the mixed architecture is fine. See docs/custom_images/run_on_apple_silicon.rst.
+services:
+  ray-head:
+    platform: linux/arm64
+    image: custom-ray-node:0.32.0-arm64
+  gateway:
+    platform: linux/amd64
+  scheduler:
+    platform: linux/amd64
+  postgres:
+    platform: linux/amd64

--- a/docs/custom_images/deploy_custom_image_function.rst
+++ b/docs/custom_images/deploy_custom_image_function.rst
@@ -94,6 +94,12 @@ Run it:
 
    docker-compose up
 
+.. note::
+
+   On Apple Silicon (M-series) Macs, build your custom image on the native arm64 base and start
+   the stack with the arm64 override — see :ref:`run_on_apple_silicon`. Otherwise jobs may hang
+   in ``QUEUED``.
+
 If using **Kubernetes in local development**, create the cluster and load the image:
 
 .. code-block::

--- a/docs/custom_images/index.rst
+++ b/docs/custom_images/index.rst
@@ -21,3 +21,4 @@ This is an advanced feature typically used by function providers who need full c
 
    deploy_custom_image_function
    custom_image_examples
+   run_on_apple_silicon

--- a/docs/custom_images/index.rst
+++ b/docs/custom_images/index.rst
@@ -16,6 +16,11 @@ Custom images allow providers to:
 
 This is an advanced feature typically used by function providers who need full control over the execution environment.
 
+.. note::
+
+   Developing custom images locally on an Apple Silicon (M-series) Mac? See
+   :ref:`run_on_apple_silicon` for a native arm64 path that avoids Ray startup timeouts.
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/custom_images/run_on_apple_silicon.rst
+++ b/docs/custom_images/run_on_apple_silicon.rst
@@ -4,31 +4,18 @@
 Local development on Apple Silicon (arm64)
 =========================================
 
-The published ``ray-node`` image is built for ``linux/amd64`` only. On Apple Silicon
-(M-series) Macs it therefore runs under QEMU emulation, which is slow enough that Ray 2.55's
-dashboard startup does not finish within its hardcoded timeouts. The symptom is that the Ray
-dashboard appears healthy but **jobs submitted to a local cluster stay stuck in** ``QUEUED``
-(and eventually ``ERROR``), and the job never shows up in the Ray dashboard.
+The published ``ray-node`` image is built for ``linux/amd64`` only and with the latest Ray versions
+(>2.55) it can show issues for local development on Apple Silicon Macs, where Ray startup times can get
+too long and hit timeouts. The usual symptom is jobs not transitioning from ``QUEUED`` to ``DONE``.
 
-This page describes an alternative local-development path that builds and runs a **native
-arm64** ``ray-node`` image. Because it runs natively (no emulation), Ray starts quickly and its
-default timeouts are satisfied — without changing the Ray version or patching any timeouts.
+This page describes an alternative local development path that builds and runs a **native
+arm64** ``ray-node`` image that can be used as-is or for custom image development.
 
 .. note::
 
    This is a **local development** workaround for Apple Silicon only. Production and CI on
    native ``amd64`` hosts continue to use the official ``amd64`` images unchanged.
 
-Symptom and root cause
-----------------------
-
-* **Symptom:** on an Apple Silicon Mac, ``job.result()`` never returns; the job sits in
-  ``QUEUED`` and the scheduler logs show repeated package uploads to Ray while the Ray dashboard
-  log shows ``POST /api/jobs/`` returning ``500`` after ~60s.
-* **Cause:** Ray 2.55 starts several dashboard subprocess modules that must each report ready
-  within hardcoded ~30s windows. Under QEMU emulation on arm64 these do not complete in time,
-  so the jobs API is unavailable even though the dashboard HTTP port responds.
-* **Fix:** run ``ray-head`` as a native arm64 image so startup is fast.
 
 1. Build the native arm64 base image
 ------------------------------------
@@ -51,8 +38,34 @@ the repository root:
    Rust-toolchain block in ``ray-node/Dockerfile.arm64`` (so ``ffsim`` compiles from source) and
    restore those entries in ``requirements-dynamic-dependencies-arm64.txt``.
 
-2. (Custom functions) build on the arm64 base
----------------------------------------------
+2. Choose your path
+-------------------
+
+From here there are two ways to use the arm64 base image, depending on whether you need to build
+a local "provider" image or you are following the "custom function" path without a bespoke image.
+
+Path 1 — Run the stack with the arm64 base image as-is
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you just need a working local cluster (for example to run custom functions),
+use the arm64 base image directly. The repository ships ``docker-compose.arm64.yaml``, which runs
+``ray-head`` natively on arm64 and keeps the ``gateway``, ``scheduler`` and ``postgres`` services
+on ``amd64`` (they contain no Ray code and talk to ``ray-head`` over HTTP, so the mixed
+architecture is fine):
+
+.. code-block::
+   :caption: Start the stack on Apple Silicon
+
+   VERSION=0.32.0 docker compose \
+     -f docker-compose.yaml \
+     -f docker-compose.arm64.yaml \
+     up
+
+With the stack running, upload and run your function; the job should now progress
+``QUEUED`` → ``DONE``.
+
+Path 2 — Build a custom function image on the arm64 base
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you are following :ref:`deploy_image`, point your function's ``Sample-Dockerfile`` at the
 arm64 base instead of the published ``icr.io`` image:
@@ -71,12 +84,9 @@ arm64 base instead of the published ``icr.io`` image:
 Then build it as usual, e.g.
 ``docker build --platform linux/arm64 -t test-local-provider-function -f Sample-Dockerfile .``.
 
-3. Start the stack with the arm64 override
-------------------------------------------
-
-The repository ships ``docker-compose.arm64.yaml``, which runs ``ray-head`` natively on arm64
-and keeps the ``gateway``, ``scheduler`` and ``postgres`` services on ``amd64`` (they contain no
-Ray code and talk to ``ray-head`` over HTTP, so the mixed architecture is fine):
+Start the stack with the arm64 override, overriding the ``ray-head`` image with your custom
+function image — either by editing ``docker-compose.arm64.yaml`` or via an additional override
+file — keeping ``platform: linux/arm64``:
 
 .. code-block::
    :caption: Start the stack on Apple Silicon
@@ -85,10 +95,6 @@ Ray code and talk to ``ray-head`` over HTTP, so the mixed architecture is fine):
      -f docker-compose.yaml \
      -f docker-compose.arm64.yaml \
      up
-
-If you built a custom function image (step 2), override the ``ray-head`` image with it — either
-by editing ``docker-compose.arm64.yaml`` or via an additional override file — keeping
-``platform: linux/arm64``.
 
 With the stack running, upload and run your function as described in :ref:`deploy_image`; the job
 should now progress ``QUEUED`` → ``DONE``.

--- a/docs/custom_images/run_on_apple_silicon.rst
+++ b/docs/custom_images/run_on_apple_silicon.rst
@@ -1,0 +1,94 @@
+.. _run_on_apple_silicon:
+
+=========================================
+Local development on Apple Silicon (arm64)
+=========================================
+
+The published ``ray-node`` image is built for ``linux/amd64`` only. On Apple Silicon
+(M-series) Macs it therefore runs under QEMU emulation, which is slow enough that Ray 2.55's
+dashboard startup does not finish within its hardcoded timeouts. The symptom is that the Ray
+dashboard appears healthy but **jobs submitted to a local cluster stay stuck in** ``QUEUED``
+(and eventually ``ERROR``), and the job never shows up in the Ray dashboard.
+
+This page describes an alternative local-development path that builds and runs a **native
+arm64** ``ray-node`` image. Because it runs natively (no emulation), Ray starts quickly and its
+default timeouts are satisfied — without changing the Ray version or patching any timeouts.
+
+.. note::
+
+   This is a **local development** workaround for Apple Silicon only. Production and CI on
+   native ``amd64`` hosts continue to use the official ``amd64`` images unchanged.
+
+Symptom and root cause
+----------------------
+
+* **Symptom:** on an Apple Silicon Mac, ``job.result()`` never returns; the job sits in
+  ``QUEUED`` and the scheduler logs show repeated package uploads to Ray while the Ray dashboard
+  log shows ``POST /api/jobs/`` returning ``500`` after ~60s.
+* **Cause:** Ray 2.55 starts several dashboard subprocess modules that must each report ready
+  within hardcoded ~30s windows. Under QEMU emulation on arm64 these do not complete in time,
+  so the jobs API is unavailable even though the dashboard HTTP port responds.
+* **Fix:** run ``ray-head`` as a native arm64 image so startup is fast.
+
+1. Build the native arm64 base image
+------------------------------------
+
+This repository ships an arm64 variant of the base image, ``ray-node/Dockerfile.arm64``, and a
+matching dependency file, ``ray-node/requirements-dynamic-dependencies-arm64.txt``. Build it from
+the repository root:
+
+.. code-block::
+   :caption: Build the arm64 ray-node image
+
+   docker build --platform linux/arm64 \
+     -t custom-ray-node:0.32.0-arm64 \
+     -f ray-node/Dockerfile.arm64 .
+
+.. note::
+
+   The arm64 dependency set omits ``ffsim`` and ``qiskit-addon-aqc-tensor`` because
+   ``ffsim==0.0.60`` has no published arm64 wheel. If your function needs them, uncomment the
+   Rust-toolchain block in ``ray-node/Dockerfile.arm64`` (so ``ffsim`` compiles from source) and
+   restore those entries in ``requirements-dynamic-dependencies-arm64.txt``.
+
+2. (Custom functions) build on the arm64 base
+---------------------------------------------
+
+If you are following :ref:`deploy_image`, point your function's ``Sample-Dockerfile`` at the
+arm64 base instead of the published ``icr.io`` image:
+
+.. code-block::
+   :caption: Sample-Dockerfile on the arm64 base
+
+   FROM custom-ray-node:0.32.0-arm64
+
+   USER 0
+   WORKDIR /runner
+   COPY ./runner.py /runner
+   WORKDIR /
+   USER 1000
+
+Then build it as usual, e.g.
+``docker build --platform linux/arm64 -t test-local-provider-function -f Sample-Dockerfile .``.
+
+3. Start the stack with the arm64 override
+------------------------------------------
+
+The repository ships ``docker-compose.arm64.yaml``, which runs ``ray-head`` natively on arm64
+and keeps the ``gateway``, ``scheduler`` and ``postgres`` services on ``amd64`` (they contain no
+Ray code and talk to ``ray-head`` over HTTP, so the mixed architecture is fine):
+
+.. code-block::
+   :caption: Start the stack on Apple Silicon
+
+   VERSION=0.32.0 docker compose \
+     -f docker-compose.yaml \
+     -f docker-compose.arm64.yaml \
+     up
+
+If you built a custom function image (step 2), override the ``ray-head`` image with it — either
+by editing ``docker-compose.arm64.yaml`` or via an additional override file — keeping
+``platform: linux/arm64``.
+
+With the stack running, upload and run your function as described in :ref:`deploy_image`; the job
+should now progress ``QUEUED`` → ``DONE``.

--- a/docs/custom_images/run_on_apple_silicon.rst
+++ b/docs/custom_images/run_on_apple_silicon.rst
@@ -1,8 +1,8 @@
 .. _run_on_apple_silicon:
 
-=========================================
+==========================================
 Local development on Apple Silicon (arm64)
-=========================================
+==========================================
 
 The published ``ray-node`` image is built for ``linux/amd64`` only and with the latest Ray versions
 (>2.55) it can show issues for local development on Apple Silicon Macs, where Ray startup times can get

--- a/docs/deployment/local.rst
+++ b/docs/deployment/local.rst
@@ -77,6 +77,12 @@ Step 2: Install and Configure Docker Runtime
 
 Both deployment methods (Docker Compose and Kind) require a Docker runtime. We recommend **Colima**, especially for macOS with ARM processors, as it provides better performance and avoids architecture-related issues.
 
+.. note::
+
+   On Apple Silicon (M-series) Macs, the published ``amd64`` ``ray-node`` image runs under
+   emulation and can cause locally-submitted jobs to hang in ``QUEUED``. If you hit this, see
+   :ref:`run_on_apple_silicon` for a native arm64 local-development path.
+
 2.1: Install Docker Runtime
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/ray-node/Dockerfile.arm64
+++ b/ray-node/Dockerfile.arm64
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1.17
+#
+# arm64-native variant of the ray-node image, for LOCAL DEV on Apple Silicon (M-series) Macs.
+# Build with: --platform linux/arm64
+#
+# Why: the published ray-node image is amd64-only, so on Apple Silicon it runs under QEMU
+# emulation. Ray 2.55's dashboard subprocess-modules must report ready within hardcoded ~30s
+# startup windows; under emulation they time out, the jobs API never becomes available, and
+# jobs stay stuck in QUEUED. Running a NATIVE arm64 image removes the emulation overhead so the
+# default timeouts are satisfied. The Ray version is unchanged.
+#
+# This mirrors ray-node/Dockerfile, but installs the arm64 dynamic-dependencies set
+# (ffsim / qiskit-addon-aqc-tensor omitted; see requirements-dynamic-dependencies-arm64.txt).
+FROM registry.access.redhat.com/ubi9-minimal:9.8-1779809423
+# set environment variables
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Install system dependencies and setup Python symlinks
+RUN microdnf update -y && \
+    microdnf install -y \
+        python3.11 \
+        python3.11-devel \
+        wget-1.21.1 && \
+    microdnf clean all && \
+    ln -s /usr/bin/python3.11 /usr/local/bin/python3 && \
+    ln -s /usr/bin/python3.11 /usr/local/bin/python && \
+    ln -s /usr/bin/pip3.11 /usr/local/bin/pip3 && \
+    ln -s /usr/bin/pip3.11 /usr/local/bin/pip
+
+
+USER 0
+# Create data directories and upgrade pip/setuptools
+# /data and /function_data are used by the Ray runner as PDS mount points.
+# /function_user_data, /job_user_data, /function_provider_data and /job_provider_data
+# are used by the Fleets runner (4-mount COS path layout).
+RUN mkdir /data /function_data /function_user_data /job_user_data /function_provider_data /job_provider_data && \
+    chown 1000:1000 /data /function_data /function_user_data /job_user_data /function_provider_data /job_provider_data && \
+    python3.11 -m ensurepip --upgrade && \
+    pip install --upgrade --no-cache-dir \
+        "pip>=24.2" \
+        "setuptools>=80.0.0"
+
+# ---------------------------------------------------------------------------
+# OPTIONAL: to keep ffsim / qiskit-addon-aqc-tensor on arm64 (no ffsim arm64 wheel),
+# install a Rust toolchain so ffsim compiles from source, and restore those two lines
+# in requirements-dynamic-dependencies-arm64.txt. Uncomment:
+#
+# RUN microdnf install -y gcc gcc-c++ make && microdnf clean all && \
+#     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+# ENV PATH="/root/.cargo/bin:${PATH}"
+# ---------------------------------------------------------------------------
+
+# Install additional dependencies (arm64 variant)
+COPY ray-node/requirements-dynamic-dependencies-arm64.txt /tmp/requirements-dynamic-dependencies.txt
+RUN pip install -r /tmp/requirements-dynamic-dependencies.txt --no-cache-dir && \
+    rm /tmp/requirements-dynamic-dependencies.txt
+
+# Install latest version of client (at the end for better layer cache usage)
+COPY client /tmp/qs
+RUN pip install /tmp/qs --no-cache-dir
+RUN cp -r -n /usr/local/lib64/python3.11/site-packages/symengine /usr/local/lib/python3.11/site-packages && \
+    cp -r -n /usr/local/lib/python3.11/site-packages/symengine /usr/local/lib64/python3.11/site-packages && \
+    rm -rf /tmp/qs /tmp/requirements*.txt
+
+USER 1000

--- a/ray-node/requirements-dynamic-dependencies-arm64.txt
+++ b/ray-node/requirements-dynamic-dependencies-arm64.txt
@@ -1,0 +1,12 @@
+# arm64 (Apple Silicon) local-dev variant of requirements-dynamic-dependencies.txt.
+# ffsim==0.0.60 has no published arm64 wheel (Rust extension) and qiskit-addon-aqc-tensor
+# pulls ffsim, so both are omitted here to keep the local arm64 build wheel-only.
+# To use them on arm64, add a Rust toolchain in Dockerfile.arm64 (see the commented block
+# there) and restore the two lines below.
+mergedeep==1.3.4
+mthree==3.0.0
+pyscf==2.11.0
+qiskit-addon-obp==0.3.0
+qiskit-addon-sqd==0.12.0
+qiskit-addon-utils==0.2.0
+qiskit-aer==0.17.2


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The update to Ray 2.55 results in the scheduler hanging on Apple Silicon Macs (and potentially other architectures). On Apple Silicon Macs the amd64 ray-node image runs under QEMU emulation, which is too slow for Ray 2.55's hardcoded ~30s dashboard startup timeouts: the dashboard HTTP port responds but the jobs API never comes up, so locally-submitted jobs stay stuck in QUEUED. 

This PR proposes a path for running ray-head as a native arm64 image, which removes the emulation overhead so Ray's default timeouts are satisfied. There are no changes to the "official" image building path, as this runs on linux and doesn't experience the same issue with Ray.


### Details and comments

To be able to run a local build for arm64 I had to provide the following custom files

- `ray-node/Dockerfile.arm64`: arm64 variant mirroring ray-node/Dockerfile, with an optional Rust-toolchain block for ffsim.
- `ray-node/requirements-dynamic-dependencies-arm64.txt`: dynamic deps minus ffsim and qiskit-addon-aqc-tensor (ffsim 0.0.60 has no arm64 wheel).
- `docker-compose.arm64.yaml`: override running ray-head native arm64 while keeping gateway/scheduler/postgres on amd64 (no Ray code; HTTP-only, so arch-mixed is fine).
-` docs/custom_images/run_on_apple_silicon.rst`: explains the symptom, root cause and the build+run steps; registered in the custom_images toctree.
