### PR TITLE
Basename client download target to prevent path traversal

### DIFF
--- a/client/qiskit_serverless/core/files.py
+++ b/client/qiskit_serverless/core/files.py
@@ -99,6 +99,10 @@ class GatewayFilesClient:
             chunk_size = 8192
             progress_bar = tqdm(total=total_size_in_bytes, unit="iB", unit_scale=True)
             file_name = target_name or f"downloaded_{str(uuid.uuid4())[:8]}_{file}"
+            # os.path.basename keeps only the file name and strips any directory
+            # part, which could be a traversal like "../../etc/passwd", so a
+            # crafted name cannot escape download_location.
+            file_name = os.path.basename(file_name)
             with open(os.path.join(download_location, file_name), "wb") as f:
                 for chunk in req.iter_content(chunk_size=chunk_size):
                     progress_bar.update(len(chunk))

--- a/client/tests/core/test_files.py
+++ b/client/tests/core/test_files.py
@@ -151,6 +151,67 @@ class TestDownload:
                 assert result.endswith("_test.txt")
 
     @patch("qiskit_serverless.core.files.requests.get")
+    @patch("qiskit_serverless.core.files.tqdm")
+    def test_download_strips_path_traversal_from_target_name(self, mock_tqdm, mock_get, files_client, test_function):
+        """download() strips directory parts from target_name so it can't escape download_location."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.headers = {"content-length": "1024"}
+        mock_response.iter_content = MagicMock(return_value=[b"malicious"])
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_get.return_value = mock_response
+
+        mock_progress = MagicMock()
+        mock_tqdm.return_value = mock_progress
+
+        with tempfile.TemporaryDirectory() as parent_dir:
+            download_location = os.path.join(parent_dir, "downloads")
+            os.makedirs(download_location)
+
+            result = files_client.download(
+                file="test.txt",
+                download_location=download_location,
+                function=test_function,
+                target_name="../../evil.txt",
+            )
+
+            # Only the basename is kept, so the returned name has no directory part.
+            assert result == "evil.txt"
+            # The file is written inside download_location, never outside of it.
+            assert os.path.exists(os.path.join(download_location, "evil.txt"))
+            assert not os.path.exists(os.path.join(parent_dir, "evil.txt"))
+
+    @patch("qiskit_serverless.core.files.requests.get")
+    @patch("qiskit_serverless.core.files.tqdm")
+    def test_download_writes_file_inside_download_location(self, mock_tqdm, mock_get, files_client, test_function):
+        """download() writes the file with a plain target_name inside download_location."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.headers = {"content-length": "1024"}
+        mock_response.iter_content = MagicMock(return_value=[b"hello ", b"world"])
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_get.return_value = mock_response
+
+        mock_progress = MagicMock()
+        mock_tqdm.return_value = mock_progress
+
+        with tempfile.TemporaryDirectory() as download_location:
+            result = files_client.download(
+                file="test.txt",
+                download_location=download_location,
+                function=test_function,
+                target_name="downloaded.txt",
+            )
+
+            assert result == "downloaded.txt"
+            written_path = os.path.join(download_location, "downloaded.txt")
+            assert os.path.exists(written_path)
+            with open(written_path, "rb") as written_file:
+                assert written_file.read() == b"hello world"
+
+    @patch("qiskit_serverless.core.files.requests.get")
     def test_download_raises_on_http_error(self, mock_get, files_client, test_function):
         """download() raises exception on HTTP error."""
         mock_response = MagicMock()


### PR DESCRIPTION
### Summary

Strip any directory part from the download file name in the client so a crafted name cannot escape the download location.

The download target name can come from the server or the caller.
Without stripping it, a value like "../../etc/passwd" would let the write land outside download_location.
Wrapping it in os.path.basename keeps only the file name, so the write always stays inside the intended folder.

### Details and comments

The fix is a single line added right before the file is opened.
It does not change the normal case where the name is a plain file name.

When target_name is not set, the name is built from a random value, so this only matters when a name is passed in or returned by the server.