### PR TITLE
Align Functions usage events with the billing service contract

### DIFF
--- a/gateway/core/ibm_cloud/event_streams/abstract_event_streams_client.py
+++ b/gateway/core/ibm_cloud/event_streams/abstract_event_streams_client.py
@@ -19,13 +19,13 @@ class EventStreamsClient(ABC):
     """Interface for job usage event publishing."""
 
     @abstractmethod
-    def emit_job_started(self, job) -> None:
-        """Publish or log a job_started event."""
+    def emit_job_started(self, job, metric_type: str) -> None:
+        """Publish or log a function_job_started event for the given metric."""
 
     @abstractmethod
-    def emit_job_in_progress(self, job) -> None:
-        """Publish or log a job_in_progress event."""
+    def emit_job_in_progress(self, job, metric_type: str) -> None:
+        """Publish or log a function_job_in_progress event for the given metric."""
 
     @abstractmethod
-    def emit_job_ended(self, job) -> None:
-        """Publish or log a job_ended event."""
+    def emit_job_completed(self, job, metric_type: str) -> None:
+        """Publish or log a function_job_completed event for the given metric."""

--- a/gateway/core/ibm_cloud/event_streams/kafka_event_streams_client.py
+++ b/gateway/core/ibm_cloud/event_streams/kafka_event_streams_client.py
@@ -31,7 +31,12 @@ class KafkaEventStreamsClient(EventStreamsClient):
     """
     Kafka producer client for IBM Cloud Event Streams.
 
-    Publishes CloudEvents 1.0 usage events for Fleets jobs.
+    Publishes CloudEvents 1.0 usage events for Fleets jobs. Each event carries a
+    single metric in its `data` payload: `metric_type` (what is being billed) and
+    `metric_value` (how much, in milliseconds for time-based metrics), plus
+    `job_started` / `job_completed` flags so consumers can detect lifecycle
+    boundaries without interpreting the metric type.
+
     Configured from environment variables:
       EVENT_STREAMS_BOOTSTRAP_SERVERS — comma-separated broker list
       EVENT_STREAMS_API_KEY           — SASL/PLAIN password
@@ -54,25 +59,45 @@ class KafkaEventStreamsClient(EventStreamsClient):
         )
         self.topic = f"quantum.{environment}.function-usage.v1"
 
-    def emit_job_started(self, job) -> None:
-        """Publish a job_started event (usage_nanoseconds=0)."""
-        self._publish(job, event_type="job_started", usage_nanoseconds=0)
+    def emit_job_started(self, job, metric_type: str) -> None:
+        """Publish a job-started event for the given metric (metric_value=0)."""
+        self._publish(job, metric_type=metric_type, metric_value=0, job_started=True, job_completed=False)
 
-    def emit_job_in_progress(self, job) -> None:
-        """Publish a job_in_progress event with current usage."""
-        self._publish(job, event_type="job_in_progress", usage_nanoseconds=self._usage_ns(job))
+    def emit_job_in_progress(self, job, metric_type: str) -> None:
+        """Publish a job-in-progress event for the given metric with current usage."""
+        self._publish(
+            job,
+            metric_type=metric_type,
+            metric_value=self._usage_ms(job),
+            job_started=False,
+            job_completed=False,
+        )
 
-    def emit_job_ended(self, job) -> None:
-        """Publish a job_ended event with final usage."""
-        self._publish(job, event_type="job_ended", usage_nanoseconds=self._usage_ns(job))
+    def emit_job_completed(self, job, metric_type: str) -> None:
+        """Publish a job-completed event for the given metric with final usage."""
+        self._publish(
+            job,
+            metric_type=metric_type,
+            metric_value=self._usage_ms(job),
+            job_started=False,
+            job_completed=True,
+        )
 
-    def _usage_ns(self, job) -> int:
+    def _usage_ms(self, job) -> int:
         if job.running_started_at is None:
             return 0
         delta = datetime.now(timezone.utc) - job.running_started_at
-        return int(delta.total_seconds() * 1e9)
+        return int(delta.total_seconds() * 1e3)
 
-    def _publish(self, job, *, event_type: str, usage_nanoseconds: int) -> None:
+    def _publish(
+        self,
+        job,
+        *,
+        metric_type: str,
+        metric_value: int,
+        job_started: bool,
+        job_completed: bool,
+    ) -> None:
         now = datetime.now(timezone.utc)
         event = {
             "specversion": "1.0",
@@ -83,10 +108,12 @@ class KafkaEventStreamsClient(EventStreamsClient):
             "subject": str(job.id),
             "datacontenttype": "application/json",
             "data": {
-                "event_type": event_type,
-                "usage_nanoseconds": usage_nanoseconds,
+                "metric_type": metric_type,
+                "metric_value": metric_value,
                 "instance_crn": job.instance_crn,
-                "function_id": str(job.id),
+                "resource_id": str(job.id),
+                "job_started": job_started,
+                "job_completed": job_completed,
             },
         }
         self._producer.produce(

--- a/gateway/core/ibm_cloud/event_streams/noop_event_streams_client.py
+++ b/gateway/core/ibm_cloud/event_streams/noop_event_streams_client.py
@@ -26,11 +26,11 @@ class NoOpEventStreamsClient(EventStreamsClient):
     Logs each emit call at DEBUG level instead of publishing to Kafka.
     """
 
