### PR TITLE
Arguments validation/backoffice: validate scheme on save job

### DIFF
--- a/gateway/api/admin.py
+++ b/gateway/api/admin.py
@@ -218,17 +218,20 @@ class ProgramAdmin(admin.ModelAdmin):
             readonly_fields.append("title")
         return readonly_fields
 
-    def render_change_form(self, request, context, add=False, change=False, form_url="", obj=None):
+    def render_change_form(self, request, context, *args, **kwargs):
         """Warn at the top of the page when the stored arguments_schema is unusable.
 
         The form has already worked out the reason, so this costs nothing extra. It only fires on a
         page being shown, since `stored_schema_error` stays None for a bound form.
+
+        The remaining arguments are passed straight through: Django's `_changeform_view` sends `add`,
+        `change`, `form_url` and `obj` by keyword, and none of them matter here.
         """
         stored_schema_error = getattr(context["adminform"].form, "stored_schema_error", None)
         if stored_schema_error:
             messages.warning(request, stored_schema_error)
 
-        return super().render_change_form(request, context, add=add, change=change, form_url=form_url, obj=obj)
+        return super().render_change_form(request, context, *args, **kwargs)
 
     def get_urls(self):
         """Add program history url to the available urls."""

--- a/gateway/api/admin.py
+++ b/gateway/api/admin.py
@@ -132,6 +132,25 @@ class ProgramAdminForm(forms.ModelForm):
         # class is declared. ProgramAdmin narrows this down to its fieldsets anyway.
         fields = "__all__"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.stored_schema_error = None
