### PR TITLE
Add release note checklist item to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,7 @@
 <!--
 ⚠️ If you do not respect this template, your pull request will be closed.
 ⚠️ Your pull request title should be short detailed and understandable for all.
-⚠️ Also, please add a release note file using reno if the change needs to be
-  documented in the release notes.
 ⚠️ If your pull request fixes an open issue, please link to the issue.
-
-- [ ] I have added the tests to cover my changes.
-- [ ] I have updated the documentation accordingly.
-- [ ] I have read the CONTRIBUTING document.
 -->
 
 ### Summary
@@ -16,3 +10,10 @@
 
 ### Details and comments
 
+
+
+### Checklist
+
+- [ ] I have added tests to cover my changes.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have added a [release note](https://github.com/Qiskit/qiskit-serverless/blob/main/CONTRIBUTING.md#release-notes) for any user-facing change (new feature, bug fix, deprecation, or breaking change), or this PR has no user-facing changes.


### PR DESCRIPTION
## Summary

Moves the PR checklist out of the HTML comment (where it was invisible) and adds an explicit item asking contributors to add a release note for any user-facing change.

## Changes

- Checklist is now rendered visibly below the summary sections instead of being hidden in the comment block.
- Removed the redundant inline warning about release notes from the comment; replaced it with a checklist item that links to the contributing guide.
- Removed the "I have read the CONTRIBUTING document" item (not actionable/verifiable).