### PR TITLE
Deprecation notice on widget and client name attribute

### DIFF
--- a/client/qiskit_serverless/core/client.py
+++ b/client/qiskit_serverless/core/client.py
@@ -68,12 +68,18 @@ class BaseClient(JobService, RunService, JsonSerializable, ABC):
         Initialize a BaseClient instance.
 
         Args:
-            name: name of client
+            name: (deprecated) name of client - will be removed in a future release
             host: host of client a.k.a managers host
             token: authentication token for manager
             instance: IBM Cloud CRN or IQP h/g/p
             channel: identifies the method to use to authenticate the user
         """
+        if name:
+            warnings.warn(
+                "The 'name' attribute is deprecated and will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2
+            )
         self.name = name
         self.host = host
         self.token = token
@@ -189,7 +195,19 @@ class BaseClient(JobService, RunService, JsonSerializable, ABC):
     ######################
 
     def widget(self):
-        """Widget for information about provider and jobs."""
+        """Widget for information about provider and jobs.
+
+        .. deprecated:: 0.33.0
+            The ``widget()`` method is deprecated and will be removed in a future release.
+            The Jupyter widget interface is no longer maintained. Use ``jobs()`` and
+            ``functions()`` directly, or the IBM Quantum web dashboard instead.
+        """
+        warnings.warn(
+            "The `widget()` method is deprecated and will be removed in a future release. "
+            "Use `jobs()` and `functions()` directly, or the IBM Quantum web dashboard instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         # prevent cyclic import
         from qiskit_serverless.visualization import (  # pylint: disable=import-outside-toplevel
             Widget,

--- a/client/qiskit_serverless/core/client.py
+++ b/client/qiskit_serverless/core/client.py
@@ -78,7 +78,7 @@ class BaseClient(JobService, RunService, JsonSerializable, ABC):
             warnings.warn(
                 "The 'name' attribute is deprecated and will be removed in a future release.",
                 DeprecationWarning,
-                stacklevel=2
+                stacklevel=2,
             )
         self.name = name
         self.host = host

--- a/client/qiskit_serverless/core/clients/serverless_client.py
+++ b/client/qiskit_serverless/core/clients/serverless_client.py
@@ -117,7 +117,7 @@ class ServerlessClient(BaseClient):  # pylint: disable=too-many-public-methods
         Initializes the ServerlessClient instance.
 
         Args:
-            name: name of client
+            name: (deprecated) name of client - will be removed in a future release
             host: host of gateway. If None, it uses the ENV_GATEWAY_PROVIDER_HOST env var
             version: version of gateway
             token: authorization token

--- a/client/qiskit_serverless/core/clients/serverless_client.py
+++ b/client/qiskit_serverless/core/clients/serverless_client.py
@@ -124,7 +124,13 @@ class ServerlessClient(BaseClient):  # pylint: disable=too-many-public-methods
             instance: IBM Cloud CRN
             channel: identifies the method to use to authenticate the user
         """
-        name = name or "gateway-client"
+        if name:
+            warnings.warn(
+                "The 'name' attribute is deprecated and will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        resolved_name = name or "gateway-client"
         host = host or os.environ.get(ENV_GATEWAY_PROVIDER_HOST)
         if host is None:
             raise QiskitServerlessException("Please provide `host` of gateway.")
@@ -155,7 +161,10 @@ class ServerlessClient(BaseClient):  # pylint: disable=too-many-public-methods
                 "Authentication with IBM Quantum Platform requires to pass the CRN as an instance."
             )
 
-        super().__init__(name, host, token, instance, channel)
+        # Pass name=None so BaseClient does not emit a second deprecation
+        # warning; the warning above is the single one users should see.
+        super().__init__(None, host, token, instance, channel)
+        self.name = resolved_name
         self.version = version
         self._verify_credentials()
 

--- a/client/qiskit_serverless/visualization/__init__.py
+++ b/client/qiskit_serverless/visualization/__init__.py
@@ -20,6 +20,11 @@ Visualization (:mod:`qiskit_serverless.visualization`)
 Qiskit Serverless visualisation module classes and functions
 =============================================================
 
+.. deprecated:: 0.33.0
+    The ``qiskit_serverless.visualization`` module is deprecated and will be removed
+    in a future release. Use ``client.jobs()`` and ``client.functions()`` directly,
+    or the IBM Quantum web dashboard instead.
+
 .. autosummary::
     :toctree: ../stubs/
 

--- a/client/qiskit_serverless/visualization/widget.py
+++ b/client/qiskit_serverless/visualization/widget.py
@@ -20,6 +20,12 @@ Decorators (:mod:`qiskit_serverless.visualization.widget`)
 Qiskit Serverless widgets
 ==========================
 
+.. deprecated:: 0.33.0
+    The :class:`Widget` class and the entire ``qiskit_serverless.visualization`` module
+    are deprecated and will be removed in a future release.
+    Use ``client.jobs()`` and ``client.functions()`` directly, or the IBM Quantum
+    web dashboard instead.
+
 .. autosummary::
     :toctree: ../stubs/
 
