### PR TITLE
PSQL secret refactor

### DIFF
--- a/charts/qiskit-serverless/charts/gateway/values.yaml
+++ b/charts/qiskit-serverless/charts/gateway/values.yaml
@@ -99,6 +99,9 @@ secrets:
       host: database-host
       port: database-port
       userName: user-name
+    createExternalSecret: false
+    secretRef: ""
+    secretStoreName: qiskit-serverless
   superuser:
     name: gateway-superuser
     key:

--- a/charts/qiskit-serverless/templates/secret-psql.yaml
+++ b/charts/qiskit-serverless/templates/secret-psql.yaml
@@ -9,4 +9,21 @@ stringData:
   {{ .Values.gateway.secrets.servicePsql.key.host }}: {{ .Values.gateway.secrets.servicePsql.value.host }}
   {{ .Values.gateway.secrets.servicePsql.key.port }}: {{ .Values.gateway.secrets.servicePsql.value.port | quote }}
   {{ .Values.gateway.secrets.servicePsql.key.userName }}: {{ .Values.gateway.secrets.servicePsql.value.userName }}
+{{- else if .Values.gateway.secrets.servicePsql.createExternalSecret }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.gateway.secrets.servicePsql.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  data:
+  - secretKey: key_all
+    remoteRef:
+      key: {{ .Values.gateway.secrets.servicePsql.secretRef }}
+  secretStoreRef:
+    kind: SecretStore
+    name: {{ .Values.gateway.secrets.servicePsql.secretStoreName }}
+  target:
+    creationPolicy: Owner
+    name: {{ .Values.gateway.secrets.servicePsql.name }}
 {{- end }}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

### Summary

This PR creates an external secret for PSQL services managed from secrets managers in the cloud.

Additional key `createExternalSecret`: this key is temporal and I'm going to remove it as soon as we can confirm everything is working as expected in all environments. 

- [x] This PR requires also a migration in the internal repository to use the correct keys

### Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a [release note](https://github.com/Qiskit/qiskit-serverless/blob/main/CONTRIBUTING.md#release-notes) for any user-facing change (new feature, bug fix, deprecation, or breaking change), or this PR has no user-facing changes.
