### PR TITLE
Update aqc-tensor dependency

### DIFF
--- a/gateway/tests/api/test_v1_dependencies.py
+++ b/gateway/tests/api/test_v1_dependencies.py
@@ -24,7 +24,7 @@ class TestAvailableDependenciesVersion(APITestCase):
             "mergedeep==1.3.4",
             "mthree==3.0.0",
             "pyscf==2.11.0",
-            "qiskit-addon-aqc-tensor[quimb-jax]==0.2.0",
+            "qiskit-addon-aqc-tensor[quimb-jax]==0.3.0",
             "qiskit-addon-obp==0.3.0",
             "qiskit-addon-sqd==0.12.0",
             "qiskit-addon-utils==0.2.0",

--- a/ray-node/requirements-dynamic-dependencies.txt
+++ b/ray-node/requirements-dynamic-dependencies.txt
@@ -2,7 +2,7 @@ ffsim==0.0.60
 mergedeep==1.3.4
 mthree==3.0.0
 pyscf==2.11.0
-qiskit-addon-aqc-tensor[quimb-jax]==0.2.0
+qiskit-addon-aqc-tensor[quimb-jax]==0.3.0
 qiskit-addon-obp==0.3.0
 qiskit-addon-sqd==0.12.0
 qiskit-addon-utils==0.2.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR is pretty simple. It updates the dependency `aqc-tensor` dependency to use the 0.3.0 version.