### PR TITLE
Update kafka credentials secret

### DIFF
--- a/charts/qiskit-serverless/templates/kafka-credentials.yaml
+++ b/charts/qiskit-serverless/templates/kafka-credentials.yaml
@@ -4,8 +4,6 @@ kind: ExternalSecret
 metadata:
   name: kafka-credentials
   namespace: {{ .Release.Namespace }}
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"
 spec:
   data:
   - secretKey: credentials
@@ -13,7 +11,7 @@ spec:
       key: "{{ .Values.gateway.secrets.kafka }}"
   secretStoreRef:
     kind: SecretStore
-    name: qiskit-serverless
+    name: qiskit-serverless-secret-store
   target:
     template:
       engineVersion: v2


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes the `kafka-credentials` external secret to read from the proper secretStore. Also, moving it to the same sync wave the other external secrets are just for consistency.


### Details and comments
This change just align the code with the private repository to avoid mismatches later.
