### PR TITLE
fix: make Ray result storage provider-aware

### DIFF
--- a/gateway/core/services/storage/result_storage_ray.py
+++ b/gateway/core/services/storage/result_storage_ray.py
@@ -15,10 +15,10 @@
 import logging
 import os
 
-from django.conf import settings
-
 from core.models import Job
 from core.services.storage.result_storage import ResultStorage
+from core.services.storage.path_builder import PathBuilder
+from core.services.storage.enums.working_dir import WorkingDir
 
 logger = logging.getLogger("core.RayResultStorage")
 
@@ -27,22 +27,39 @@ class RayResultStorage(ResultStorage):
     """Handles the storage and retrieval of user job results for Ray jobs."""
 
     RESULT_FILE_EXTENSION = ".json"
+    PATH = "results"
     ENCODING = "utf-8"
 
     def __init__(self, job: Job) -> None:
-        """Initialize the storage with the user's results directory.
+        """Initialize the storage with this job's results directory.
+
+        The directory must match the location the running function writes to via the
+        ``RESULTS_PATH`` environment variable (see ``build_env_variables``). That path is
+        provider-aware for provider (custom-image) functions, so the read side here must be
+        provider-aware too — otherwise results written by a provider function under
+        ``{username}/{provider}/{title}/results`` would never be found by the username-only
+        read path. This mirrors :class:`RayArgumentsStorage`.
 
         Args:
             job: The Job instance to store/retrieve results for.
         """
         self._job_id = str(job.id)
-        self.user_results_directory = os.path.join(settings.MEDIA_ROOT, job.author.username, "results")
-        os.makedirs(self.user_results_directory, exist_ok=True)
+        username = job.author.username
+        function_title = job.program.title
+        provider_name = job.program.provider.name if job.program.provider else None
+
+        self.results_directory = PathBuilder.absolute_path(
+            working_dir=WorkingDir.USER_STORAGE,
+            username=username,
+            function_title=function_title,
+            provider_name=provider_name,
+            extra_sub_path=self.PATH,
+        )
 
     @property
     def result_file_path(self) -> str:
         """Absolute path to this job's result JSON file."""
-        return os.path.join(self.user_results_directory, f"{self._job_id}{self.RESULT_FILE_EXTENSION}")
+        return os.path.join(self.results_directory, f"{self._job_id}{self.RESULT_FILE_EXTENSION}")
 
     def _get_result_path(self) -> str:
         return self.result_file_path

--- a/gateway/tests/core/services/storage/test_result_storage.py
+++ b/gateway/tests/core/services/storage/test_result_storage.py
@@ -17,15 +17,29 @@ class TestRayResultStorage:
         program = TestUtils.create_program(program_title="myfun", author="user1")
         return TestUtils.create_job(author="user1", program=program)
 
+    @pytest.fixture
+    def provider_job(self):
+        program = TestUtils.create_program(program_title="myfun", author="user1", provider="myprovider")
+        return TestUtils.create_job(author="user1", program=program)
+
     def test_path_generation(self, tmp_path, settings, job):
-        """Test path is {username}/results/"""
+        """User (artifact) function: path is {username}/results/."""
         settings.MEDIA_ROOT = str(tmp_path)
         storage = ResultStorage(job=job)
-        assert storage.user_results_directory == f"{tmp_path}/user1/results"
-        assert os.path.exists(storage.user_results_directory)
+        assert storage.results_directory == f"{tmp_path}/user1/results"
+        assert os.path.exists(storage.results_directory)
+
+    def test_path_generation_provider(self, tmp_path, settings, provider_job):
+        """Provider (custom-image) function: path is provider-aware,
+        {username}/{provider}/{title}/results/ — matching where the function writes
+        results via the RESULTS_PATH env var."""
+        settings.MEDIA_ROOT = str(tmp_path)
+        storage = ResultStorage(job=provider_job)
+        assert storage.results_directory == f"{tmp_path}/user1/myprovider/myfun/results"
+        assert os.path.exists(storage.results_directory)
 
     def test_save_and_get(self, tmp_path, settings, job):
