### PR TITLE
Look up jobs with filter().first() instead of catching DoesNotExist

### DIFF
--- a/gateway/api/use_cases/jobs/associate_runtime_jobs.py
+++ b/gateway/api/use_cases/jobs/associate_runtime_jobs.py
@@ -4,7 +4,6 @@ import logging
 from uuid import UUID
 
 from django.contrib.auth.models import AbstractUser
-from django.core.exceptions import ObjectDoesNotExist
 
 from api.access_policies.jobs import JobAccessPolicies
 from api.domain.exceptions.job_not_found_exception import JobNotFoundException
@@ -32,9 +31,8 @@ class AssociateRuntimeJobsUseCase:
         Raises:
             NotFoundError: If the job does not exist or access is denied.
         """
-        try:
-            job = Job.objects.get(id=job_id)
-        except ObjectDoesNotExist:
+        job = Job.objects.filter(id=job_id).first()
+        if job is None:
             raise JobNotFoundException(job_id)
 
         if not JobAccessPolicies.can_manage_runtime_jobs(user, job):

--- a/gateway/api/use_cases/jobs/create_event.py
+++ b/gateway/api/use_cases/jobs/create_event.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 import logging
-from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth.models import AbstractUser
 from api.domain.exceptions.invalid_access_exception import InvalidAccessException
 from api.domain.exceptions.job_not_found_exception import JobNotFoundException
@@ -47,9 +46,8 @@ class CreateJobEventUseCase:
             JobNotFoundException: If the job does not exist or the user is not allowed to create events.
             InvalidAccessException: If the job is not in RUNNING status.
         """
-        try:
-            job = Job.objects.get(id=job_id)
-        except ObjectDoesNotExist:
+        job = Job.objects.filter(id=job_id).first()
+        if job is None:
             raise JobNotFoundException(str(job_id))
 
         can_create_events = JobAccessPolicies.can_create_events(user, job)

--- a/gateway/api/use_cases/jobs/get_logs.py
+++ b/gateway/api/use_cases/jobs/get_logs.py
@@ -6,7 +6,6 @@ import logging
 from uuid import UUID
 
 from django.contrib.auth.models import AbstractUser
-from django.core.exceptions import ObjectDoesNotExist
 
 from api.access_policies.jobs import JobAccessPolicies
 from api.domain.exceptions.job_not_found_exception import JobNotFoundException
@@ -30,9 +29,8 @@ class GetJobLogsUseCase:
             GetLogsResponse() with both fields None (Fleet, no logs yet),
             or GetLogsResponse with raw_log set (Ray).
         """
-        try:
-            job = Job.objects.get(id=job_id)
-        except ObjectDoesNotExist:
+        job = Job.objects.filter(id=job_id).first()
+        if job is None:
             raise JobNotFoundException(job_id)
 
         if not JobAccessPolicies.can_read_user_logs(user, job):

--- a/gateway/api/use_cases/jobs/get_result.py
+++ b/gateway/api/use_cases/jobs/get_result.py
@@ -5,7 +5,6 @@ from typing import cast
 from uuid import UUID
 
 from django.contrib.auth.models import AbstractUser
-from django.core.exceptions import ObjectDoesNotExist
 
 from api.access_policies.jobs import JobAccessPolicies
 from api.domain.exceptions.job_not_found_exception import JobNotFoundException
@@ -28,9 +27,8 @@ class GetJobResultUseCase:
             GetResultResponse(result_ready=False) (Fleet, no result yet),
             or GetResultResponse with raw_result set (Ray).
         """
-        try:
-            job = Job.objects.get(id=job_id)
-        except ObjectDoesNotExist:
+        job = Job.objects.filter(id=job_id).first()
+        if job is None:
             raise JobNotFoundException(job_id)
 
         if not JobAccessPolicies.can_read_result(user, job):

--- a/gateway/api/use_cases/jobs/get_runtime_jobs.py
+++ b/gateway/api/use_cases/jobs/get_runtime_jobs.py
@@ -4,7 +4,6 @@ import logging
 from uuid import UUID
 
 from django.contrib.auth.models import AbstractUser
