### PR TITLE
Arguments validation/fix: report an unusable stored schema instead of decoding it into the wrong type

### DIFF
--- a/client/qiskit_serverless/core/function.py
+++ b/client/qiskit_serverless/core/function.py
@@ -38,24 +38,53 @@ from qiskit_serverless.core.job import (
     Job,
     Configuration,
 )
+from qiskit_serverless.exception import QiskitServerlessException
 
 GenericType = Literal["GENERIC"]
 ApplicationType = Literal["APPLICATION"]
 CircuitType = Literal["CIRCUIT"]
 
 
-def _decode_fields(data: Dict[str, Any], field_names: set) -> Dict[str, Any]:
-    """Keep only known dataclass fields and decode the ones the gateway sends as text.
+def _decode_arguments_schema(raw_schema: Any) -> Optional[Union[Dict[str, Any], bool]]:
+    """Turn the text the gateway stores for ``arguments_schema`` back into a schema.
 
-    ``arguments_schema`` is stored server-side as text (defaulting to ``"{}"``), so a
-    function without a schema comes back as an empty object rather than null.
+    The column holds text (defaulting to ``"{}"``), so a function without a schema arrives as
+    an empty object rather than null, and both read back as ``None``. Sending ``{}`` is also how
+    a schema is removed, which works because the upload only omits the field when it is ``None``
+    rather than when it is falsy.
+
+    A boolean is a valid JSON Schema and is kept as one: ``False`` rejects every instance, so
+    reporting it as ``None`` would describe the strictest possible schema as no schema at all.
+    Anything else is not a schema the gateway would have accepted, so it is reported rather than
+    returned with a type the caller does not expect.
+
+    Raises:
+        QiskitServerlessException: if the stored value is not JSON, or is JSON but not an object
+            or a boolean.
     """
+    if isinstance(raw_schema, str):
+        if not raw_schema:
+            return None
+        try:
+            raw_schema = json.loads(raw_schema)
+        except json.JSONDecodeError as error:
+            raise QiskitServerlessException(f"The function arguments schema is not valid JSON: {error.msg}") from error
+
+    if raw_schema is None or raw_schema == {}:
+        return None
+    if isinstance(raw_schema, (dict, bool)):
+        return raw_schema
+    raise QiskitServerlessException(
+        "A function arguments schema must be an object or a boolean, "
+        f"not {type(raw_schema).__name__}: {raw_schema!r}"
+    )
+
+
+def _decode_fields(data: Dict[str, Any], field_names: set) -> Dict[str, Any]:
+    """Keep only known dataclass fields and decode the ones the gateway sends as text."""
     decoded = {k: v for k, v in data.items() if k in field_names}
     if "arguments_schema" in decoded:
-        raw_schema = decoded["arguments_schema"]
-        if isinstance(raw_schema, str):
-            raw_schema = json.loads(raw_schema) if raw_schema else None
-        decoded["arguments_schema"] = raw_schema or None
+        decoded["arguments_schema"] = _decode_arguments_schema(decoded["arguments_schema"])
     return decoded
 
 
@@ -73,7 +102,10 @@ class QiskitFunction:  # pylint: disable=too-many-instance-attributes
         working_dir: directory where entrypoint file is located (max size 50MB)
         description: description of a program
         version: version of a program
-        arguments_schema: JSON Schema dict describing valid arguments for this function
+        arguments_schema: JSON Schema describing valid arguments for this function. Normally an
+            object; ``True`` and ``False`` are also valid schemas, accepting and rejecting every
+            argument respectively. ``None`` means the function does not declare one, and setting
+            it to ``{}`` on an upload removes the schema an earlier upload stored.
     """
 
     GENERIC: ClassVar[GenericType] = "GENERIC"
@@ -92,7 +124,7 @@ class QiskitFunction:  # pylint: disable=too-many-instance-attributes
     raw_data: Optional[Dict[str, Any]] = None
     image: Optional[str] = None
     runner: str = "ray"
-    arguments_schema: Optional[Dict[str, Any]] = None
+    arguments_schema: Optional[Union[Dict[str, Any], bool]] = None
     type: Union[GenericType, ApplicationType, CircuitType] = GENERIC
 
     def __post_init__(self):

--- a/client/tests/core/test_serverless_client_functions.py
+++ b/client/tests/core/test_serverless_client_functions.py
@@ -673,3 +673,29 @@ class TestValidateArgumentsMethod:
 
         with pytest.raises(QiskitServerlessException):
             mock_client.validate_arguments(title="my-function", arguments={"shots": "wrong"})
