### PR TITLE
Update serverless version in docs and fix version-bump workflow

### DIFF
--- a/.github/workflows/update-component-versions.yaml
+++ b/.github/workflows/update-component-versions.yaml
@@ -65,6 +65,8 @@ jobs:
           sed -i "s/qiskit-serverless\/ray-node:${OLDNUM}/qiskit-serverless\/ray-node:${NEWNUM}/" docs/custom_images/custom_function/Sample-Dockerfile
           sed -i "s/FROM icr.io\/quantum-public\/qiskit-serverless\/ray-node:${OLDNUM}/FROM icr.io\/quantum-public\/qiskit-serverless\/ray-node:${NEWNUM}/" docs/custom_images/deploy_custom_image_function.rst
           sed -i "s/FROM icr.io\/quantum-public\/qiskit-serverless\/ray-node:${OLDNUM}/FROM icr.io\/quantum-public\/qiskit-serverless\/ray-node:${NEWNUM}/" docs/custom_images/custom_image_examples.rst
+          sed -i "s/custom-ray-node:${OLDNUM}-arm64/custom-ray-node:${NEWNUM}-arm64/g" docs/custom_images/run_on_apple_silicon.rst
+          sed -i "s/VERSION=${OLDNUM} docker compose/VERSION=${NEWNUM} docker compose/g" docs/custom_images/run_on_apple_silicon.rst
       - name: Update CITATION.cff
         shell: bash
         run: |

--- a/docs/custom_images/run_on_apple_silicon.rst
+++ b/docs/custom_images/run_on_apple_silicon.rst
@@ -29,7 +29,7 @@ the repository root:
 
    docker build --platform linux/arm64 \
      --target arm64 \
-     -t custom-ray-node:0.32.0-arm64 \
+     -t custom-ray-node:0.34.0-arm64 \
      -f ray-node/Dockerfile .
 
 .. note::
@@ -57,7 +57,7 @@ architecture is fine):
 .. code-block::
    :caption: Start the stack on Apple Silicon
 
-   VERSION=0.32.0 docker compose \
+   VERSION=0.34.0 docker compose \
      -f docker-compose.yaml \
      -f docker-compose.arm64.yaml \
      up
@@ -74,7 +74,7 @@ arm64 base instead of the published ``icr.io`` image:
 .. code-block::
    :caption: Sample-Dockerfile on the arm64 base
 
-   FROM custom-ray-node:0.32.0-arm64
+   FROM custom-ray-node:0.34.0-arm64
 
    USER 0
    WORKDIR /runner
@@ -92,7 +92,7 @@ file — keeping ``platform: linux/arm64``:
 .. code-block::
    :caption: Start the stack on Apple Silicon
 
-   VERSION=0.32.0 docker compose \
+   VERSION=0.34.0 docker compose \
      -f docker-compose.yaml \
      -f docker-compose.arm64.yaml \
      up


### PR DESCRIPTION
## Summary

- Updates `docs/custom_images/run_on_apple_silicon.rst`: four version references were still pointing to `0.32.0`, bumped to `0.34.0`
- Adds two missing `sed` patterns to the "Update docs" step in `.github/workflows/update-component-versions.yaml` so `run_on_apple_silicon.rst` stays in sync on future releases (`custom-ray-node:X-arm64` tag and `VERSION=X docker compose`)

## Test plan

- [x] Verify version strings in `run_on_apple_silicon.rst` read `0.34.0`
- [x] Trigger `update-component-versions` workflow manually with a test version and confirm `run_on_apple_silicon.rst` is updated in the resulting PR