-from django.core.exceptions import ObjectDoesNotExist
 
 from api.access_policies.jobs import JobAccessPolicies
 from api.domain.exceptions.job_not_found_exception import JobNotFoundException
@@ -30,9 +29,8 @@ class GetRuntimeJobsUseCase:
         Raises:
             NotFoundError: If the job does not exist or access is denied.
         """
-        try:
-            job = Job.objects.get(id=job_id)
-        except ObjectDoesNotExist:
+        job = Job.objects.filter(id=job_id).first()
+        if job is None:
             raise JobNotFoundException(job_id)
 
         if not JobAccessPolicies.can_manage_runtime_jobs(user, job):

--- a/gateway/api/use_cases/jobs/list_events.py
+++ b/gateway/api/use_cases/jobs/list_events.py
@@ -5,7 +5,6 @@ Use case for retrieving job events.
 from typing import List
 from uuid import UUID
 
-from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth.models import AbstractUser
 
 from api.access_policies.jobs import JobAccessPolicies
@@ -28,9 +27,8 @@ class ListJobEventsUseCase:
         Returns:
             list[Job]: (jobs, total_count)
         """
-        try:
-            job = Job.objects.get(id=job_id)
-        except ObjectDoesNotExist:
+        job = Job.objects.filter(id=job_id).first()
+        if job is None:
             raise JobNotFoundException(str(job_id))
 
         if not JobAccessPolicies.can_read_events(user, job):

--- a/gateway/api/use_cases/jobs/provider_logs.py
+++ b/gateway/api/use_cases/jobs/provider_logs.py
@@ -7,7 +7,6 @@ from typing import Optional
 from uuid import UUID
 
 from django.contrib.auth.models import AbstractUser
-from django.core.exceptions import ObjectDoesNotExist
 
 from api.access_policies.jobs import JobAccessPolicies
 from api.domain.exceptions.job_not_found_exception import JobNotFoundException
@@ -37,9 +36,8 @@ class GetProviderJobLogsUseCase:
             GetLogsResponse() with both fields None (Fleet, no logs yet),
             or GetLogsResponse with raw_log set (Ray).
         """
-        try:
-            job = Job.objects.get(id=job_id)
-        except ObjectDoesNotExist:
+        job = Job.objects.filter(id=job_id).first()
+        if job is None:
             raise JobNotFoundException(job_id)
 
         if not JobAccessPolicies.can_read_provider_logs(user, job, accessible_functions=accessible_functions):

--- a/gateway/api/use_cases/jobs/retrieve.py
+++ b/gateway/api/use_cases/jobs/retrieve.py
@@ -4,7 +4,6 @@ import logging
 from typing import Optional
 from uuid import UUID
 from django.contrib.auth.models import AbstractUser
-from django.core.exceptions import ObjectDoesNotExist
 from api.domain.exceptions.job_not_found_exception import JobNotFoundException
 from core.domain.authorization.function_access_result import FunctionAccessResult
 from core.models import Job
@@ -37,9 +36,8 @@ class JobRetrieveUseCase:
         Returns:
             Job: job found
         """
-        try:
-            job = Job.objects.get(id=job_id)
-        except ObjectDoesNotExist:
+        job = Job.objects.filter(id=job_id).first()
+        if job is None:
             raise JobNotFoundException(str(job_id))
 
         if not JobAccessPolicies.can_access(user, job, accessible_functions=accessible_functions):

--- a/gateway/api/use_cases/jobs/save_result.py
+++ b/gateway/api/use_cases/jobs/save_result.py
@@ -5,7 +5,6 @@ Use case for saving job results.
 from uuid import UUID
 import logging
 from django.contrib.auth.models import AbstractUser
-from django.core.exceptions import ObjectDoesNotExist
 
 from api.domain.exceptions.invalid_access_exception import InvalidAccessException
 from api.domain.exceptions.job_not_found_exception import JobNotFoundException