+
+
+class TestArgumentsSchemaDecoding:
+    """Tests for how a stored arguments_schema is decoded when a function is read back."""
+
+    def test_boolean_schema_is_kept_instead_of_looking_absent(self):
+        """``false`` is the schema that rejects everything, so it must not read as "no schema"."""
+        function = QiskitFunction.from_json({"title": "t", "arguments_schema": "false"})
+
+        assert function.arguments_schema is False
+
+    def test_empty_object_still_means_no_schema(self):
+        """Regression lock: sending ``{}`` is how a schema is removed, and it reads back as None."""
+        function = QiskitFunction.from_json({"title": "t", "arguments_schema": "{}"})
+
+        assert function.arguments_schema is None
+
+    def test_schema_that_is_not_an_object_or_boolean_is_rejected(self):
+        """A JSON scalar is not a schema, so it must not leak through with the wrong type."""
+        with pytest.raises(QiskitServerlessException):
+            QiskitFunction.from_json({"title": "t", "arguments_schema": "123"})
+
+    def test_schema_that_is_not_json_is_rejected(self):
+        """A column value that is not JSON must raise the SDK exception, not a bare JSON error."""
+        with pytest.raises(QiskitServerlessException):
+            QiskitFunction.from_json({"title": "t", "arguments_schema": "not json at all"})

--- a/gateway/api/v1/views/programs/get_by_title.py
+++ b/gateway/api/v1/views/programs/get_by_title.py
@@ -76,6 +76,11 @@ def get_by_title(request: Request, title: str) -> Response:
     """Retrieve a single Qiskit Function by title."""
     user = cast(AbstractUser, request.user)
     accessible_functions = cast(FunctionAccessResult, request.auth.accessible_functions)
+    # Unlike the endpoints that take the title in the body, the "provider/title" form cannot arrive
+    # here: the route is <str:title>, whose converter is "[^/]+", and a percent-encoded slash is
+    # decoded before routing, so either spelling 404s before reaching this view. The provider always
+    # comes from the query parameter. The shared helper still handles both, which is what the other
+    # callers need, and it keeps the error identical if the route ever starts allowing a slash.
     function_title, provider_name = parse_title_and_provider(title, request.query_params.get("provider"))
     logger.info(
         "[programs-get-by-title] user_id=%s program=%s provider=%s accessible_functions=%s",

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -861,6 +861,28 @@ class TestProgramApi(APITestCase):
         assert response.status_code == status.HTTP_200_OK
         assert response.data.get("arguments_schema") == schema
 
+    def test_get_by_title_does_not_take_the_provider_in_the_path(self):
+        """Regression lock: the <str:title> route cannot carry a slash, so the provider is a query param.
+
+        The function used here IS retrievable as ``?provider=default``, so if the route ever started
+        accepting a slash (a <path:title> converter), these requests would resolve and return 200.
+        The 404 is therefore evidence that routing rejects both spellings before the view runs.
+        """
+        user = TestUtils.authorize_client(user="test_user_2", client=self.client)
+        TestUtils.create_program(program_title="Docker-Image-Program", author=user, provider="default")
+
+        reachable = self.client.get(
+            "/api/v1/programs/get_by_title/Docker-Image-Program/",
+            {"provider": "default"},
+            format="json",
+        )
+        literal_slash = self.client.get("/api/v1/programs/get_by_title/default/Docker-Image-Program/", format="json")
+        encoded_slash = self.client.get("/api/v1/programs/get_by_title/default%2FDocker-Image-Program/", format="json")
+
+        assert reachable.status_code == status.HTTP_200_OK
+        assert literal_slash.status_code == status.HTTP_404_NOT_FOUND
+        assert encoded_slash.status_code == status.HTTP_404_NOT_FOUND
+
     def test_get_jobs(self):
         """Tests run existing authorized."""
 


### PR DESCRIPTION
### Summary
Two small fixes from the argument validation work. A function's `arguments_schema` is stored as text in the database and nothing validates it, so reading a function back through the client SDK could hand the caller a value of the wrong type, or let a raw JSON error escape. Worse, `false`, the strictest possible schema, was reported as no schema at all. Now booleans round-trip correctly and anything else invalid raises `QiskitServerlessException`. This widens the declared type of `arguments_schema` to `Optional[Union[Dict[str, Any], bool]]`. The second change is a comment explaining a routing detail on the `get_by_title` endpoint.

### Details and comments
On the client, decoding used to treat a falsy schema as "no schema", which turned `false` into `None`. Other stored values that are not valid schemas (a bare number, string, or list) used to come back typed as that value instead of failing; they now raise `QiskitServerlessException`, matching the rule the gateway already applies at upload: a schema must be an object or a boolean. Sending `{}` on upload still removes a stored schema, and a column holding `{}` still reads back as `None`.

The other change adds a comment to `get_by_title`, recording why it reads the provider from a query parameter rather than the path: the route uses Django's `<str:title>` converter, which can't contain a slash, and a percent-encoded slash is decoded before routing, so both forms 404 before the view runs. The shared parsing helper still supports both forms because two other endpoints take the title from the request body, where a slash is meaningful, so the branch is not dead code even though it looks unreachable here.
