### PR TITLE
Use ibmCloudFidApiKey instead of ibmCloudApiKey

### DIFF
--- a/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
+++ b/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
@@ -282,7 +282,7 @@ spec:
               value: {{ .Values.application.limits.maxActiveJobsPerUser | quote }}
             - name: LOG_FORMAT
               value: {{ .Values.application.logFormat | quote }}
-            {{- if .Values.secrets.ibmCloudFidApiKey }}
+            {{- if .Values.application.ibmCloudFidApiKey.enabled }}
             - name: IBM_CLOUD_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -490,7 +490,7 @@ spec:
               value: {{ .Values.application.logsMaximumSize | quote }}
             - name: LOG_FORMAT
               value: {{ .Values.application.logFormat | quote }}
-            {{- if .Values.secrets.ibmCloudFidApiKey }}
+            {{- if .Values.application.ibmCloudFidApiKey.enabled }}
             - name: IBM_CLOUD_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
+++ b/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
@@ -282,12 +282,12 @@ spec:
               value: {{ .Values.application.limits.maxActiveJobsPerUser | quote }}
             - name: LOG_FORMAT
               value: {{ .Values.application.logFormat | quote }}
-            {{- if .Values.secrets.ibmCloudApiKey }}
+            {{- if .Values.secrets.ibmCloudFidApiKey }}
             - name: IBM_CLOUD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.secrets.ibmCloudApiKey.name }}
-                  key: {{ .Values.secrets.ibmCloudApiKey.key }}
+                  name: {{ .Values.secrets.ibmCloudFidApiKey.name }}
+                  key: {{ .Values.secrets.ibmCloudFidApiKey.key }}
             {{- end }}
             {{- if .Values.ce }}
             - name: FLEETS_GATEWAY_HOST
@@ -490,12 +490,12 @@ spec:
               value: {{ .Values.application.logsMaximumSize | quote }}
             - name: LOG_FORMAT
               value: {{ .Values.application.logFormat | quote }}
-            {{- if .Values.secrets.ibmCloudApiKey }}
+            {{- if .Values.secrets.ibmCloudFidApiKey }}
             - name: IBM_CLOUD_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.secrets.ibmCloudApiKey.name }}
-                  key: {{ .Values.secrets.ibmCloudApiKey.key }}
+                  name: {{ .Values.secrets.ibmCloudFidApiKey.name }}
+                  key: {{ .Values.secrets.ibmCloudFidApiKey.key }}
             {{- end }}
             {{- if .Values.ce }}
             - name: FLEETS_GATEWAY_HOST


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

### Summary

This PR sync some changes done due to the integration with the new external secret from #2395 , so now instead to use the old secret we will use the new one.

### Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a [release note](https://github.com/Qiskit/qiskit-serverless/blob/main/CONTRIBUTING.md#release-notes) for any user-facing change (new feature, bug fix, deprecation, or breaking change), or this PR has no user-facing changes.