@@ -35,9 +34,8 @@ class JobSaveResultUseCase:
         Returns:
             Job: The updated job object with the stored result.
         """
-        try:
-            job = Job.objects.get(id=job_id)
-        except ObjectDoesNotExist:
+        job = Job.objects.filter(id=job_id).first()
+        if job is None:
             raise JobNotFoundException(job_id)
 
         can_save_result = JobAccessPolicies.can_save_result(user, job)

--- a/gateway/api/use_cases/jobs/set_sub_status.py
+++ b/gateway/api/use_cases/jobs/set_sub_status.py
@@ -4,7 +4,6 @@ import logging
 from uuid import UUID
 
 from django.contrib.auth.models import AbstractUser
-from django.core.exceptions import ObjectDoesNotExist
 
 from api.access_policies.jobs import JobAccessPolicies
 from api.domain.exceptions.invalid_access_exception import InvalidAccessException
@@ -34,9 +33,8 @@ class SetJobSubStatusUseCase:
             JobNotFoundException: If the job does not exist or access is denied.
             ForbiddenError: If the job is not in RUNNING status.
         """
-        try:
-            job = Job.objects.get(id=job_id)
-        except ObjectDoesNotExist:
+        job = Job.objects.filter(id=job_id).first()
+        if job is None:
             raise JobNotFoundException(str(job_id))
 
         can_update_sub_status = JobAccessPolicies.can_update_sub_status(user, job)

--- a/gateway/api/use_cases/jobs/stop.py
+++ b/gateway/api/use_cases/jobs/stop.py
@@ -3,7 +3,6 @@ import logging
 from uuid import UUID
 
 from django.contrib.auth.models import AbstractUser
-from django.core.exceptions import ObjectDoesNotExist
 from qiskit_ibm_runtime import QiskitRuntimeService, RuntimeInvalidStateError
 
 from core.models import Job, JobEvent, RuntimeJob
@@ -25,9 +24,8 @@ class StopJobUseCase:
         self.stopped_sessions = []
 
     def execute(self, job_id: UUID, service_str: str, user: AbstractUser) -> str:
-        try:
-            job = Job.objects.get(id=job_id)
-        except ObjectDoesNotExist:
+        job = Job.objects.filter(id=job_id).first()
+        if job is None:
             raise JobNotFoundException(job_id)
 
         if not JobAccessPolicies.can_stop(user, job):


### PR DESCRIPTION
### Summary

Every job use case looks a job up by id and turns a miss into a 404. Until now they did it by catching the ORM exception:

```python
try:
    job = Job.objects.get(id=job_id)
except ObjectDoesNotExist:
    raise JobNotFoundException(job_id)
```

This PR moves all eleven of them to the other shape we already use elsewhere in the repo (`api/use_cases/programs/get_jobs.py`, `Provider.objects.get_by_name`):

```python
job = Job.objects.filter(id=job_id).first()
if job is None:
    raise JobNotFoundException(job_id)
```

Follows up on the review discussion in #2402, and rebased on main now that it is in, so the diff here is only the sweep.

### Details and comments

Behaviour is identical, so no test changes: a missing job still raises `JobNotFoundException`, which the exception handler maps to 404. The lookup is still a single primary key query, `first()` only adds an `ORDER BY id LIMIT 1` that the index already satisfies.

Beyond the style preference, the reason to unify is that mixing both shapes is what produced the bug in #2402. `JobRetrieveUseCase` kept a `if job is None` check that stopped being reachable the moment `JobsRepository.get_job_by_id()` (which did return `None`) was replaced by `Job.objects.get()`, and the commit that added the `except` to its ten siblings gave `retrieve.py` the `ObjectDoesNotExist` import and nothing else. With one shape, a lookup that forgets its guard is visibly wrong instead of silently returning a 500.

The now unused `ObjectDoesNotExist` imports are gone from the eleven files. `Config.get()` in `core/models.py` still catches `DoesNotExist` on purpose: it converts the miss into a `KeyError` that flags a boot ordering mistake, which is a different intent from an HTTP 404, so it stays as it is.

Files touched: `retrieve`, `get_result`, `get_logs`, `provider_logs`, `save_result`, `stop`, `set_sub_status`, `create_event`, `list_events`, `get_runtime_jobs` and `associate_runtime_jobs`.