+        # Only when showing an existing row: a bound form is handling a submission, where the stored
+        # value is no longer what the page is about, and an unsaved instance has nothing stored yet.
+        if self.is_bound or not self.instance.pk:
+            return
+
+        self.stored_schema_error = _arguments_schema_error(self.instance.arguments_schema)
+        if self.stored_schema_error is None:
+            return
+
+        field = self.fields["arguments_schema"]
+        field.help_text = format_html(
+            '<span style="color: var(--error-fg);">{}</span>{}',
+            self.stored_schema_error,
+            f" {field.help_text}" if field.help_text else "",
+        )
+
     def clean_arguments_schema(self):
         """Check the schema, but only when this field is the one being changed.
 
@@ -198,6 +217,18 @@ class ProgramAdmin(admin.ModelAdmin):
         if obj:
             readonly_fields.append("title")
         return readonly_fields
+
+    def render_change_form(self, request, context, add=False, change=False, form_url="", obj=None):
+        """Warn at the top of the page when the stored arguments_schema is unusable.
+
+        The form has already worked out the reason, so this costs nothing extra. It only fires on a
+        page being shown, since `stored_schema_error` stays None for a bound form.
+        """
+        stored_schema_error = getattr(context["adminform"].form, "stored_schema_error", None)
+        if stored_schema_error:
+            messages.warning(request, stored_schema_error)
+
+        return super().render_change_form(request, context, add=add, change=change, form_url=form_url, obj=obj)
 
     def get_urls(self):
         """Add program history url to the available urls."""

--- a/gateway/api/admin.py
+++ b/gateway/api/admin.py
@@ -3,12 +3,19 @@
 import json
 import logging
 
-from django.contrib import admin
+from django import forms
+from django.contrib import admin, messages
 from django.db.models import Count, F, Q
 from django.utils.html import format_html
 from django.urls import path
 from django.shortcuts import render, get_object_or_404
 from django.contrib.admin.views.main import PAGE_VAR
+
+from api.domain.arguments_schema import (
+    MAX_SCHEMA_LENGTH,
+    UnsupportedSchemaError,
+    check_uploaded_schema_in_isolation,
+)
 from core.models import (
     CodeEngineProject,
     Config,
@@ -89,10 +96,65 @@ class ProviderAdmin(admin.ModelAdmin):
     filter_horizontal = ["admin_groups"]
 
 
+def _arguments_schema_error(value: str | None) -> str | None:
+    """Return why `value` is not a usable arguments schema, or None when it is.
+
+    The wording matches the upload endpoint's serializer on purpose, so a schema turned down here
+    and one turned down there read the same in the logs.
+    """
+    if not value:
+        # The column allows null and defaults to "{}", so a blank field means the function does not
+        # declare a schema. Django strips a form CharField, so spaces only arrive as "".
+        return None
+
+    if len(value) > MAX_SCHEMA_LENGTH:
+        return f"arguments_schema is {len(value)} characters long and the maximum is {MAX_SCHEMA_LENGTH}."
+
+    try:
+        check_uploaded_schema_in_isolation(value)
+    except UnsupportedSchemaError as exc:
+        return f"arguments_schema cannot be used: {exc}."
+
+    return None
+
+
+class ProgramAdminForm(forms.ModelForm):
+    """Program form that validates arguments_schema the way the upload endpoint does.
+
+    Without this, the admin was the only way left to store a schema the gateway cannot evaluate, and
+    a single bad row breaks `client.functions()` for everyone who can see that function, because the
+    SDK decodes the whole list at once.
+    """
+
+    class Meta:
+        model = Program
+        # A ModelForm has to name fields or exclude, or Django raises ImproperlyConfigured when the
+        # class is declared. ProgramAdmin narrows this down to its fieldsets anyway.
+        fields = "__all__"
+
+    def clean_arguments_schema(self):
+        """Check the schema, but only when this field is the one being changed.
+
+        A function whose stored schema is already broken still has to be editable: disabling it is
+        exactly what you want to be able to do quickly, and validating on every save would stand in
+        the way.
+        """
+        value = self.cleaned_data["arguments_schema"]
+        if "arguments_schema" not in self.changed_data:
+            return value
+
+        error = _arguments_schema_error(value)
+        if error is not None:
+            raise forms.ValidationError(error)
+
+        return value
+
+
 @admin.register(Program)
 class ProgramAdmin(admin.ModelAdmin):
     """ProgramAdmin."""
 
+    form = ProgramAdminForm
     search_fields = ["title", "author__username"]
     list_filter = ["provider", "type", "runner", "disabled"]
     filter_horizontal = ["instances", "trial_instances"]

--- a/gateway/tests/test_program_admin.py
+++ b/gateway/tests/test_program_admin.py
@@ -7,6 +7,7 @@ from django.test.client import RequestFactory
 from django.urls import reverse
 
 from api.admin import ProgramAdmin
+from api.domain.arguments_schema import MAX_SCHEMA_LENGTH
 from core.models import Program, Provider
 
 
@@ -95,6 +96,34 @@ def test_admin_lets_you_edit_a_function_whose_stored_schema_is_broken():
 
 
 @pytest.mark.django_db
+def test_admin_lets_you_clear_the_schema():
+    """Emptying the field is how a schema is removed, so it must not be sent to the validator."""
+    program = _program(arguments_schema='{"type": "object"}')
+    form_class = ProgramAdmin(Program, AdminSite()).get_form(RequestFactory().get("/"), obj=program)
+
+    form = form_class(data={"arguments_schema": ""}, instance=program)
+
+    form.is_valid()
+    assert "arguments_schema" in form.changed_data
+    assert "arguments_schema" not in form.errors
+
+
+@pytest.mark.django_db
+def test_admin_rejects_an_oversized_schema_without_forking():
+    """The length limit comes first, so a huge document never reaches the isolation."""
+    program = _program(arguments_schema="{}")
+    form_class = ProgramAdmin(Program, AdminSite()).get_form(RequestFactory().get("/"), obj=program)
+    oversized = '{"description": "' + "x" * (MAX_SCHEMA_LENGTH + 1) + '"}'
+
+    form = form_class(data={"arguments_schema": oversized}, instance=program)
+
+    assert not form.is_valid()
+    assert form.errors["arguments_schema"] == [
+        f"arguments_schema is {len(oversized)} characters long and the maximum is {MAX_SCHEMA_LENGTH}."
+    ]
+
+
+@pytest.mark.django_db
 def test_opening_a_function_with_a_broken_schema_shows_the_reason():
     """A row that is already broken should stop being invisible."""
     program = _program(arguments_schema="not json at all")
@@ -104,6 +133,18 @@ def test_opening_a_function_with_a_broken_schema_shows_the_reason():
 
     assert form.stored_schema_error == "arguments_schema cannot be used: it must be valid JSON."
     assert "it must be valid JSON" in form.fields["arguments_schema"].help_text
+
+
+@pytest.mark.django_db
+def test_opening_a_function_with_a_good_schema_says_nothing():
+    """The everyday case must stay quiet, with no warning and nothing added to the field."""
+    program = _program(arguments_schema='{"type": "object"}')
+    form_class = ProgramAdmin(Program, AdminSite()).get_form(RequestFactory().get("/"), obj=program)
+
+    form = form_class(instance=program)
+
+    assert form.stored_schema_error is None
+    assert form.fields["arguments_schema"].help_text == ""
 
 
 @pytest.mark.django_db

--- a/gateway/tests/test_program_admin.py
+++ b/gateway/tests/test_program_admin.py
@@ -4,6 +4,7 @@ import pytest
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from api.admin import ProgramAdmin
 from core.models import Program, Provider
@@ -91,3 +92,49 @@ def test_admin_lets_you_edit_a_function_whose_stored_schema_is_broken():
     form.is_valid()
     assert "arguments_schema" not in form.changed_data
     assert "arguments_schema" not in form.errors
+
+
+@pytest.mark.django_db
+def test_opening_a_function_with_a_broken_schema_shows_the_reason():
+    """A row that is already broken should stop being invisible."""
+    program = _program(arguments_schema="not json at all")
+    form_class = ProgramAdmin(Program, AdminSite()).get_form(RequestFactory().get("/"), obj=program)
+
+    form = form_class(instance=program)
+
+    assert form.stored_schema_error == "arguments_schema cannot be used: it must be valid JSON."
+    assert "it must be valid JSON" in form.fields["arguments_schema"].help_text
+
+
+@pytest.mark.django_db
+def test_the_stored_schema_is_not_checked_while_handling_a_submission():
+    """One fork per page opened, none per save.
+
+    Skipping this on a bound form also avoids a confusing message: after fixing the schema and
+    hitting another validation error, the warning would still be describing the old value.
+    """
+    program = _program(arguments_schema="not json at all")
+    form_class = ProgramAdmin(Program, AdminSite()).get_form(RequestFactory().get("/"), obj=program)
+
+    form = form_class(data={"arguments_schema": '{"type": "object"}'}, instance=program)
+
+    assert form.stored_schema_error is None
+
+
+@pytest.mark.django_db
+def test_the_change_page_warns_about_a_broken_stored_schema(client):
+    """Exercise the real page, which is the only thing that proves the warning is rendered.
+
+    The form attribute alone would not catch a `render_change_form` that never runs or a template
+    with nowhere to put the message.
+    """
+    program = _program(arguments_schema="not json at all")
+    client.force_login(User.objects.create_superuser(username="admin", password="x", email="a@b.c"))
+
+    response = client.get(reverse("admin:api_program_change", args=[program.pk]))
+
+    assert response.status_code == 200
+    # Read the messages themselves, not the page text: the reason also reaches the HTML through the
+    # field's help_text, so looking for it in the body would pass with no warning at all.
+    warnings = [str(message) for message in response.context["messages"] if message.level_tag == "warning"]
+    assert warnings == ["arguments_schema cannot be used: it must be valid JSON."]

--- a/gateway/tests/test_program_admin.py
+++ b/gateway/tests/test_program_admin.py
@@ -9,6 +9,16 @@ from api.admin import ProgramAdmin
 from core.models import Program, Provider
 
 
+def _program(arguments_schema: str) -> Program:
+    """Store a Program carrying `arguments_schema`, straight through the ORM so nothing validates it.
+
+    Fixed names are fine: every test runs in its own transaction, so there is nothing to collide with.
+    """
+    user = User.objects.create_user(username="u", password="x")
+    provider = Provider.objects.create(name="P")
+    return Program.objects.create(title="t", author=user, provider=provider, arguments_schema=arguments_schema)
+
+
 @pytest.mark.django_db
 def test_title_editable_on_add_and_readonly_on_change():
     """`title` must be present and editable when creating a program, and