-    def emit_job_started(self, job) -> None:
-        logger.info("job_id=%s [noop] emit_job_started", job.id)
+    def emit_job_started(self, job, metric_type: str) -> None:
+        logger.info("job_id=%s metric_type=%s [noop] emit_job_started", job.id, metric_type)
 
-    def emit_job_in_progress(self, job) -> None:
-        logger.info("job_id=%s [noop] emit_job_in_progress", job.id)
+    def emit_job_in_progress(self, job, metric_type: str) -> None:
+        logger.info("job_id=%s metric_type=%s [noop] emit_job_in_progress", job.id, metric_type)
 
-    def emit_job_ended(self, job) -> None:
-        logger.info("job_id=%s [noop] emit_job_ended", job.id)
+    def emit_job_completed(self, job, metric_type: str) -> None:
+        logger.info("job_id=%s metric_type=%s [noop] emit_job_completed", job.id, metric_type)

--- a/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
+++ b/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
@@ -20,6 +20,11 @@ from .task import SchedulerTask
 
 logger = logging.getLogger("scheduler.UpdateFleetsJobsStatuses")
 
+# Metric billed for the wall-clock time a Fleets job spends running. Every Fleets job
+# currently reports this single metric; deriving the metric type from
+# provider/function/size and compute profile is handled in a follow-up task.
+CLASSICAL_TIME_METRIC_TYPE = "classical_time"
+
 
 class UpdateFleetsJobsStatuses(SchedulerTask):
     """Update status of Fleets (Code Engine) jobs."""
@@ -81,8 +86,9 @@ class UpdateFleetsJobsStatuses(SchedulerTask):
             else:
                 # Job already RUNNING — emit in-progress before checking timeout.
                 # A job transitioning to terminal via stop_job_if_timeout in this same tick
-                # will produce both job_in_progress and job_ended events; consumers key on event_type.
-                self.event_streams_client.emit_job_in_progress(job)
+                # will produce both an in-progress and a completed event; consumers key on
+                # the job_started / job_completed flags.
+                self.event_streams_client.emit_job_in_progress(job, CLASSICAL_TIME_METRIC_TYPE)
 
             self.stop_job_if_timeout(job)
 
@@ -107,7 +113,7 @@ class UpdateFleetsJobsStatuses(SchedulerTask):
             job.status,
             new_status,
         )
-        self.event_streams_client.emit_job_ended(job)
+        self.event_streams_client.emit_job_completed(job, CLASSICAL_TIME_METRIC_TYPE)
         job.update_fields({"status": new_status, "sub_status": None, "env_vars": "{}"})
         JobEvent.objects.add_status_event(
             job_id=job.id,
@@ -126,9 +132,9 @@ class UpdateFleetsJobsStatuses(SchedulerTask):
             job.status,
             Job.RUNNING,
         )
-        self.event_streams_client.emit_job_started(job)
+        self.event_streams_client.emit_job_started(job, CLASSICAL_TIME_METRIC_TYPE)
         # running_started_at is set only on first transition; already-RUNNING jobs picked up
