### PR TITLE
Propagate business_model in the license fee event

### DIFF
--- a/gateway/core/domain/business_models.py
+++ b/gateway/core/domain/business_models.py
@@ -7,3 +7,26 @@ class BusinessModel:  # pylint: disable=too-few-public-methods
     TRIAL = "TRIAL"
     SUBSIDIZED = "SUBSIDIZED"
     CONSUMPTION = "CONSUMPTION"
+
+
+# Business model names as the billing service expects them. Subsidized functions
+# are billed as licensed; the rest keep their own name, lowercased. Every
+# BusinessModel constant must appear here.
+BILLING_NAMES = {
+    BusinessModel.SUBSIDIZED: "licensed",
+    BusinessModel.TRIAL: "trial",
+    BusinessModel.CONSUMPTION: "consumption",
+}
+
+
+def billing_name_for(business_model: str) -> str:
+    """
+    Return the billing name for a business model.
+
+    Raises ValueError if the business model has no billing name, so a newly
+    added model cannot be silently billed under a guessed name.
+    """
+    try:
+        return BILLING_NAMES[business_model]
+    except KeyError:
+        raise ValueError(f"No billing name mapped for business model: {business_model!r}") from None

--- a/gateway/core/ibm_cloud/event_streams/kafka_event_streams_client.py
+++ b/gateway/core/ibm_cloud/event_streams/kafka_event_streams_client.py
@@ -21,6 +21,7 @@ import uuid
 from datetime import datetime, timezone
 
 from confluent_kafka import Producer
+from core.domain.business_models import BusinessModel
 from core.models import Job
 
 from .abstract_event_streams_client import EventStreamsClient
@@ -28,6 +29,14 @@ from .abstract_event_streams_client import EventStreamsClient
 logger = logging.getLogger("gateway.ibm_cloud.event_streams_client")
 
 LICENSE_FEE_METRIC_TYPE = "license"
+
+# Business model names as billing expects them. Subsidized functions are billed
+# as licensed; the rest keep their own name, lowercased.
+BUSINESS_MODEL_NAMES = {
+    BusinessModel.SUBSIDIZED: "licensed",
+    BusinessModel.TRIAL: "trial",
+    BusinessModel.CONSUMPTION: "consumption",
+}
 
 
 class KafkaEventStreamsClient(EventStreamsClient):
@@ -38,7 +47,8 @@ class KafkaEventStreamsClient(EventStreamsClient):
     single metric in its `data` payload: `metric_type` (what is being billed) and
     `metric_value` (how much, in milliseconds for time-based metrics), plus
     `job_started` / `job_completed` flags so consumers can detect lifecycle
-    boundaries without interpreting the metric type.
+    boundaries without interpreting the metric type. License fee events also
+    carry `business_model`.
 
     Configured from environment variables:
       EVENT_STREAMS_BOOTSTRAP_SERVERS — comma-separated broker list
@@ -94,7 +104,13 @@ class KafkaEventStreamsClient(EventStreamsClient):
             metric_value=1,
             job_started=True,
             job_completed=True,
+            business_model=self._business_model_name(job),
         )
+
+    @staticmethod
+    def _business_model_name(job: Job) -> str:
+        """Map the job's business model to the name billing expects."""
+        return BUSINESS_MODEL_NAMES.get(job.business_model, job.business_model.lower())
 
     def _usage_ms(self, job) -> int:
         if job.running_started_at is None:
@@ -110,8 +126,20 @@ class KafkaEventStreamsClient(EventStreamsClient):
         metric_value: int,
         job_started: bool,
         job_completed: bool,
+        business_model: str | None = None,
     ) -> None:
         now = datetime.now(timezone.utc)
