### PR TITLE
Cache the 204 response from the Runtime functions API

### DIFF
--- a/charts/qiskit-serverless/charts/gateway/values.yaml
+++ b/charts/qiskit-serverless/charts/gateway/values.yaml
@@ -52,7 +52,7 @@ application:
     url: "https://cloud.ibm.com"
   runtimeApi:
     url: "https://quantum.cloud.ibm.com"
-    cacheTtl: "60"
+    cacheTtl: "1"
   allowedHosts: "*"
   trustedOrigins: "http://localhost"
   corsOrigins: "http://localhost"

--- a/gateway/api/clients/function_access_client.py
+++ b/gateway/api/clients/function_access_client.py
@@ -48,40 +48,39 @@ class FunctionAccessClient:
         if response.status_code == 204:
             # We agreed with Runtime that 204 response means there is no functions configured
             # for this instance, so we should fallback to Django
-            return FunctionAccessResult(
+            result = FunctionAccessResult(
                 use_legacy_authorization=True, message="Instance not configured, migration pending"
             )
-
-        if response.status_code != 200:
+        elif response.status_code != 200:
             logger.warning(
                 "FunctionAccessClient: unexpected status %s for CRN %s",
                 response.status_code,
                 instance_crn,
             )
             raise RuntimeFunctionsException(f"Unexpected status {response.status_code} for CRN {instance_crn}")
+        else:
+            response_json = response.json()
+            functions = []
+            for entry in response_json.get("functions", []):
+                try:
+                    function_entry = FunctionAccessEntry(
+                        provider_name=entry["provider"],
+                        function_title=entry["name"],
+                        permissions=set(entry.get("permissions", [])),
+                        business_model=entry["business_model"],
+                    )
+                    functions.append(function_entry)
+                except (KeyError, ValueError) as exc:
+                    # entry with missing field or incorrect business model
+                    logger.error("FunctionAccessClient: invalid entry %s — %s", entry, exc)
 
-        response_json = response.json()
-        functions = []
-        for entry in response_json.get("functions", []):
-            try:
-                function_entry = FunctionAccessEntry(
-                    provider_name=entry["provider"],
-                    function_title=entry["name"],
-                    permissions=set(entry.get("permissions", [])),
-                    business_model=entry["business_model"],
-                )
-                functions.append(function_entry)
-            except (KeyError, ValueError) as exc:
-                # entry with missing field or incorrect business model
-                logger.error("FunctionAccessClient: invalid entry %s — %s", entry, exc)
-
-        # custom_functions may be present but null (cleared), so coalesce both levels to avoid
-        # AttributeError on None.get(...).
-        custom_function_permissions = set((response_json.get("custom_functions") or {}).get("permissions") or [])
-        result = FunctionAccessResult(
-            use_legacy_authorization=False,
-            functions=functions,
-            custom_function_permissions=custom_function_permissions,
-        )
+            # custom_functions may be present but null (cleared), so coalesce both levels to avoid
+            # AttributeError on None.get(...).
+            custom_function_permissions = set((response_json.get("custom_functions") or {}).get("permissions") or [])
+            result = FunctionAccessResult(
+                use_legacy_authorization=False,
+                functions=functions,
+                custom_function_permissions=custom_function_permissions,
+            )
         cache.set(cache_key, result, timeout=settings.RUNTIME_API_CACHE_TTL)
         return result

--- a/gateway/tests/api/clients/test_function_access_client.py
+++ b/gateway/tests/api/clients/test_function_access_client.py
@@ -80,6 +80,17 @@ def test_caches_successful_response(instances_server):
     assert result.get_function("ibm", "sampler") is not None
 
 
+def test_caches_204_response(instances_server):
+    instances_server.error(204)
+
+    first = FunctionAccessClient().get_accessible_functions("crn:cache:204", "test-api-key")
+    second = FunctionAccessClient().get_accessible_functions("crn:cache:204", "test-api-key")
+
+    assert instances_server.request_count == 1
+    assert first.use_legacy_authorization is True
+    assert second.use_legacy_authorization is True
+
+
 def test_does_not_cache_error_response(instances_server):
     instances_server.error(500)
 


### PR DESCRIPTION
## Summary

`FunctionAccessClient.get_accessible_functions` calls the Runtime functions API to resolve which functions an instance can access. When the API responds `204` (instance not yet configured, meaning the caller should fall back to legacy Django-based authorization), the result was returned immediately without going through the cache, unlike every other response path. This meant every request for an unconfigured instance hit the Runtime API again instead of reusing a cached fallback result.

This PR restructures the status-code handling so the `204` case builds its result and falls through to the same `cache.set(...)` call as the `200` and error paths, so it now benefits from `RUNTIME_API_CACHE_TTL` like the rest.

It also includes an unrelated small config change lowering `cacheTtl` from `60` to `1` in the gateway Helm chart values as default value (it will be overwritten per environment in the values.yaml)