@@ -24,3 +34,60 @@ def test_title_editable_on_add_and_readonly_on_change():
     provider = Provider.objects.create(name="P")
     program = Program.objects.create(title="t", author=user, provider=provider)
     assert "title" in admin.get_readonly_fields(request, obj=program)
+
+
+@pytest.mark.django_db
+def test_admin_rejects_a_schema_that_is_not_json():
+    """The value that breaks client.functions() for everyone must not be storable."""
+    program = _program(arguments_schema="{}")
+    form_class = ProgramAdmin(Program, AdminSite()).get_form(RequestFactory().get("/"), obj=program)
+
+    form = form_class(data={"arguments_schema": "not json at all"}, instance=program)
+
+    assert not form.is_valid()
+    assert form.errors["arguments_schema"] == ["arguments_schema cannot be used: it must be valid JSON."]
+
+
+@pytest.mark.django_db
+def test_admin_rejects_a_schema_that_only_fails_when_evaluated():
+    """`{"$ref": "#"}` is valid JSON and a valid JSON Schema; it recurses without end when used.
+
+    Asserting the message, and not just that the form is invalid, is what tells a rejection by our
+    own validation apart from a failure for any other reason.
+    """
+    program = _program(arguments_schema="{}")
+    form_class = ProgramAdmin(Program, AdminSite()).get_form(RequestFactory().get("/"), obj=program)
+
+    form = form_class(data={"arguments_schema": '{"$ref": "#"}'}, instance=program)
+
+    assert not form.is_valid()
+    assert form.errors["arguments_schema"][0].startswith("arguments_schema cannot be used:")
+
+
+@pytest.mark.django_db
+def test_admin_accepts_a_valid_schema():
+    """The happy path: a usable schema raises no complaint about the field."""
+    program = _program(arguments_schema="{}")
+    form_class = ProgramAdmin(Program, AdminSite()).get_form(RequestFactory().get("/"), obj=program)
+
+    form = form_class(data={"arguments_schema": '{"type": "object"}'}, instance=program)
+
+    form.is_valid()
+    assert "arguments_schema" not in form.errors
+
+
+@pytest.mark.django_db
+def test_admin_lets_you_edit_a_function_whose_stored_schema_is_broken():
+    """Disabling a broken function must not be blocked by the schema it already has.
+
+    The schema is only checked when the field itself changes, so sending back the same stored value
+    leaves it out of `changed_data` and out of the errors.
+    """
+    program = _program(arguments_schema="not json at all")
+    form_class = ProgramAdmin(Program, AdminSite()).get_form(RequestFactory().get("/"), obj=program)
+
+    form = form_class(data={"arguments_schema": "not json at all", "disabled": "on"}, instance=program)
+
+    form.is_valid()
+    assert "arguments_schema" not in form.changed_data
+    assert "arguments_schema" not in form.errors

