### PR TITLE
Fix detect-secrets issues

### DIFF
--- a/charts/qiskit-serverless/templates/kafka-credentials.yaml
+++ b/charts/qiskit-serverless/templates/kafka-credentials.yaml
@@ -17,7 +17,7 @@ spec:
     template:
       engineVersion: v2
       data:
-        api_key: >-
+        api_key: >- # pragma: allowlist secret
           {{ printf "{{ (.credentials | fromJson).api_key }}" }}
         bootstrap_servers: >-
           {{ printf "{{ (.credentials | fromJson).kafka_brokers_sasl | join \",\" }}" }}

--- a/gateway/api/static/admin/css/carbon_theme.css
+++ b/gateway/api/static/admin/css/carbon_theme.css
@@ -510,7 +510,7 @@ select {
 }
 
 input[type=text]:focus,
-input[type=password]:focus,
+input[type=password]:focus, /* pragma: allowlist secret */
 input[type=email]:focus,
 input[type=url]:focus,
 input[type=number]:focus,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes couple unaudited secrets in the repository:
48 potential secrets in .secrets.baseline were reviewed. Found 0 live secrets, 2 unaudited secrets and 0 secrets that were audited as real.
Failed Condition    Secret Type     Filename                                                     Line
------------------  --------------  ---------------------------------------------------------  ------
Unaudited           Secret Keyword  charts/qiskit-serverless/templates/kafka-credentials.yaml      20
Unaudited           Secret Keyword  gateway/api/static/admin/css/carbon_theme.css                 513

Without that, the pipeline fails in the detect-secrets step.


### Details and comments
To solve that, we escaped the two false positives with `# pragma: allowlist secret` in order to be skipped when scanning.
