### PR TITLE
Load .env file in Gateway/Scheduler

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,11 @@ docker-compose-dev.yaml
 .idea
 .vscode/
 
+### Local env files (never bake into the image)
+
+**/.env
+**/.env.*
+
 ### Python project ignores
 
 *.pyc

--- a/gateway/.dockerignore
+++ b/gateway/.dockerignore
@@ -1,3 +1,5 @@
+.env
+.env.*
 *.pyc
 *.pyo
 *.mo

--- a/gateway/manage.py
+++ b/gateway/manage.py
@@ -8,8 +8,31 @@ import sys
 logger = logging.getLogger("main")
 
 
+def _load_local_env():
+    """Load a local .env file when ENV_FILE points to one.
+
+    Opt-in only: nothing is loaded unless ENV_FILE is set, so docker compose and
+    Kubernetes (which do not set it) keep getting their config from real
+    environment variables. Meant for local development, e.g.
+    `ENV_FILE=.env.staging python manage.py runserver`.
+    """
+    env_file = os.environ.get("ENV_FILE")
+    if not env_file:
+        return
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        return
+    env_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), env_file)
+    if os.path.exists(env_path):
+        # override=False: real shell env vars still win over the file.
+        load_dotenv(env_path, override=False)
+        logger.info(f"[BOOT] Loaded local env file {env_file}")
+
+
 def main():
     """Run administrative tasks."""
+    _load_local_env()
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "main.settings")
     try:
         from django.core.management import execute_from_command_line

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -32,3 +32,4 @@ PyJWT>=2.13.0, <3
 ibm-cos-sdk>=2.16.2, <3
 ibm-cloud-sdk-core>=3.25.0, <4
 confluent-kafka>=2.15.0,<3
+python-dotenv>=1.0.0, <2


### PR DESCRIPTION
### Summary

This adds optional loading of a local `.env` file into the environment on startup, controlled by an `ENV_FILE` variable, so developers can point their local server at a different configuration without editing code or exporting variables by hand every time.

It is opt-in and does nothing unless `ENV_FILE` is set. Real deployments do not set it (docker compose and Kubernetes pass their configuration through actual environment variables), so they are unaffected.

### Details and comments

- New `python-dotenv` dependency, used only by `manage.py`.
- Set `ENV_FILE` to the file you want, resolved next to `manage.py`, for example `ENV_FILE=.env.staging python manage.py runserver`.
- `load_dotenv(..., override=False)` so any variable already set in the shell still wins over the file.
- If `python-dotenv` is not installed or the file does not exist, it is a no-op.
- `.env` files are added to both `.dockerignore` files so they never get baked into the image.