+        data = {
+            "metric_type": metric_type,
+            "metric_value": metric_value,
+            "instance_crn": job.instance_crn,
+            "resource_id": str(job.id),
+            "job_started": job_started,
+            "job_completed": job_completed,
+        }
+        if business_model is not None:
+            data["business_model"] = business_model
+
         event = {
             "specversion": "1.0",
             "id": str(uuid.uuid4()),
@@ -120,14 +148,7 @@ class KafkaEventStreamsClient(EventStreamsClient):
             "time": now.isoformat(),
             "subject": str(job.id),
             "datacontenttype": "application/json",
-            "data": {
-                "metric_type": metric_type,
-                "metric_value": metric_value,
-                "instance_crn": job.instance_crn,
-                "resource_id": str(job.id),
-                "job_started": job_started,
-                "job_completed": job_completed,
-            },
+            "data": data,
         }
         self._producer.produce(
             topic=self.topic,

--- a/gateway/core/ibm_cloud/event_streams/kafka_event_streams_client.py
+++ b/gateway/core/ibm_cloud/event_streams/kafka_event_streams_client.py
@@ -21,7 +21,7 @@ import uuid
 from datetime import datetime, timezone
 
 from confluent_kafka import Producer
-from core.domain.business_models import BusinessModel
+from core.domain.business_models import billing_name_for
 from core.models import Job
 
 from .abstract_event_streams_client import EventStreamsClient
@@ -29,14 +29,6 @@ from .abstract_event_streams_client import EventStreamsClient
 logger = logging.getLogger("gateway.ibm_cloud.event_streams_client")
 
 LICENSE_FEE_METRIC_TYPE = "license"
-
-# Business model names as billing expects them. Subsidized functions are billed
-# as licensed; the rest keep their own name, lowercased.
-BUSINESS_MODEL_NAMES = {
-    BusinessModel.SUBSIDIZED: "licensed",
-    BusinessModel.TRIAL: "trial",
-    BusinessModel.CONSUMPTION: "consumption",
-}
 
 
 class KafkaEventStreamsClient(EventStreamsClient):
@@ -104,13 +96,8 @@ class KafkaEventStreamsClient(EventStreamsClient):
             metric_value=1,
             job_started=True,
             job_completed=True,
-            business_model=self._business_model_name(job),
+            business_model=billing_name_for(job.business_model),
         )
-
-    @staticmethod
-    def _business_model_name(job: Job) -> str:
-        """Map the job's business model to the name billing expects."""
-        return BUSINESS_MODEL_NAMES.get(job.business_model, job.business_model.lower())
 
     def _usage_ms(self, job) -> int:
         if job.running_started_at is None:

