### PR TITLE
Fix `Job.status()` ignoring `sub_status` 

### DIFF
--- a/client/qiskit_serverless/core/job.py
+++ b/client/qiskit_serverless/core/job.py
@@ -195,7 +195,11 @@ class Job:
         fresh_data = self._job_service.get_job_data(self.job_id)
         if isinstance(fresh_data, dict):
             self.raw_data.update(fresh_data)
-            return _map_status_from_serveless(fresh_data.get("status"))
+            raw_status = fresh_data.get("status")
+            sub_status = fresh_data.get("sub_status")
+            if raw_status == Job.RUNNING and sub_status is not None:
+                return _map_status_from_serveless(sub_status)
+            return _map_status_from_serveless(raw_status)
         return _map_status_from_serveless(self._job_service.status(self.job_id))
 
     def stop(self, service: Optional[QiskitRuntimeService] = None):

--- a/client/tests/core/test_job.py
+++ b/client/tests/core/test_job.py
@@ -755,3 +755,33 @@ class TestJobMethods:
 
         assert result == "RUNNING"
         mock_service.status.assert_called_once_with("test-job")
+
+    def test_status_returns_sub_status_when_running(self):
+        """status() returns mapped sub_status when status is RUNNING and sub_status is present."""
+        mock_service = Mock()
+        mock_service.get_job_data.return_value = {"status": "RUNNING", "sub_status": "MAPPING"}
+
+        job = Job(job_id="test-job", job_service=mock_service)
+        result = job.status()
+
+        assert result == "RUNNING: MAPPING"
+
+    def test_status_ignores_sub_status_when_not_running(self):
+        """status() ignores sub_status for non-RUNNING statuses."""
+        mock_service = Mock()
+        mock_service.get_job_data.return_value = {"status": "SUCCEEDED", "sub_status": "MAPPING"}
+
+        job = Job(job_id="test-job", job_service=mock_service)
+        result = job.status()
+
+        assert result == "DONE"
+
+    def test_status_returns_running_when_sub_status_is_none(self):
+        """status() returns RUNNING when sub_status is None."""
+        mock_service = Mock()
+        mock_service.get_job_data.return_value = {"status": "RUNNING", "sub_status": None}
+
+        job = Job(job_id="test-job", job_service=mock_service)
+        result = job.status()
+
+        assert result == "RUNNING"

--- a/releasenotes/notes/fix-job-status-sub-status-d3a7c1e8f2b94a05.yaml
+++ b/releasenotes/notes/fix-job-status-sub-status-d3a7c1e8f2b94a05.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed :meth:`~qiskit_serverless.core.job.Job.status` returning ``RUNNING``
+    for jobs that report a ``sub_status`` (e.g. ``RUNNING: MAPPING``).
+    The fast path introduced in #2072 read only the top-level ``status`` field
+    and silently dropped the ``sub_status`` check that existed in
+    ``ServerlessClient.status()``.  The sub-status is now forwarded correctly
+    when the top-level status is ``RUNNING`` and ``sub_status`` is not ``None``.


### PR DESCRIPTION
## Summary

- `Job.status()` was always returning `RUNNING` for jobs that report a sub-status, instead of the granular sub-status value.
- Root cause: PR #2072 introduced a fast path via `get_job_data()` that only read the top-level `status` field, silently dropping the `sub_status` check that existed in `ServerlessClient.status()`.
- Fix: restore the sub-status check in the `get_job_data` fast path, mirroring the existing logic in `ServerlessClient.status()`.

## Root cause bisection

Introduced in commit `b99435b47` (2026-05-04) — "Expose fleet_id on Job and allow status polling via get_job_data" (#2072).

Before that commit, `Job.status()` always delegated to `self._job_service.status()` → `ServerlessClient.status()`, which correctly handled `sub_status`. The new fast path bypassed that method entirely.

## Test plan

- [x] Added unit tests for the fixed `Job.status()` path: sub_status returned when RUNNING, ignored for non-RUNNING states, `None` sub_status falls back to RUNNING.