-        """Test saving and retrieving results."""
+        """Test saving and retrieving results (user function)."""
         settings.MEDIA_ROOT = str(tmp_path)
         storage = ResultStorage(job=job)
         assert storage.get() is None
@@ -33,3 +47,12 @@ class TestRayResultStorage:
         assert storage.get() == "foo"
         storage.save("overwrite")
         assert storage.get() == "overwrite"
+
+    def test_save_and_get_provider(self, tmp_path, settings, provider_job):
+        """Save/get round-trips for a provider function (regression for the
+        provider results path mismatch)."""
+        settings.MEDIA_ROOT = str(tmp_path)
+        storage = ResultStorage(job=provider_job)
+        assert storage.get() is None
+        storage.save("bar")
+        assert storage.get() == "bar"

--- a/releasenotes/notes/fix-ray-provider-result-path-0b3c1d2e4f5a6b7c.yaml
+++ b/releasenotes/notes/fix-ray-provider-result-path-0b3c1d2e4f5a6b7c.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixed result retrieval for provider (custom-image) functions running on the Ray
+    runner. The function writes its result to a provider-scoped path
+    (``{username}/{provider}/{title}/results/{job_id}.json``, via the ``RESULTS_PATH``
+    environment variable), but the gateway read the result from a username-only path
+    (``{username}/results/{job_id}.json``). As a result, ``job.result()`` could return
+    an empty result for a provider function even though the job completed successfully.
+    ``RayResultStorage`` is now provider-aware, mirroring ``RayArgumentsStorage``, so the
+    read path matches where the function writes.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Provider (custom-image) functions running on the Ray runner can complete successfully (status == DONE) but return an empty result from job.result(). The cause is a path mismatch between where the function writes its result and where the gateway reads it back:

```
┌──────────────────┬─────────────────────────────────────────────────────┬──────────────────────────────────────────────────┐
│       Side       │                        Path                         │                      Source                      │
├──────────────────┼─────────────────────────────────────────────────────┼──────────────────────────────────────────────────┤
│ Write (function, │                                                     │ build_env_variables() in gateway/api/utils.py    │
│  via             │ {username}/{provider}/{title}/results/{job_id}.json │ (provider-aware DATA_PATH)                       │
│ RESULTS_PATH)    │                                                     │                                                  │
├──────────────────┼─────────────────────────────────────────────────────┼──────────────────────────────────────────────────┤
│                  │                                                     │ RayResultStorage in                              │
│ Read (gateway)   │ {username}/results/{job_id}.json                    │ core/services/storage/result_storage_ray.py      │
│                  │                                                     │ (username-only)                                  │
└──────────────────┴─────────────────────────────────────────────────────┴──────────────────────────────────────────────────┘

```

For user (custom) functions the two paths are identical, so nothing breaks. For provider functions they diverge, the gateway looks in the wrong directory, finds no file, and returns an empty result.

`RayArgumentsStorage` is already provider-aware (it uses `PathBuilder` with `provider_name`), but it looks like the result storage was not. This PR makes `RayResultStorage` build its directory with the same `PathBuilder.absolute_path(WorkingDir.USER_STORAGE, …, provider_name=…)` call, so the read path matches the write path for provider functions and stays `{username}/results` for user functions.

### Details and comments

- Affects only jobs with `program.runner == RAY`. Fleets jobs use `FleetsResultStorage` (COS-based) and are unaffected.
- I have not had time to verify if current deployed provider images are affected. If they are, we should get the fix in a provide a release ASAP.

### How to reproduce

Deploy a custom provider image as specified in the documentation and check that result is empty.

### Why it wasn't caught earlier

The existing storage unit tests only used user functions (no provider), so the divergent branch was never exercised; and the integration tests mock `_submit_to_ray`, so no real function ever wrote a result file for the gateway to read back. The write↔read seam — the only place the mismatch is visible — was never tested for a provider function.