@@ -27,6 +33,7 @@ Qiskit Serverless widgets
 """
 
 import os
+import warnings
 from datetime import datetime
 
 from IPython.display import display, clear_output
@@ -53,7 +60,13 @@ TABLE_STYLE = """
 
 
 class Widget:  # pylint: disable=too-many-instance-attributes
-    """Widget for displaying information related to provider."""
+    """Widget for displaying information related to provider.
+
+    .. deprecated:: 0.33.0
+        The ``Widget`` class is deprecated and will be removed in a future release.
+        Use ``client.jobs()`` and ``client.functions()`` directly, or the IBM Quantum
+        web dashboard instead.
+    """
 
     def __init__(self, provider: BaseClient):
         """Constructor for widget.
@@ -61,6 +74,13 @@ class Widget:  # pylint: disable=too-many-instance-attributes
         Args:
             provider: provider
         """
+        warnings.warn(
+            "The `Widget` class is deprecated and will be removed in a future release. "
+            "Use `client.jobs()` and `client.functions()` directly, "
+            "or the IBM Quantum web dashboard instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if provider is None:
             raise QiskitServerlessException("Provider must be set in order to display widget.")
         self.provider = provider

--- a/docs/function_features/basic/01_custom_upload_run.ipynb
+++ b/docs/function_features/basic/01_custom_upload_run.ipynb
@@ -356,7 +356,8 @@
    "id": "9784597b-9377-4d26-8ab9-a8a9b363c924",
    "metadata": {},
    "source": [
-    "`ServerlessClient` object has method `.widget` which renders Jupyter widget to see list of executed programs."
+    "`ServerlessClient` object has method `.widget` which renders Jupyter widget to see list of executed programs. <br>\n",
+    "This method is **deprecated** and will be removed in a future release. Use `client.jobs()` and `client.functions()` directly, or visit the IBM Quantum web dashboard instead."
    ]
   },
   {

--- a/releasenotes/notes/deprecate-widget-and-client-name-a3f1c8e2d4b07691.yaml
+++ b/releasenotes/notes/deprecate-widget-and-client-name-a3f1c8e2d4b07691.yaml
@@ -1,0 +1,21 @@
+---
+deprecations:
+  - |
+    The ``name`` parameter in ``BaseClient``, ``ServerlessClient``, and
+    ``IBMServerlessClient`` is deprecated and will be removed in version 0.x.x
+    The parameter is no longer used for client functionality. Users should
+    remove this parameter from their client instantiation code.
+
+    Note: The ``name`` parameter in ``IBMServerlessClient`` is NOT deprecated
+    as it is used to load saved accounts.
+  - |
+    The ``widget()`` method of ``BaseClient`` (and its subclasses ``ServerlessClient``
+    and ``IBMServerlessClient``) has been deprecated and will be removed in a future
+    release. The Jupyter widget interface is no longer maintained.
+    Use ``client.jobs()`` and ``client.functions()`` directly to retrieve job and
+    function information, or visit the IBM Quantum web dashboard instead.
+  - |
+    The ``Widget`` class in ``qiskit_serverless.visualization.widget`` and the
+    entire ``qiskit_serverless.visualization`` module have been deprecated and will
+    be removed in a future release. The ``ipywidgets`` and ``ipython`` dependencies
+    will also be removed at that time.

--- a/releasenotes/notes/deprecate-widget-and-client-name-a3f1c8e2d4b07691.yaml
+++ b/releasenotes/notes/deprecate-widget-and-client-name-a3f1c8e2d4b07691.yaml
@@ -2,7 +2,7 @@
 deprecations:
   - |
     The ``name`` parameter in ``BaseClient``, ``ServerlessClient``, and
-    ``IBMServerlessClient`` is deprecated and will be removed in version 0.x.x
+    ``IBMServerlessClient`` is deprecated and will be removed in a future release.
     The parameter is no longer used for client functionality. Users should
     remove this parameter from their client instantiation code.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Deprecation notice on the Widget and Name attribute of client as preparation to their removal.

### Details and comments

**Goal**: Warn users that the `name` attribute will be removed in a future release.

### 1.1 Add warning to `BaseClient.__init__()`

**File**: [`client/qiskit_serverless/core/client.py:77-81`](client/qiskit_serverless/core/client.py:77-81)

```python
if name:
    warnings.warn(
        "The 'name' attribute is deprecated and will be removed in a future release.",
        DeprecationWarning,
        stacklevel=2
    )
```

#### 1.2 Update docstrings

Mark `name` parameter as deprecated in:
- [`client/qiskit_serverless/core/client.py:67-76`](client/qiskit_serverless/core/client.py:67-76)
- [`client/qiskit_serverless/core/clients/serverless_client.py:112-122`](client/qiskit_serverless/core/clients/serverless_client.py:112-122)

Widget is also deprecated in the client.
The whole visualization folder is going to be deleted.