### PR TITLE
Update Cotengrust Dependency

### DIFF
--- a/gateway/tests/api/test_v1_dependencies.py
+++ b/gateway/tests/api/test_v1_dependencies.py
@@ -24,6 +24,7 @@ class TestAvailableDependenciesVersion(APITestCase):
             "mergedeep==1.3.4",
             "mthree==3.0.0",
             "pyscf==2.13.1",
+            "cotengrust==0.2.0",
             "qiskit-addon-aqc-tensor[quimb-jax]==0.3.0",
             "qiskit-addon-obp==0.3.0",
             "qiskit-addon-sqd==0.12.1",

--- a/ray-node/requirements-dynamic-dependencies.txt
+++ b/ray-node/requirements-dynamic-dependencies.txt
@@ -2,6 +2,7 @@ ffsim==0.0.60
 mergedeep==1.3.4
 mthree==3.0.0
 pyscf==2.13.1
+cotengrust==0.2.0
 qiskit-addon-aqc-tensor[quimb-jax]==0.3.0
 qiskit-addon-obp==0.3.0
 qiskit-addon-sqd==0.12.1

--- a/releasenotes/notes/add-cotengrust-dependency-e7b273eb496ca9b4.yaml
+++ b/releasenotes/notes/add-cotengrust-dependency-e7b273eb496ca9b4.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added ``cotengrust==0.2.0`` to the dynamic dependencies allowlist bundled in
+    the Ray runner image. Qiskit Functions can now declare and use
+    ``cotengrust`` for tensor network contraction path optimization.


### PR DESCRIPTION
## Summary

PR is simple. It is to add cotengrust to the allowlist of external dependencies allowed to be installed for running custom functions. This is required for more memory efficient TN simulation workflows. 

Similar to @Tansito PR: https://github.com/Qiskit/qiskit-serverless/pull/2319

