### PR TITLE
Move gateway ray template dir off world-writable /tmp

### DIFF
--- a/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
+++ b/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
@@ -400,7 +400,7 @@ spec:
           volumeMounts:
             - mountPath: "/usr/src/app/media/"
               name: gateway-pv-storage
-            - mountPath: "/tmp/templates/"
+            - mountPath: "/etc/gateway/templates/"
               name: ray-cluster-template
             - mountPath: "/tmp/gpujobs/"
               name: gpu-jobs

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -112,7 +112,11 @@ ROOT_URLCONF = "main.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [BASE_DIR / "templates", "/tmp/templates"],
+        # The extra template directory (the ray cluster template delivered via a
+        # configmap mount) must not be a shared world-writable location such as
+        # /tmp, where a co-resident process could drop a malicious template into
+        # Django's search path.
+        "DIRS": [BASE_DIR / "templates", "/etc/gateway/templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -114,8 +114,8 @@ TEMPLATES = [
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         # The extra template directory (the ray cluster template delivered via a
         # configmap mount) must not be a shared world-writable location such as
-        # /tmp, where a co-resident process could drop a malicious template into
-        # Django's search path.
+        # /tmp, where any other process on the host could drop a malicious
+        # template into Django's search path.
         "DIRS": [BASE_DIR / "templates", "/etc/gateway/templates"],
         "APP_DIRS": True,
         "OPTIONS": {

--- a/gateway/tests/main/test_settings.py
+++ b/gateway/tests/main/test_settings.py
@@ -1,0 +1,16 @@
+"""Tests for Django settings."""
+
+from django.conf import settings
+
+
+def test_template_dirs_use_etc_gateway_not_tmp():
+    """The extra template dir must be /etc/gateway/templates, never /tmp.
+
+    The chart mounts the ray cluster template into /etc/gateway/templates. If
+    that mount ever drifts back to a world-writable location like /tmp, any
+    other process on the host could drop a malicious template into Django's
+    search path. This test catches such a desync.
+    """
+    dirs = [str(path) for path in settings.TEMPLATES[0]["DIRS"]]
+    assert "/etc/gateway/templates" in dirs
+    assert "/tmp/templates" not in dirs


### PR DESCRIPTION
### Summary

Move the extra Django template directory from /tmp/templates to /etc/gateway/templates.

The ray cluster template is delivered through a config map mount, and Django looks in that directory when it renders templates.
/tmp is world writable and shared, so another process on the same host could drop a malicious template into Django's search path.
Moving it to a path that is not world writable closes that gap.

### Details and comments

Two references are updated together and must stay in sync: the mount path in the gateway Helm chart deployment, and the TEMPLATES DIRS entry in gateway settings.
The template still resolves at runtime because both now point at the same new path.