### PR TITLE
Helm kafka refactor

### DIFF
--- a/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
+++ b/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
@@ -524,7 +524,7 @@ spec:
               value: {{ .Values.application.eventStreams.enabled | default false | quote }}
             - name: ENVIRONMENT
               value: {{ .Values.application.eventStreams.environment | default "" | quote }}
-            {{- if .Values.secrets.kafka }}
+            {{- if .Values.application.eventStreams.enabled }}
             - name: EVENT_STREAMS_BOOTSTRAP_SERVERS
               valueFrom:
                 secretKeyRef:

--- a/charts/qiskit-serverless/charts/gateway/values.yaml
+++ b/charts/qiskit-serverless/charts/gateway/values.yaml
@@ -108,6 +108,9 @@ secrets:
   w3idSso:
     name: ""
     secretStoreName: qiskit-serverless
+  kafka:
+    name: ""
+    secretStoreName: qiskit-serverless
 
 image:
   repository: icr.io/quantum-public/qiskit-serverless/gateway

--- a/charts/qiskit-serverless/templates/kafka-credentials.yaml
+++ b/charts/qiskit-serverless/templates/kafka-credentials.yaml
@@ -9,10 +9,10 @@ spec:
   data:
   - secretKey: credentials
     remoteRef:
-      key: "{{ .Values.gateway.secrets.kafka }}"
+      key: "{{ .Values.gateway.secrets.kafka.name }}"
   secretStoreRef:
     kind: SecretStore
-    name: qiskit-serverless-secret-store
+    name: {{ .Values.gateway.secrets.kafka.secretStoreName }}
   target:
     template:
       engineVersion: v2

--- a/charts/qiskit-serverless/templates/kafka-credentials.yaml
+++ b/charts/qiskit-serverless/templates/kafka-credentials.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.gateway.kafkaCredentials.create -}}
+{{- if .Values.gateway.application.eventStreams.enabled -}}
+---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/charts/qiskit-serverless/values.yaml
+++ b/charts/qiskit-serverless/values.yaml
@@ -72,9 +72,6 @@ gateway:
   cos:
     claimName: gateway-claim
 
-  kafkaCredentials:
-    create: false
-
   secrets:
     secretKey:
       name: gateway-secret-key

--- a/charts/qiskit-serverless/values.yaml
+++ b/charts/qiskit-serverless/values.yaml
@@ -93,6 +93,9 @@ gateway:
     w3idSso:
       name: ""
       secretStoreName: qiskit-serverless
+    kafka:
+      name: ""
+      secretStoreName: qiskit-serverless
 
 # ===================
 # Kuberay Operator


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

### Summary

This PR is a follow-up from #2372 and the second PR in a series of refactor I'm planning to do in our helm configuration around secrets to try to leave them as more similar as possible. In this one we are focusing in the kafka secret configuration applying two main changes:
- `kafkaCredentials` was removed in favor of `eventStreams` so we only need to maintain one variable. For reference, `eventStreams` is just being used in our internal repository. I'm just syncing this change and improving the configuration.
- Similar to the previous PR in the other change we are making dynamic the secret store reference.

This PR will require the next changes in the internal repo:
- `kafkaCredentials` refactor
- `secrets.kafka` refactor

### Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a [release note](https://github.com/Qiskit/qiskit-serverless/blob/main/CONTRIBUTING.md#release-notes) for any user-facing change (new feature, bug fix, deprecation, or breaking change), or this PR has no user-facing changes.
