### PR TITLE
Split fleet-node image into base and selector stages

### DIFF
--- a/fleet-node/Dockerfile
+++ b/fleet-node/Dockerfile
@@ -11,18 +11,24 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 #
-# Fleets worker base image (Python 3.12) — the Fleets-runner counterpart of
-# ray-node/Dockerfile. This is the runtime image Code Engine fleet tasks run in;
-# the integration-test worker (tests/fleets/fleet-worker/Dockerfile) builds FROM it.
+# Fleets worker image (Python 3.12) — the Fleets-runner counterpart of
+# ray-node/Dockerfile, split into the same two stages:
+#   base:     slim public image (client only, no dynamic deps). Function providers
+#             build custom Fleets images FROM it, and the integration-test worker
+#             (tests/fleets/fleet-worker/Dockerfile) builds FROM it.
+#   selector: base + requirements-dynamic-dependencies.txt (the qiskit workload
+#             stack). The full runtime the gateway deploys for imageless Fleets
+#             jobs. It is the LAST stage, so a build with no --target resolves to it.
 #
-# Build from repo root (client/ and ray-node/ must be in the build context):
-#   docker build --platform linux/amd64 -f fleet-node/Dockerfile -t fleet-node:latest .
+# Build from repo root (client/ must be in the build context):
+#   docker build --platform linux/amd64 -f fleet-node/Dockerfile -t fleet-node:latest .                 # full (selector)
+#   docker build --platform linux/amd64 --target base -f fleet-node/Dockerfile -t fleet-node:base .     # slim base
 #
 # No CUDA base: nothing here links against CUDA (qiskit-aer is the CPU build),
 # and CE's NVIDIA container runtime injects the driver + nvidia-smi into GPU
 # workers at runtime. UBI9 (glibc 2.34) satisfies the mthree manylinux_2_34 wheel;
 # all pinned deps ship linux/x86_64 wheels for 3.12, so no build toolchain is needed.
-FROM registry.access.redhat.com/ubi9-minimal:9.8-1784092902
+FROM registry.access.redhat.com/ubi9-minimal:9.8-1784092902 AS base
 ARG PYTHON_VERSION=3.12
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
@@ -57,16 +63,9 @@ RUN mkdir /function_user_data /job_user_data /function_provider_data /job_provid
         "pip>=26.1.2" \
         "setuptools>=83.0.0"
 
-# Dynamic dependencies — the qiskit workload stack pre-baked so Fleets functions
-# run without reinstalling. Kept in fleet-node's own file (not shared with
-# ray-node) so the two runners can evolve independently; today the set is the
-# same as ray-node's. All resolve to prebuilt 3.12 wheels.
-COPY fleet-node/requirements-dynamic-dependencies.txt /tmp/
-RUN pip install --no-cache-dir \
-        -r /tmp/requirements-dynamic-dependencies.txt && \
-    rm /tmp/requirements-dynamic-dependencies.txt
-
-# Install the client last for better layer-cache reuse. Keep this on its own RUN
+# Install the client into the base stage (plain, no [ray] extra — Fleets does not
+# use Ray) so images built FROM base — custom provider images and the
+# integration-test worker — already have the client. Keep this on its own RUN
 # with plain '&&' so a failed install fails the build — do NOT chain '|| true'
 # guards onto this step (that would silently ship an image with no client).
 # (No symengine lib/lib64 copy: Qiskit 2.2 dropped symengine, so it is not
@@ -74,5 +73,16 @@ RUN pip install --no-cache-dir \
 COPY client /tmp/qs
 RUN pip install --no-cache-dir /tmp/qs && \
     rm -rf /tmp/qs
+USER 1000
 
+# Dynamic dependencies — the qiskit workload stack pre-baked so Fleets functions
+# run without reinstalling. Kept in fleet-node's own file (not shared with
+# ray-node) so the two runners can evolve independently; today the set is the
+# same as ray-node's. All resolve to prebuilt 3.12 wheels.
+FROM base AS selector
+USER 0
+COPY fleet-node/requirements-dynamic-dependencies.txt /tmp/
+RUN pip install --no-cache-dir \
+        -r /tmp/requirements-dynamic-dependencies.txt && \
+    rm /tmp/requirements-dynamic-dependencies.txt
 USER 1000

--- a/fleet-node/requirements-dynamic-dependencies.txt
+++ b/fleet-node/requirements-dynamic-dependencies.txt
@@ -3,7 +3,7 @@ mergedeep==1.3.4
 mthree==3.0.0
 pyscf==2.13.1
 cotengrust==0.2.0
-qiskit-addon-aqc-tensor[quimb-jax]==0.3.0
+qiskit-addon-aqc-tensor[quimb-jax]==0.3.1
 qiskit-addon-obp==0.3.0
 qiskit-addon-sqd==0.12.1
 qiskit-addon-utils==0.2.0


### PR DESCRIPTION
### Summary

This splits the fleet-node image into two stages, the same way ray-node already works.

Before, fleet-node was a single stage with everything baked in. That left no slim base for function providers to build on, and no clean full image to deploy. Now there are two:

- base: slim image with just the client (no dynamic deps, no ray). Providers build their custom Fleets images from this, and the integration test worker builds from it too.
- selector: base plus the qiskit stack from requirements-dynamic-dependencies.txt. This is the full image the gateway runs for imageless jobs. It is the last stage, so a build with no --target still gives the full image.

### Details and comments

Nothing changes for the current builds. The Makefile, the fleets compose test, and the integration test workflow all build with no --target, so they keep getting the full image tagged fleet-node:latest.

The client install moved into the base stage (like ray-node) so anything built from base already has the client.

I also synced the fleet-node dynamic deps with ray-node. The only gap was qiskit-addon-aqc-tensor (0.3.0 vs 0.3.1). Both are on 0.3.1 now and the two requirements files match.

Checked both targets build on linux/amd64: base has qiskit_serverless but not qiskit_aer or ray, and the no-target build resolves to selector with qiskit_serverless, qiskit_aer and pyscf. pip check is clean and both run as uid 1000.
