### PR TITLE
Update AQC Tensor Addon Version

### DIFF
--- a/gateway/tests/api/test_v1_dependencies.py
+++ b/gateway/tests/api/test_v1_dependencies.py
@@ -25,7 +25,7 @@ class TestAvailableDependenciesVersion(APITestCase):
             "mthree==3.0.0",
             "pyscf==2.13.1",
             "cotengrust==0.2.0",
-            "qiskit-addon-aqc-tensor[quimb-jax]==0.3.0",
+            "qiskit-addon-aqc-tensor[quimb-jax]==0.3.1",
             "qiskit-addon-obp==0.3.0",
             "qiskit-addon-sqd==0.12.1",
             "qiskit-addon-utils==0.2.0",

--- a/ray-node/requirements-dynamic-dependencies.txt
+++ b/ray-node/requirements-dynamic-dependencies.txt
@@ -3,7 +3,7 @@ mergedeep==1.3.4
 mthree==3.0.0
 pyscf==2.13.1
 cotengrust==0.2.0
-qiskit-addon-aqc-tensor[quimb-jax]==0.3.0
+qiskit-addon-aqc-tensor[quimb-jax]==0.3.1
 qiskit-addon-obp==0.3.0
 qiskit-addon-sqd==0.12.1
 qiskit-addon-utils==0.2.0

--- a/releasenotes/notes/bump-qiskit-addon-aqc-tensor-4a34476ed557217d.yaml
+++ b/releasenotes/notes/bump-qiskit-addon-aqc-tensor-4a34476ed557217d.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Bumped ``qiskit-addon-aqc-tensor[quimb-jax]`` from ``0.3.0`` to ``0.3.1``
+    in the dynamic dependencies allowlist bundled in the Ray runner image.
+    Qiskit Functions can now declare and use this newer version.


### PR DESCRIPTION
Pretty simple PR updating the version allowed to be installed in the dynamic dependencies list of custom functions from 0.3.0 to 0.3.1 for `qiskit-addon-aqc-tensor`

Similar to @Tansito PR: https://github.com/Qiskit/qiskit-serverless/pull/2319