### PR TITLE
Fix authentication for non-default-region CRNs (e.g. eu-de)

### DIFF
--- a/gateway/api/clients/function_access_client.py
+++ b/gateway/api/clients/function_access_client.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import logging
+from urllib.parse import urlparse, urlunparse
 
 import requests
 from django.conf import settings
@@ -19,10 +20,27 @@ logger = logging.getLogger("api.FunctionAccessClient")
 class FunctionAccessClient:
     """Client for retrieving accessible functions for a given instance CRN."""
 
+    def _regional_base_url(self, base_url: str, instance_crn: str) -> str:
+        """Return the Runtime API base URL for the region encoded in ``instance_crn``.
+
+        The Runtime API is region-scoped: the default region (see
+        ``RUNTIME_API_DEFAULT_REGION``) is served by the bare host, while other regions
+        are reached via a ``{region}.`` host prefix (e.g. ``eu-de.quantum.cloud.ibm.com``).
+        The region is the 6th ``:``-delimited segment of the CRN
+        (``crn:v1:bluemix:public:quantum-computing:<region>:...``). A CRN whose region
+        cannot be parsed falls back to ``base_url`` unchanged.
+        """
+        parts = instance_crn.split(":") if instance_crn else []
+        region = parts[5] if len(parts) > 6 else None
+        if not region or region == settings.RUNTIME_API_DEFAULT_REGION:
+            return base_url
+        parsed = urlparse(base_url)
+        return urlunparse(parsed._replace(netloc=f"{region}.{parsed.netloc}"))
+
     def get_accessible_functions(self, instance_crn: str, api_key: str) -> FunctionAccessResult:
         """Return all functions accessible to the given instance CRN with their permissions."""
         enabled = Config.get_bool(ConfigKey.RUNTIME_INSTANCES_API_ENABLED)
-        base_url = settings.RUNTIME_API_BASE_URL
+        base_url = self._regional_base_url(settings.RUNTIME_API_BASE_URL, instance_crn)
         if not enabled:
             return FunctionAccessResult(use_legacy_authorization=True, message="RUNTIME_INSTANCES_API_ENABLED is False")
 

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -322,6 +322,9 @@ QISKIT_IBM_URL = os.environ.get("QISKIT_IBM_URL", "https://cloud.ibm.com")
 # Authentication Runtime API
 RUNTIME_API_BASE_URL = os.environ.get("RUNTIME_API_BASE_URL", "https://quantum.test.cloud.ibm.com")
 RUNTIME_API_CACHE_TTL = int(os.environ.get("RUNTIME_API_CACHE_TTL", "60"))
+# The Runtime API is region-scoped. RUNTIME_API_BASE_URL serves the default region on the
+# bare host; other regions are reached via a "{region}." host prefix derived from the CRN.
+RUNTIME_API_DEFAULT_REGION = os.environ.get("RUNTIME_API_DEFAULT_REGION", "us-east")
 
 # IBM Cloud
 

--- a/gateway/tests/api/clients/test_function_access_client.py
+++ b/gateway/tests/api/clients/test_function_access_client.py
@@ -135,3 +135,29 @@ def test_regional_url_unparseable_crn_falls_back(settings, crn):
     result = FunctionAccessClient()._regional_base_url(BASE_URL, crn)
 
     assert result == BASE_URL
+
+
+def test_request_routed_to_region_prefixed_host(settings, requests_mock):
+    """End-to-end: a non-default-region CRN sends the /functions request to the
+    region-prefixed host, not the bare default-region host."""
+    settings.RUNTIME_API_BASE_URL = BASE_URL
+    settings.RUNTIME_API_DEFAULT_REGION = "us-east"
+    matcher = requests_mock.get("https://eu-de.quantum.cloud.ibm.com/api/v1/functions", status_code=204)
+
+    result = FunctionAccessClient().get_accessible_functions(_crn("eu-de"), "test-api-key")
+
+    assert matcher.called_once
+    assert matcher.last_request.headers["Service-CRN"] == _crn("eu-de")
+    # 204 → instance not configured in the runtime API, fall back to legacy authorization.
+    assert result.use_legacy_authorization is True
+
+
+def test_request_routed_to_default_host(settings, requests_mock):
+    """End-to-end: a default-region CRN uses the bare host with no region prefix."""
+    settings.RUNTIME_API_BASE_URL = BASE_URL
+    settings.RUNTIME_API_DEFAULT_REGION = "us-east"
+    matcher = requests_mock.get("https://quantum.cloud.ibm.com/api/v1/functions", status_code=204)
+
+    FunctionAccessClient().get_accessible_functions(_crn("us-east"), "test-api-key")
+
+    assert matcher.called_once

--- a/gateway/tests/api/clients/test_function_access_client.py
+++ b/gateway/tests/api/clients/test_function_access_client.py
@@ -100,3 +100,38 @@ def test_does_not_cache_error_response(instances_server):
         FunctionAccessClient().get_accessible_functions("crn:cache:err", "test-api-key")
 
     assert instances_server.request_count == 2
