### PR TITLE
w3id secret refactor

### DIFF
--- a/charts/qiskit-serverless/charts/gateway/values.yaml
+++ b/charts/qiskit-serverless/charts/gateway/values.yaml
@@ -105,7 +105,9 @@ secrets:
       name: name
       password: password
       email: email
-  w3idSso: ""
+  w3idSso:
+    name: ""
+    secretStoreName: qiskit-serverless
 
 image:
   repository: icr.io/quantum-public/qiskit-serverless/gateway

--- a/charts/qiskit-serverless/templates/w3id-sso-credentials.yaml
+++ b/charts/qiskit-serverless/templates/w3id-sso-credentials.yaml
@@ -6,20 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   data:
-  - secretKey: credentials
+  - secretKey: key_all
     remoteRef:
-      key: "{{ .Values.gateway.secrets.w3idSso }}"
+      key: "{{ .Values.gateway.secrets.w3idSso.name }}"
   secretStoreRef:
     kind: SecretStore
-    name: qiskit-serverless-secret-store
+    name: {{ .Values.gateway.secrets.w3idSso.secretStoreName }}
   target:
-    template:
-      engineVersion: v2
-      data:
-        client-id: >-
-          {{ printf "{{ (.credentials | fromJson).client_id }}" }}
-        client-secret: >-
-          {{ printf "{{ (.credentials | fromJson).client_secret }}" }}
     creationPolicy: Owner
     name: gateway-w3id-sso
 {{- end -}}

--- a/charts/qiskit-serverless/values.yaml
+++ b/charts/qiskit-serverless/values.yaml
@@ -93,6 +93,9 @@ gateway:
         name: name
         password: password
         email: email
+    w3idSso:
+      name: ""
+      secretStoreName: qiskit-serverless
 
 # ===================
 # Kuberay Operator


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

### Summary

This PR is a first step in a series of PR I'm planning to do to standardize our external secrets configuration. This one specifically introduces a minor refactor in the w3id secreto to ensure:
- The secret uses the `secret` field in the values in a structure way (`secrets.w3idSso.name` & `secrets.w3idSso.secretStoreName`)
- The secret store name is dynamic
- Sync the secret to be a key-value secret instead of an arbitrary-secret

This change doesn't require modifications in the internal repository (that's the reason I'm going to open one PR per template, so we can keep track of every change that we need to apply there).

### Checklist

- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a [release note](https://github.com/Qiskit/qiskit-serverless/blob/main/CONTRIBUTING.md#release-notes) for any user-facing change (new feature, bug fix, deprecation, or breaking change), or this PR has no user-facing changes.