--- a/specs/ARGUMENTS_VALIDATION.md
+++ b/specs/ARGUMENTS_VALIDATION.md
@@ -83,6 +83,23 @@ table. Both cases were false rejections of legitimate schemas before, refused at
 the reference and enforced the subschema it names. Stepping aside costs a false accept at worst, and the trial
 validation and `jsonschema`'s own `Unresolvable` at run time both still apply.
 
+### The Django admin applies the same check
+
+`ProgramAdminForm` (`gateway/api/admin.py`) runs `_arguments_schema_error`, which applies the same length limit and
+makes the same `check_uploaded_schema_in_isolation` call the upload serializer does, so both ways into the column
+accept exactly the same documents. Before this, the admin was the only way left to store a schema the gateway cannot
+evaluate, and one bad row breaks `client.functions()` for everyone who can see that function, because the SDK decodes
+the whole list at once.
+
+The admin differs from the upload in two ways, both on purpose. The check only runs when `arguments_schema` is among
+the changed fields, so a function whose stored schema is already broken stays editable and can still be turned off in
+a hurry. And a blank value is read as "no schema" instead of being handed to the validator, which is what the column
+means by its `{}` default.
+
+Opening a function whose stored schema does not work shows the reason twice, under the field and as a warning on the
+page, which is what turns an already broken row from invisible into visible. That check runs once per page shown and
+never while a submission is being handled.
+
 ### Re-upload preserves the schema
 
 `UploadFunctionUseCase._update` only writes `arguments_schema` when the field is present in the request, using `None`


### PR DESCRIPTION
### Summary

An unusable `arguments_schema` stored through the Django admin makes every later run of that function fail, and makes `client.functions()` raise for everyone who can see it. The upload endpoint already turns those schemas down. The admin did not, and now it does.

### Details and comments

Opening a function whose stored schema is broken shows a warning, but still lets you save. Whoever is editing is usually not the person who put the bad schema there, and turning a broken function off has to stay possible.

Changing the schema field is a different matter. That gets validated on save, so a bad schema cannot be stored in the first place.

It is the same check the upload endpoint makes, so the admin doubles as a place to try a schema out without packaging and uploading a function. It is not a dry run though: a schema that passes gets saved.