+
+
+# Region routing: the Runtime API is region-scoped. The default region is served by the
+# bare host; other regions get a "{region}." host prefix derived from the CRN.
+
+BASE_URL = "https://quantum.cloud.ibm.com"
+
+
+def _crn(region: str) -> str:
+    return f"crn:v1:bluemix:public:quantum-computing:{region}:a/acct:guid::"
+
+
+def test_regional_url_default_region_unchanged(settings):
+    settings.RUNTIME_API_DEFAULT_REGION = "us-east"
+
+    result = FunctionAccessClient()._regional_base_url(BASE_URL, _crn("us-east"))
+
+    assert result == BASE_URL
+
+
+def test_regional_url_non_default_region_prefixed(settings):
+    settings.RUNTIME_API_DEFAULT_REGION = "us-east"
+
+    result = FunctionAccessClient()._regional_base_url(BASE_URL, _crn("eu-de"))
+
+    assert result == "https://eu-de.quantum.cloud.ibm.com"
+
+
+@pytest.mark.parametrize("crn", ["crn:test:123", "", None])
+def test_regional_url_unparseable_crn_falls_back(settings, crn):
+    settings.RUNTIME_API_DEFAULT_REGION = "us-east"
+
+    result = FunctionAccessClient()._regional_base_url(BASE_URL, crn)
+
+    assert result == BASE_URL

--- a/releasenotes/notes/0.33.0/fix-eu-de-region-auth-4b8c2e9f1a6d0357.yaml
+++ b/releasenotes/notes/0.33.0/fix-eu-de-region-auth-4b8c2e9f1a6d0357.yaml
@@ -1,0 +1,14 @@
+---
+fixes:
+  - |
+    Fixed authentication failures for IBM Cloud instances in regions other than the
+    gateway's default region (for example ``eu-de``). During authentication the gateway
+    resolves accessible functions via the region-scoped Runtime API, but it previously
+    used a single fixed ``RUNTIME_API_BASE_URL`` for every CRN. A CRN from a non-default
+    region was sent to the default-region host, which returned ``404 Instance not
+    found`` and failed authentication. The gateway now derives the region from the CRN
+    (the ``crn:v1:bluemix:public:quantum-computing:<region>:...`` segment) and routes the
+    functions-access request to the matching regional endpoint. The default region is
+    configurable via the ``RUNTIME_API_DEFAULT_REGION`` environment variable
+    (default ``us-east``), which is served by the bare ``RUNTIME_API_BASE_URL`` host;
+    other regions use a ``{region}.`` host prefix.


### PR DESCRIPTION
## Summary

Authentication failed for any IBM Cloud instance CRN whose region is not the gateway's default region — reported for `eu-de`.

**Root cause:** During authentication the gateway resolves accessible functions via the IBM Runtime API (`/api/v1/functions`), which is **region-scoped**. `FunctionAccessClient` used a single fixed `settings.RUNTIME_API_BASE_URL` for *every* CRN, so a non-default-region CRN was sent to the default-region (us-east) host:

| CRN region | Endpoint hit | Result |
|---|---|---|
| `us-east` | `https://quantum.cloud.ibm.com` | 204 ✅ |
| `eu-de`   | `https://quantum.cloud.ibm.com` (us-east) | **404 code 1279 "Instance not found"** ❌ |
| `eu-de`   | `https://eu-de.quantum.cloud.ibm.com` | 204 ✅ |

The 404 became a `RuntimeFunctionsException`, which failed the whole auth flow.

**Why it worked before:** `FunctionAccessClient` has been region-blind since it was added (#2039), but it only runs when the `RUNTIME_INSTANCES_API_ENABLED` config flag is on — otherwise auth uses the region-agnostic legacy path. The failure surfaced when the instances API was enabled for the environment (a config change, not a code commit). This is **not** related to the client-side PRs #2187 / #2239, which pass the CRN through unchanged.

## Fix

Derive the region from the CRN (the `crn:v1:bluemix:public:quantum-computing:<region>:...` segment) and route the functions-access request to the matching regional endpoint:
- the default region is served by the bare `RUNTIME_API_BASE_URL` host;
- other regions use a `{region}.` host prefix (e.g. `eu-de.quantum.cloud.ibm.com`);
- unparseable CRNs fall back to the base URL unchanged.

The default region is configurable via the new `RUNTIME_API_DEFAULT_REGION` env var (default `us-east`).

## Testing

- Added unit tests for default-region (unchanged), non-default-region (prefixed), and unparseable-CRN (fallback) routing. Full suite for the client passes (13/13); `black` clean; `pylint` 10.00/10.
- Verified end-to-end against the live Runtime API with real eu-de and us-east credentials (read-only, no jobs submitted): eu-de now authenticates where it previously raised `RuntimeFunctionsException(404)`, and us-east is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)