### PR TITLE
Use format_html instead of mark_safe in admin displays

### DIFF
--- a/gateway/api/admin.py
+++ b/gateway/api/admin.py
@@ -5,7 +5,7 @@ import logging
 
 from django.contrib import admin
 from django.db.models import Count, F, Q
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.urls import path
 from django.shortcuts import render, get_object_or_404
 from django.contrib.admin.views.main import PAGE_VAR
@@ -201,7 +201,7 @@ class JobEventInline(admin.TabularInline):
 
         pretty_json = json.dumps(instance.data, indent=2).strip()
 
-        return mark_safe(f'<pre class="event-json-block">{pretty_json}</pre>')
+        return format_html('<pre class="event-json-block">{}</pre>', pretty_json)
 
     @admin.display(description="Status/SubStatus")
     def pretty_status(self, instance):
@@ -213,7 +213,7 @@ class JobEventInline(admin.TabularInline):
         elif instance.event_type == JobEventType.SUB_STATUS_CHANGE:
             status = instance.data["sub_status"]
 
-        return mark_safe(f'<span class="event-badge" data-event-status="{status}">{status}</span>')
+        return format_html('<span class="event-badge" data-event-status="{}">{}</span>', status, status)
 
     class Media:  # pylint: disable=too-few-public-methods
         """JobEventInline Media"""
@@ -380,7 +380,7 @@ class JobAdmin(admin.ModelAdmin):
     @admin.display(description="Status")
     def status_badge(self, obj):
         """Render status as a colored badge."""
-        return mark_safe(f'<span class="qs-status-badge" data-status="{obj.status}">{obj.status}</span>')
+        return format_html('<span class="qs-status-badge" data-status="{}">{}</span>', obj.status, obj.status)
 
     @admin.display(description="Program")
     def get_program(self, obj):


### PR DESCRIPTION
### Summary

The admin display helpers built HTML with `mark_safe()` on f-strings that interpolate values (job status, sub-status, and event data JSON). `mark_safe` marks the whole string as safe without escaping, so any value that reached these helpers would be rendered as raw HTML in the admin. This swaps them for `format_html()` with arguments, which escapes each interpolated value while keeping the surrounding markup intact.

It also keeps `pylint` green: `pylint-django` 2.8.0 added the `mark-safe-interpolation` (W5151) check, which flags exactly these three call sites, so a fresh lint run on `main` now fails without this change.

### Details and comments

Three call sites in `gateway/api/admin.py`:

- `render_data_json` (event data JSON block)
- `pretty_status` (status/sub-status badge)
- `status_badge` (job status badge)

Rendered output is unchanged for normal values; the only difference is that interpolated values are now HTML-escaped. The `mark_safe` import is replaced by `format_html`.