### PR TITLE
Upgrade opentelemetry to 1.42+ to unblock importlib-metadata 9.x upgrade

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,15 +1,15 @@
 ray[default]>=2.55.1, <3
 requests>=2.32.5, <3
-importlib-metadata>=8.7.1, <9
+importlib-metadata>=9.0.0, <10
 qiskit[qpy-compat]>=1.4, <3
 qiskit-ibm-runtime>=0.47.0, <0.48.0
 # Make sure ray node and notebook node have the same version of cloudpickle
 cloudpickle==3.1.2
 tqdm>=4.68.3, <5
 # opentelemetry
-opentelemetry-api>=1.41.1, <1.42
-opentelemetry-sdk>=1.41.0, <1.42
-opentelemetry-exporter-otlp-proto-http>=1.41.1, <1.42
+opentelemetry-api>=1.42.0, <1.44
+opentelemetry-sdk>=1.42.0, <1.44
+opentelemetry-exporter-otlp-proto-http>=1.42.0, <1.44
 opentelemetry-instrumentation-requests>=0.62b1
 ipywidgets>=8.1.8, <9
 ipython>=8.39.0, <9


### PR DESCRIPTION
Dependabot PR #2264 tries to upgrade `importlib-metadata` from `<9` to `>=9.0.0,<10`, but CI fails because `opentelemetry-api 1.41.1` declares `importlib-metadata<8.8.0, >=6.0`, making the two ranges incompatible.

Starting from `opentelemetry-api 1.42.0`, the `importlib-metadata` dependency was dropped entirely (the module is available from the standard library in Python 3.10+). This PR upgrades the three opentelemetry packages to `>=1.42.0, <1.44` and bumps `importlib-metadata` to `>=9.0.0, <10`.

This covers Dependabot PR #2264, which can be closed.

## Changes in `client/requirements.txt`

- `importlib-metadata>=8.7.1, <9` -> `>=9.0.0, <10`
- `opentelemetry-api>=1.41.1, <1.42` -> `>=1.42.0, <1.44`
- `opentelemetry-sdk>=1.41.0, <1.42` -> `>=1.42.0, <1.44`
- `opentelemetry-exporter-otlp-proto-http>=1.41.1, <1.42` -> `>=1.42.0, <1.44`