-        # after a scheduler restart will have running_started_at=None (usage_nanoseconds=0).
+        # after a scheduler restart will have running_started_at=None (metric_value=0).
         job.update_fields({"status": Job.RUNNING, "running_started_at": django_timezone.now()})
         JobEvent.objects.add_status_event(
             job_id=job.id,

--- a/gateway/tests/core/services/ibm_cloud/event_streams/test_event_streams_client.py
+++ b/gateway/tests/core/services/ibm_cloud/event_streams/test_event_streams_client.py
@@ -97,7 +97,7 @@ class TestKafkaEventStreamsClient:
                         client = KafkaEventStreamsClient()
                         mock_producer = mock_producer_cls.return_value
                         mock_producer.flush.return_value = 0
-                        client.emit_job_started(job)
+                        client.emit_job_started(job, "classical_time")
 
         call_kwargs = mock_producer.produce.call_args[1]
         published = json.loads(call_kwargs["value"])
@@ -105,14 +105,18 @@ class TestKafkaEventStreamsClient:
         assert published["type"] == "quantum.production.function-usage.v1"
         assert published["source"] == "qiskit-serverless/scheduler/fleets"
         assert published["subject"] == str(job.id)
-        assert published["data"]["event_type"] == "job_started"
-        assert published["data"]["usage_nanoseconds"] == 0
-        assert published["data"]["instance_crn"] == job.instance_crn
-        assert published["data"]["function_id"] == str(job.id)
+        assert published["data"] == {
+            "metric_type": "classical_time",
+            "metric_value": 0,
+            "instance_crn": job.instance_crn,
+            "resource_id": str(job.id),
+            "job_started": True,
+            "job_completed": False,
+        }
         assert call_kwargs["key"] == str(job.id).encode("utf-8")
         mock_producer.flush.assert_called_once()
 
-    def test_emit_job_in_progress_computes_usage_nanoseconds(self):
+    def test_emit_job_in_progress_computes_usage_milliseconds(self):
         started_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
         job = _make_job(running_started_at=started_at)
 
@@ -133,13 +137,15 @@ class TestKafkaEventStreamsClient:
                         client = KafkaEventStreamsClient()
                         mock_producer = mock_producer_cls.return_value
                         mock_producer.flush.return_value = 0
-                        client.emit_job_in_progress(job)
+                        client.emit_job_in_progress(job, "classical_time")
 
         published = json.loads(mock_producer.produce.call_args[1]["value"])
-        assert published["data"]["event_type"] == "job_in_progress"
-        assert published["data"]["usage_nanoseconds"] == 5_000_000_000
+        assert published["data"]["metric_type"] == "classical_time"
+        assert published["data"]["metric_value"] == 5_000
+        assert published["data"]["job_started"] is False
+        assert published["data"]["job_completed"] is False
 
-    def test_emit_job_ended_computes_usage_nanoseconds(self):
+    def test_emit_job_completed_computes_usage_milliseconds(self):
         started_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
         job = _make_job(running_started_at=started_at)
 
@@ -160,11 +166,13 @@ class TestKafkaEventStreamsClient:
                         client = KafkaEventStreamsClient()
                         mock_producer = mock_producer_cls.return_value
                         mock_producer.flush.return_value = 0
-                        client.emit_job_ended(job)
+                        client.emit_job_completed(job, "classical_time")
 
         published = json.loads(mock_producer.produce.call_args[1]["value"])
-        assert published["data"]["event_type"] == "job_ended"
-        assert published["data"]["usage_nanoseconds"] == 30_000_000_000
+        assert published["data"]["metric_type"] == "classical_time"
+        assert published["data"]["metric_value"] == 30_000
+        assert published["data"]["job_started"] is False
+        assert published["data"]["job_completed"] is True
 
     def test_emit_raises_when_flush_times_out(self):
         job = _make_job()
@@ -186,7 +194,7 @@ class TestKafkaEventStreamsClient:
                         mock_producer.flush.return_value = 1  # 1 message undelivered
 
                         with pytest.raises(RuntimeError, match="not delivered after flush timeout"):
-                            client.emit_job_started(job)
+                            client.emit_job_started(job, "classical_time")
 
     def test_emit_job_in_progress_returns_zero_usage_when_running_started_at_is_none(self):
         job = _make_job(running_started_at=None)
@@ -209,7 +217,7 @@ class TestKafkaEventStreamsClient:
                         client = KafkaEventStreamsClient()
                         mock_producer = mock_producer_cls.return_value
                         mock_producer.flush.return_value = 0
-                        client.emit_job_in_progress(job)
+                        client.emit_job_in_progress(job, "classical_time")
 
         published = json.loads(mock_producer.produce.call_args[1]["value"])
-        assert published["data"]["usage_nanoseconds"] == 0
+        assert published["data"]["metric_value"] == 0

--- a/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
+++ b/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
@@ -8,7 +8,7 @@ import pytest
 from core.model_managers.job_events import JobEventContext, JobEventOrigin
 from core.models import Job, Program
 from core.services.runners import RunnerError
-from scheduler.tasks.update_fleets_jobs_statuses import UpdateFleetsJobsStatuses
+from scheduler.tasks.update_fleets_jobs_statuses import CLASSICAL_TIME_METRIC_TYPE, UpdateFleetsJobsStatuses
 
 _MOD = "scheduler.tasks.update_fleets_jobs_statuses"
 
@@ -362,7 +362,7 @@ class TestEventStreamsIntegration:
         job = _make_fleets_job(status=Job.PENDING)
 
         call_order = []
-        task.event_streams_client.emit_job_started.side_effect = lambda j: call_order.append("publish")
+        task.event_streams_client.emit_job_started.side_effect = lambda j, m: call_order.append("publish")
         job.update_fields = MagicMock(side_effect=lambda f: call_order.append("db"))
 
         with patch(f"{_MOD}.JobEvent"):
@@ -370,7 +370,7 @@ class TestEventStreamsIntegration:
                 task.to_running(job)
 
         assert call_order == ["publish", "db"]
-        task.event_streams_client.emit_job_started.assert_called_once_with(job)
+        task.event_streams_client.emit_job_started.assert_called_once_with(job, CLASSICAL_TIME_METRIC_TYPE)
 
     def test_to_running_raises_if_publish_fails(self):
         task = _make_task()
@@ -384,23 +384,23 @@ class TestEventStreamsIntegration:
 
         job.update_fields.assert_not_called()
 
-    def test_to_terminal_emits_job_ended_before_db_update(self):
+    def test_to_terminal_emits_job_completed_before_db_update(self):
         task = _make_task()
         job = _make_fleets_job(status=Job.RUNNING)
 
         call_order = []
-        task.event_streams_client.emit_job_ended.side_effect = lambda j: call_order.append("publish")
+        task.event_streams_client.emit_job_completed.side_effect = lambda j, m: call_order.append("publish")
         job.update_fields = MagicMock(side_effect=lambda f: call_order.append("db"))
 
         with patch(f"{_MOD}.JobEvent"):
             task.to_terminal(job, Job.SUCCEEDED)
 
         assert call_order == ["publish", "db"]
-        task.event_streams_client.emit_job_ended.assert_called_once_with(job)
+        task.event_streams_client.emit_job_completed.assert_called_once_with(job, CLASSICAL_TIME_METRIC_TYPE)
 
     def test_to_terminal_raises_if_publish_fails(self):
         task = _make_task()
-        task.event_streams_client.emit_job_ended.side_effect = Exception("broker down")
+        task.event_streams_client.emit_job_completed.side_effect = Exception("broker down")
         job = _make_fleets_job(status=Job.RUNNING)
 
         with patch(f"{_MOD}.JobEvent"):
@@ -422,7 +422,7 @@ class TestEventStreamsIntegration:
         ):
             task.update_job_status(job)
 