--- a/gateway/tests/core/domain/test_business_models.py
+++ b/gateway/tests/core/domain/test_business_models.py
@@ -1,0 +1,43 @@
+# This code is part of a Qiskit project.
+#
+# (C) IBM 2026
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Unit tests for business model billing names."""
+
+import pytest
+
+from core.domain.business_models import BusinessModel, billing_name_for
+
+
+@pytest.mark.parametrize(
+    "business_model,expected",
+    [
+        (BusinessModel.SUBSIDIZED, "licensed"),
+        (BusinessModel.TRIAL, "trial"),
+        (BusinessModel.CONSUMPTION, "consumption"),
+    ],
+)
+def test_billing_name_for_known_models(business_model, expected):
+    assert billing_name_for(business_model) == expected
+
+
+def test_billing_name_for_raises_on_unmapped_model():
+    with pytest.raises(ValueError, match="No billing name mapped"):
+        billing_name_for("BRAND_NEW_MODEL")
+
+
+def test_every_business_model_has_a_billing_name():
+    """A new BusinessModel constant must come with a billing name."""
+    models = [value for name, value in vars(BusinessModel).items() if not name.startswith("_")]
+
+    assert models
+    for business_model in models:
+        assert billing_name_for(business_model)

--- a/gateway/tests/core/services/ibm_cloud/event_streams/test_event_streams_client.py
+++ b/gateway/tests/core/services/ibm_cloud/event_streams/test_event_streams_client.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 import pytest
 from unittest.mock import MagicMock, patch
 
+from core.domain.business_models import BusinessModel
 from core.ibm_cloud.event_streams.kafka_event_streams_client import KafkaEventStreamsClient
 
 _CLIENT_MOD = "core.ibm_cloud.event_streams.kafka_event_streams_client"
@@ -30,11 +31,13 @@ def _make_job(
     job_id=None,
     instance_crn="crn:v1:bluemix:public:quantum-computing:us-east:a/abc:def::",
     running_started_at=None,
+    business_model=BusinessModel.SUBSIDIZED,
 ):
     job = MagicMock()
     job.id = job_id or uuid_module.uuid4()
     job.instance_crn = instance_crn
     job.running_started_at = running_started_at or datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    job.business_model = business_model
     return job
 
 
@@ -262,6 +265,66 @@ class TestKafkaEventStreamsClient:
             "resource_id": str(job.id),
             "job_started": True,
             "job_completed": True,
+            "business_model": "licensed",
         }
         assert call_kwargs["key"] == str(job.id).encode("utf-8")
         mock_producer.flush.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "business_model,expected",
+        [
+            (BusinessModel.SUBSIDIZED, "licensed"),
+            (BusinessModel.TRIAL, "trial"),
+            (BusinessModel.CONSUMPTION, "consumption"),
+        ],
+    )
+    def test_emit_license_fee_maps_business_model(self, business_model, expected):
+        job = _make_job(business_model=business_model)
+        job.program = MagicMock()
+        job.program.provider.name = "ibm"
+        job.program.title = "test-program"
+
+        with patch(f"{_CLIENT_MOD}.Producer") as mock_producer_cls:
+            with patch(f"{_CLIENT_MOD}.uuid"):
+                with patch(f"{_CLIENT_MOD}.datetime") as mock_dt:
+                    with patch.dict(
+                        os.environ,
+                        {
+                            "EVENT_STREAMS_BOOTSTRAP_SERVERS": "b:9093",
+                            "EVENT_STREAMS_API_KEY": "k",
+                            "ENVIRONMENT": "production",
+                        },
+                    ):
+                        mock_dt.now.return_value = datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc)
+
+                        client = KafkaEventStreamsClient()
+                        mock_producer = mock_producer_cls.return_value
+                        mock_producer.flush.return_value = 0
+                        client.emit_license_fee(job)
+
+        published = json.loads(mock_producer.produce.call_args[1]["value"])
+        assert published["data"]["business_model"] == expected
+
+    def test_business_model_absent_from_non_license_events(self):
+        job = _make_job()
+
+        with patch(f"{_CLIENT_MOD}.Producer") as mock_producer_cls:
+            with patch(f"{_CLIENT_MOD}.uuid"):
+                with patch(f"{_CLIENT_MOD}.datetime") as mock_dt:
+                    with patch.dict(
+                        os.environ,
+                        {
+                            "EVENT_STREAMS_BOOTSTRAP_SERVERS": "b:9093",
+                            "EVENT_STREAMS_API_KEY": "k",
+                            "ENVIRONMENT": "production",
+                        },
+                    ):
+                        mock_dt.now.return_value = datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc)
+
+                        client = KafkaEventStreamsClient()
+                        mock_producer = mock_producer_cls.return_value
+                        mock_producer.flush.return_value = 0
+                        client.emit_job_started(job, "classical_time")
+
+        published = json.loads(mock_producer.produce.call_args[1]["value"])
+        assert "business_model" not in published["data"]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

### Summary
The license fee event carried no indication of which business model the function is billed under, so the consumer could not tell a licensed function from a trial or consumption one. This reads `business_model` off the job and adds it to the license fee payload, mapped to the name billing expects: `SUBSIDIZED → licensed`, `TRIAL → trial`, `CONSUMPTION → consumption`.

```diff
  "data": {
      "metric_type": "license_ibm_test-program",
      "metric_value": 1,
      ...
+     "business_model": "licensed"
  }
```

License fee event only — the `classical_time` lifecycle events are byte-identical to before, so this is additive on the wire.


### Details and comments
All changes in `gateway/core/ibm_cloud/event_streams/kafka_event_streams_client.py`:

- `BUSINESS_MODEL_NAMES` — the mapping, keyed on the `BusinessModel` constants so a rename upstream surfaces here. `_business_model_name(job)` resolves through it, falling back to `job.business_model.lower()` for anything unmapped.
- `emit_license_fee` passes the resolved name into `_publish`, which gained an optional `business_model` kwarg; `data` is built as a local and the key inserted only when the argument is present. That is what keeps the other events unchanged.

No signature change to `emit_license_fee(job)`, so the abstract interface, no-op client and scheduler call sites are untouched.

Tests: `_make_job` takes a `business_model` (default `SUBSIDIZED`); the full-payload assertion now includes the key; a parametrized test covers all three mappings; and one test asserts the key is *absent* from a `job_started` payload, guarding the additive claim.

## Notes for reviewers

- **`TRIAL` and `CONSUMPTION` names are inferred** — only `SUBSIDIZED → licensed` was specified, the rest follow the lowercase convention. This new naming for subsidized was decided from the product side and we need to consolidate it across the platform


### Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a [release note](https://github.com/Qiskit/qiskit-serverless/blob/main/CONTRIBUTING.md#release-notes) for any user-facing change (new feature, bug fix, deprecation, or breaking change), or this PR has no user-facing changes.
