### PR TITLE
Upgrade fleet-worker base image build tools to patch CVEs

### DIFF
--- a/tests/fleets/fleet-worker/Dockerfile
+++ b/tests/fleets/fleet-worker/Dockerfile
@@ -12,6 +12,9 @@
 
 FROM python:3.11-slim
 RUN apt-get update && apt-get install -y s3fs fuse && rm -rf /var/lib/apt/lists/*
+# Upgrade the base image build tools to versions without known CVEs
+# (CVE-2026-8643 in pip, CVE-2026-24049 in wheel, CVE-2026-59890 in setuptools).
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2" "setuptools>=83.0.0" "wheel>=0.46.2"
 COPY client/ /tmp/client/
 RUN pip install /tmp/client/ boto3
 COPY tests/fleets/fleet-worker/storage.py /app/storage.py


### PR DESCRIPTION
### Summary
The CI Code Risk Analyzer (CRA) vulnerability scan is failing on every run. It flagged 13 CVEs, all from the outdated build tools in the `python:3.11-slim` base image used by `tests/fleets/fleet-worker/Dockerfile` (pip 24.0, setuptools 79.0.1, wheel 0.45.1). The high-severity ones are CVE-2026-8643 (pip) and CVE-2026-24049 (wheel). No other image in the repo is affected. This was triggered by recently published CVEs, not by a code change.

### Details and comments
Upgrades pip, setuptools and wheel to the versions reported as fixed by CRA. The scan runs with the docker build context enabled, so it inspects the built layers and picks up the upgraded versions. The change only touches the test worker image.