### PR TITLE
Group dependabot updates by module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     versioning-strategy: increase
     schedule:
       interval: "weekly"
+    groups:
+      client-dependencies:
+        patterns: ["*"]
 
   - package-ecosystem: "pip"
     directory: "/gateway"
@@ -19,6 +22,9 @@ updates:
     versioning-strategy: increase
     schedule:
       interval: "weekly"
+    groups:
+      gateway-dependencies:
+        patterns: ["*"]
 
   - package-ecosystem: "pip"
     directory: "/tests"
@@ -26,3 +32,6 @@ updates:
     versioning-strategy: increase
     schedule:
       interval: "weekly"
+    groups:
+      tests-dependencies:
+        patterns: ["*"]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Adds a groups block to each pip ecosystem entry in .github/dependabot.yml so that dependency updates are bundled into a single PR per module:

- /client → client-dependencies
- /gateway → gateway-dependencies
- /tests → tests-dependencies

Each group uses patterns: ["*"], covering all Python dependencies in that directory.


### Details and comments
This PR is an attempt to reduce the number of dependabot PRs we get every wednesday, but we might revert it if we see that some updates block others and it's not practical.
