### PR TITLE
Arguments validations: release note for the feature

### DIFF
--- a/releasenotes/notes/0.34.0/arguments-validation-5b7701bd6f304c2f.yaml
+++ b/releasenotes/notes/0.34.0/arguments-validation-5b7701bd6f304c2f.yaml
@@ -1,0 +1,55 @@
+---
+features:
+  - |
+    Qiskit Functions can now declare the arguments they accept as a JSON Schema, and the gateway validates submitted
+    arguments against it before any compute is used. Previously a function given bad input failed mid-execution, after
+    the user had already waited through queue time and container startup.
+
+    Attach the schema when uploading a function through the ``arguments_schema`` field of ``QiskitFunction``::
+
+        function = QiskitFunction(
+            title="my-function",
+            entrypoint="main.py",
+            working_dir="./src",
+            arguments_schema={
+                "type": "object",
+                "required": ["shots"],
+                "properties": {"shots": {"type": "integer"}},
+            },
+        )
+        runnable = client.upload(function)
+
+    From then on, running that function with arguments that do not match the schema is rejected with a ``400`` before
+    the job is created, so no job is queued and no partial rows are left behind. The error names the offending field::
+
+        {"message": "'wrong-type' is not of type 'integer'", "path": ["shots"]}
+
+    The feature is opt-in and backwards compatible: functions without a schema are never validated.
+
+    Re-uploading a function without the field keeps the schema it already had, so a schema is removed by uploading an
+    empty one::
+
+        function.arguments_schema = {}
+        client.upload(function)
+  - |
+    New endpoint ``POST /api/v1/programs/validate_arguments/`` checks arguments against a function's schema without
+    submitting a run, so inputs can be verified before paying for a job. It resolves the function with the same
+    permission rules as ``/run`` and returns ``200 {"valid": true}`` or a ``400`` describing the problem.
+
+    From the client SDK::
+
+        runnable.validate_arguments({"shots": 1024})
+
+    Invalid arguments raise ``QiskitServerlessException``.
+  - |
+    Functions read back with ``client.function(...)`` or ``client.functions()`` now include ``arguments_schema``, so the
+    arguments a function expects can be inspected even by callers who did not upload it.
+upgrade:
+  - |
+    ``QiskitFunction.schema`` has been renamed to ``arguments_schema`` and its type changed from ``Optional[str]`` to
+    ``Optional[Dict[str, Any]]``. The old field was never read by the client nor sent to the gateway, so there is no
+    deprecation path. Pass a plain dict rather than a JSON string.
+  - |
+    The unused ``validate`` field has been removed from ``QiskitFunction``. It gated a client-side validation hook that
+    was never implemented and always reported success, so passing ``validate=False`` had no effect. Argument validation
+    now happens on the gateway against ``arguments_schema``.


### PR DESCRIPTION
### Summary
This is the release note for the arguments validation feature, split out into its own PR so @ElePT  and the team can review the wording on its own. Keeping it here means the review of the text does not block the code review, and it does not get buried under a diff of code and tests either.

### Details and comments
The feature lets a Qiskit Function declare a JSON Schema for the arguments it accepts, so the gateway can validate submitted arguments against it and reject a mismatch before creating a job. It spans three PRs: #2330, #2341 and #2348. This is the single note that covers all of it, which is why it mentions things that come from more than one PR rather than from just one.

What to look at: the wording, and in particular whether the `upgrade` entries describe the breaking changes clearly enough, since those are the ones users will actually have to act on.

Two behaviours in the note are worth a second opinion:

- A schema is removed by uploading an empty one (`{}`), because omitting the field on re-upload preserves the existing schema. The note says this, but please check that it reads unambiguously, since the two cases (omit vs empty dict) do different things.
- `QiskitFunction.schema` has been renamed to `arguments_schema`, and its type changes from a string to a dict. There is no deprecation path for the old field, I think it doesn't matter because the code use not used by anybody (it was useless)...
