### PR TITLE
Add private VirtualService for SDNLB private gateway

### DIFF
--- a/charts/qiskit-serverless/templates/istio.yaml
+++ b/charts/qiskit-serverless/templates/istio.yaml
@@ -38,6 +38,29 @@ spec:
             port:
               number: {{ .Values.gateway.application.service.port  }}
 ---
+{{ if .Values.istio.privateHost }}
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: gateway-virtual-service-private
+spec:
+  hosts:
+    - {{ .Values.istio.privateHost }}
+  gateways:
+    - qiskit-serverless-gateway-private
+  http:
+    - match:
+        - uri:
+            prefix: /metrics
+      directResponse:
+        status: 404
+    - route:
+        - destination:
+            host: {{ .Values.gateway.fullnameOverride }}
+            port:
+              number: {{ .Values.gateway.application.service.port }}
+{{ end }}
+---
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:


### PR DESCRIPTION
### Summary

Add an Istio VirtualService that routes traffic through the private SDNLB gateway (`qiskit-serverless-gateway-private`), alongside the existing public one. The new resource is guarded by `{{ if .Values.istio.privateHost }}` .

### Details and comments

The private SDNLB is provisioned on the infra side (Gateway resource named `qiskit-serverless-gateway-private`). The app chart only needs the VirtualService pointing at it.

To enable in an environment, set in the values override:

```yaml
istio:
  privateHost: private.qiskit-serverless-dev.quantum.ibm.com
```