### PR TITLE
Stop seeding Code Engine projects on startup

### DIFF
--- a/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
+++ b/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
@@ -294,9 +294,6 @@ spec:
               value: {{ .Values.ce.fleetsGatewayHost | quote }}
             - name: CE_DEFAULT_PROJECT_NAME
               value: {{ .Values.ce.defaultProjectName | quote }}
-            - name: CE_PROJECTS
-              value: {{ .Values.ce.projects | toJson | quote }}
-
             - name: CE_HMAC_SECRET_NAME
               value: {{ .Values.ce.hmacSecretName | quote }}
             - name: FLEETS_DEFAULT_IMAGE
@@ -505,9 +502,6 @@ spec:
               value: {{ .Values.ce.fleetsGatewayHost | quote }}
             - name: CE_DEFAULT_PROJECT_NAME
               value: {{ .Values.ce.defaultProjectName | quote }}
-            - name: CE_PROJECTS
-              value: {{ .Values.ce.projects | toJson | quote }}
-
             - name: CE_HMAC_SECRET_NAME
               value: {{ .Values.ce.hmacSecretName | quote }}
             - name: FLEETS_DEFAULT_IMAGE

--- a/gateway/entrypoint-gateway.sh
+++ b/gateway/entrypoint-gateway.sh
@@ -2,7 +2,6 @@
 
 python manage.py collectstatic --noinput
 python manage.py migrate_with_lock
-python manage.py sync_ce_project
 python manage.py createsuperuser --noinput
 
 exec "$@"

--- a/gateway/entrypoint-scheduler.sh
+++ b/gateway/entrypoint-scheduler.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 python manage.py migrate_with_lock
-python manage.py sync_ce_project
 
 exec python manage.py run_scheduler

--- a/gateway/tests/api/test_sync_ce_project.py
+++ b/gateway/tests/api/test_sync_ce_project.py
@@ -1,0 +1,55 @@
+"""Tests for the sync_ce_project management command."""
+
+import pytest
+from django.core.management import call_command
+
+from core.models import CodeEngineProject
+
+
+def _project(**overrides):
+    """Build a CE_PROJECTS entry with all keys sync_ce_project requires."""
+    data = {
+        "project_id": "ce-1",
+        "project_name": "qiskit-functions",
+        "region": "us-east",
+        "resource_group_id": "rg-1",
+        "subnet_pool_id": "subnet-1",
+        "pds_name_state": "pds-state",
+        "pds_name_users": "pds-users",
+        "pds_name_providers": "pds-providers",
+        "cos_instance_name": "cos-instance",
+        "cos_key_name": "cos-key",
+        "cos_bucket_task_store_name": "task-bucket",
+        "cos_bucket_user_data_name": "user-bucket",
+        "cos_bucket_provider_data_name": "provider-bucket",
+    }
+    data.update(overrides)
+    return data
+
+
+@pytest.mark.django_db
+class TestSyncCeProject:
+    """sync_ce_project upserts CodeEngineProject rows from settings.CE_PROJECTS."""
+
+    def test_creates_then_updates_in_place(self, settings):
+        """A second run with a changed field updates the same row (idempotent upsert)."""
+        settings.CE_PROJECTS = [_project(region="us-east")]
+        call_command("sync_ce_project")
+
+        assert CodeEngineProject.objects.count() == 1
+        project = CodeEngineProject.objects.get(project_id="ce-1")
+        assert project.region == "us-east"
+        assert project.active is True
+
+        settings.CE_PROJECTS = [_project(region="eu-de")]
+        call_command("sync_ce_project")
+
+        assert CodeEngineProject.objects.count() == 1
+        project.refresh_from_db()
+        assert project.region == "eu-de"
+
+    def test_empty_projects_is_noop(self, settings):
+        """Empty CE_PROJECTS makes no changes (never wipes existing rows)."""
+        settings.CE_PROJECTS = []
+        call_command("sync_ce_project")
+        assert CodeEngineProject.objects.count() == 0

--- a/releasenotes/notes/stop-seeding-ce-projects-on-startup-1f7e6b8681267812.yaml
+++ b/releasenotes/notes/stop-seeding-ce-projects-on-startup-1f7e6b8681267812.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    The gateway and scheduler no longer run ``sync_ce_project`` on startup. Code Engine
+    project rows are seeded on demand instead, so a fresh deployment must seed them before
+    Fleets jobs can be scheduled.


### PR DESCRIPTION
### Summary
Stop running sync_ce_project on gateway/scheduler startup; it is run on demand instead.

### Details and comments
Removes the boot call from both entrypoints and the now-unused CE_PROJECTS pod env. Adds a test.