-        task.event_streams_client.emit_job_in_progress.assert_called_once_with(job)
+        task.event_streams_client.emit_job_in_progress.assert_called_once_with(job, CLASSICAL_TIME_METRIC_TYPE)
 
     def test_run_publish_failure_skips_db_update_and_continues_other_jobs(self):
         task = _make_task()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

### Summary
The billing consumer bills **per metric**, but we were publishing usage events in a job-lifecycle shape with no notion of a metric — `event_type`, a raw `usage_nanoseconds` value and a `function_id`, none of which the consumer can resolve a billable metric against. This reshapes the payload so every message carries the metric and its value. Step-0 change that unblocks the consumer work on the billing side.

```diff
  "data": {
-     "event_type": "job_started",
-     "usage_nanoseconds": 5000000000,
+     "metric_type": "classical_time",
+     "metric_value": 5000,
      "instance_crn": "crn:v1:bluemix:public:quantum-computing:...",
-     "function_id": "0fa1...",
+     "resource_id": "0fa1...",
+     "job_started": true,
+     "job_completed": false
  }
```

- `metric_type` — *what* is billed. Passed in by the caller, since it derives from provider/function/size and compute profile.
- `metric_value` — *how much*, in **milliseconds** (how usage is measured today).
- `resource_id` — contract field name for the existing `function_id` value (the job id).
- `job_started` / `job_completed` — lifecycle boundaries as explicit booleans, so consumers don't parse the metric type. `job_started: true` only on the started event, `job_completed: true` only on the completed event.

CloudEvents envelope, topic (`quantum.{environment}.function-usage.v1`) and flush-and-raise delivery are unchanged.


### Details and comments
Three commits:

1. **Make event streams interface metric-aware** — `metric_type` param on the abstract interface and the no-op client; `emit_job_ended` → `emit_job_completed` to match the `function_job_*` vocabulary.
2. **Emit metric-oriented usage payload from Kafka client** — reshapes `_publish`; `_usage_ns` → `_usage_ms`. Client tests now assert the whole `data` dict, so an unexpected or missing field fails.
3. **Pass the billed metric type from the scheduler** — supplies the metric at the three lifecycle call sites via a `CLASSICAL_TIME_METRIC_TYPE = "classical_time"` constant.

| Helper | `metric_value` | `job_started` | `job_completed` |
| --- | --- | --- | --- |
| `emit_job_started` | `0` | `true` | `false` |
| `emit_job_in_progress` | elapsed ms | `false` | `false` |
| `emit_job_completed` | elapsed ms | `false` | `true` |


### Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a [release note](https://github.com/Qiskit/qiskit-serverless/blob/main/CONTRIBUTING.md#release-notes) for any user-facing change (new feature, bug fix, deprecation, or breaking change), or this PR has no user-facing changes.
