### PR TITLE
Fix tox env names in the testing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,7 +236,10 @@ git rebase main issue-1234-new-feature
 ### Adding tests
 
 Our team upholds the philosophy that a healthy codebase will include the proper amount of testing.
-From the project you are working on, you can run tests with `tox -epy311`.
+From the project you are working on, you can run tests with tox, using the environment that the project declares in
+its `tox.ini`: `tox -epy312` in `gateway/` and `tests/`, and any of `tox -epy310` up to `tox -epy313` in `client/`.
+Beware that asking for an environment a project does not declare, such as `tox -epy311` in `gateway/`, installs the
+dependencies, runs no test at all and still reports success.
 Note if you run this command from qiskit-serverless top directory, it will build the project documentation.
 For detailed testing guidelines using tox environments, please refer to [this documentation](./client/tests/README.md).
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -13,8 +13,8 @@ docker build -t qiskit/qiskit-serverless/gateway:<VERSION> .
 ### Running Tests
 
 ```shell
-tox -e py311 # Run all tests using tox (recommended)
-tox -e py311 -- tests/api/test_job.py # Run specific test file
+tox -e py312 # Run all tests using tox (recommended)
+tox -e py312 -- tests/api/test_job.py # Run specific test file
 tox -e coverage # Run with coverage
 
 # You can run tests directly with pytest (but you have to take care of the venv and deps)


### PR DESCRIPTION
### Summary

The testing docs point at tox environments that no longer exist. `CONTRIBUTING.md` and `gateway/README.md` tell you to run the gateway tests with `tox -epy311`, but `gateway/tox.ini` only declares `py312` (which is what CI runs, and what `gateway/pyproject.toml` requires).

The reason this is worth fixing rather than shrugging at: asking tox for an undeclared env does not fail. It falls back to the base `[testenv]`, which has no `commands`, so tox installs every dependency, runs zero tests, prints `py311: OK` and `congratulations :)`, and exits 0. Someone following the docs believes the suite passed when nothing ran.

### Details and comments

`CONTRIBUTING.md` now names the env per project instead of a single global one, because they differ: `gateway/` and `tests/` declare `py312`, while `client/` declares `py310` through `py313`. It also warns about the silent no-op above.

`gateway/README.md` just moves from `py311` to `py312`.

No change to `client/tests/README.md`, where `tox -epy311` is still a valid example for the client.
