### PR TITLE
Modify Kafka external secret definition

### DIFF
--- a/charts/qiskit-serverless/templates/kafka-credentials.yaml
+++ b/charts/qiskit-serverless/templates/kafka-credentials.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.gateway.secrets.kafka -}}
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: kafka-credentials
+  namespace: {{ .Release.Namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
@@ -25,4 +25,3 @@ spec:
           {{ printf "{{ (.credentials | fromJson).user }}" }}
     creationPolicy: Owner
     name: kafka-credentials
-{{- end -}}

--- a/charts/qiskit-serverless/templates/kafka-credentials.yaml
+++ b/charts/qiskit-serverless/templates/kafka-credentials.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.gateway.kafkaCredentials.create -}}
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -25,3 +26,4 @@ spec:
           {{ printf "{{ (.credentials | fromJson).user }}" }}
     creationPolicy: Owner
     name: kafka-credentials
+{{- end -}}

--- a/charts/qiskit-serverless/values.yaml
+++ b/charts/qiskit-serverless/values.yaml
@@ -73,6 +73,9 @@ gateway:
   cos:
     claimName: gateway-claim
 
+  kafkaCredentials:
+    create: false
+
   secrets:
     secretKey:
       name: gateway-secret-key


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR modifies the recently introduced external secret to connect to IBM Cloud Event Streams instance to can be created even when still not using it. We want to control explicitly when to create it in order to test it is properly defined before enabling Kafka.

Also, it adds a namespace since it was missing in the first implementation.
