### PR TITLE
Drop duplicate ENV_JOB_ARGUMENTS literal env var for fleets

### DIFF
--- a/gateway/core/ibm_cloud/code_engine/fleets/utils.py
+++ b/gateway/core/ibm_cloud/code_engine/fleets/utils.py
@@ -186,8 +186,8 @@ def build_run_env_variables(
 
     # The full JSON job arguments are delivered to the container via COS at
     # ARGUMENTS_PATH (mounted file), so the duplicate ENV_JOB_ARGUMENTS literal
-    # env var only widens plaintext exposure of (potentially sensitive) user
-    # arguments in the Code Engine control plane. Drop it for fleets.
+    # env var would just expose the (possibly sensitive) user arguments as plain
+    # text in the Code Engine control plane. Drop it for fleets.
     env.pop("ENV_JOB_ARGUMENTS", None)
 
     gateway_host = getattr(settings, "FLEETS_GATEWAY_HOST", None)

--- a/gateway/core/ibm_cloud/code_engine/fleets/utils.py
+++ b/gateway/core/ibm_cloud/code_engine/fleets/utils.py
@@ -184,6 +184,12 @@ def build_run_env_variables(
     """
     env = dict(stored_env_vars)
 
+    # The full JSON job arguments are delivered to the container via COS at
+    # ARGUMENTS_PATH (mounted file), so the duplicate ENV_JOB_ARGUMENTS literal
+    # env var only widens plaintext exposure of (potentially sensitive) user
+    # arguments in the Code Engine control plane. Drop it for fleets.
+    env.pop("ENV_JOB_ARGUMENTS", None)
+
     gateway_host = getattr(settings, "FLEETS_GATEWAY_HOST", None)
     if gateway_host:
         env["ENV_JOB_GATEWAY_HOST"] = gateway_host

--- a/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_fleet_utils.py
+++ b/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_fleet_utils.py
@@ -248,6 +248,15 @@ def test_build_run_env_variables_excludes_empty_values():
     assert "ALSO_DROP" not in by_name
 
 
+def test_build_run_env_variables_drops_env_job_arguments():
+    """build_run_env_variables drops the ENV_JOB_ARGUMENTS stored env var."""
+    stored = {"ENV_JOB_ARGUMENTS": '{"secret": "value"}', "KEEP": "yes"}
+    result = build_run_env_variables(_make_paths(), stored)
+    names = {e["name"] for e in result}
+    assert "ENV_JOB_ARGUMENTS" not in names
+    assert "KEEP" in names
+
+
 def test_build_run_env_variables_with_private_log():
     """build_run_env_variables includes PRIVATE_LOG_PATH when container_private_log_path is set."""
     result = build_run_env_variables(


### PR DESCRIPTION
### Summary

Stop sending the job arguments as a plaintext literal env var to Code Engine fleets.

The full JSON arguments already reach the container through object storage at ARGUMENTS_PATH, so the extra ENV_JOB_ARGUMENTS env var only shows the arguments in plaintext in the Code Engine control plane.

### Details and comments

The container still reads its arguments from the mounted file at ARGUMENTS_PATH, so runtime behavior does not change.

Only the extra plaintext copy in the env var is removed.