### PR TITLE
Return 404 instead of 500 when retrieving an unknown job

### DIFF
--- a/gateway/api/use_cases/jobs/retrieve.py
+++ b/gateway/api/use_cases/jobs/retrieve.py
@@ -37,8 +37,9 @@ class JobRetrieveUseCase:
         Returns:
             Job: job found
         """
-        job = Job.objects.get(id=job_id)
-        if job is None:
+        try:
+            job = Job.objects.get(id=job_id)
+        except ObjectDoesNotExist:
             raise JobNotFoundException(str(job_id))
 
         if not JobAccessPolicies.can_access(user, job, accessible_functions=accessible_functions):

--- a/gateway/tests/api/test_job.py
+++ b/gateway/tests/api/test_job.py
@@ -1010,6 +1010,13 @@ class TestRetrieveJob:
         wrong_result_storage = RayResultStorage(wrong_job)
         assert wrong_result_storage.get() is None
 
+    def test_unknown_job_returns_404(self, authorize):
+        """A job id that does not exist returns 404, not 500."""
+        client = authorize("test_user")
+
+        response = client.get(reverse("v1:retrieve", args=["c5664e24-b1d8-4b55-8b09-7e7859414205"]), format="json")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
     class TestLegacyGroups:
         def test_provider_admin_can_retrieve(self, authorize):
             """Provider admin (via Django groups) can retrieve a provider job they don't own."""

--- a/gateway/tests/api/use_cases/jobs/test_retrieve.py
+++ b/gateway/tests/api/use_cases/jobs/test_retrieve.py
@@ -62,7 +62,7 @@ class TestJobRetrieveUseCase:
     def test_not_found_raises_exception(self, author):
         """Non-existent job ID raises JobNotFoundException."""
 
-        with pytest.raises(Job.DoesNotExist):
+        with pytest.raises(JobNotFoundException):
             JobRetrieveUseCase().execute(uuid.uuid4(), author, with_result=False)
 
     class TestLegacyGroups:

--- a/releasenotes/notes/fix-job-retrieve-unknown-id-7c1d3b5e9a204f68.yaml
+++ b/releasenotes/notes/fix-job-retrieve-unknown-id-7c1d3b5e9a204f68.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Requesting a job that does not exist through ``GET /api/v1/jobs/{job_id}/``
+    now returns HTTP 404 with a ``Job [job_id] not found`` message instead of
+    HTTP 500. The lookup relied on a ``None`` check that the Django ORM never
+    triggers, so ``Job.DoesNotExist`` escaped as an unexpected error.


### PR DESCRIPTION
### Summary

Retrieving a job whose id does not exist returned HTTP 500 instead of HTTP 404. We hit this in production: a `GET /api/v1/jobs/{job_id}/` for an unknown id logged `Internal Server Error` and the caller got a 500 with no useful message.

The cause is in `JobRetrieveUseCase`, which checked the lookup result for `None`:

```python
job = Job.objects.get(id=job_id)
if job is None:
    raise JobNotFoundException(str(job_id))
```

The Django ORM never returns `None` from `get()`, it raises `Job.DoesNotExist`. That exception escaped the use case and was caught by the catch-all branch of `api/v1/exception_handler.py`, which turns anything unexpected into a 500. Now the lookup catches `ObjectDoesNotExist` and raises `JobNotFoundException`, which the same handler maps to 404 with a `Job [job_id] not found` message.

### Details and comments

This is a leftover from PR #1960, which swapped `JobsRepository.get_job_by_id()` (that one did return `None`) for `Job.objects.get()`. Every other job use case picked up the `try`/`except ObjectDoesNotExist` in that same PR, `retrieve` was the only one left behind, and it kept the now dead `None` check. The unused `ObjectDoesNotExist` import already sitting at the top of the file was the giveaway.

Note that a genuine permission problem already returns 404 on purpose (`can_access` failing raises the same `JobNotFoundException`), so we do not leak whether a job the caller cannot see exists. This change makes the missing job case behave the same way.

Two tests cover it. A new endpoint test asserts that an unknown job id gets a 404, and the existing unit test `test_not_found_raises_exception` now expects `JobNotFoundException` rather than `Job.DoesNotExist`, which is what its docstring claimed all along. Both fail against the old code, the endpoint one with `assert 500 == 404`.
