### PR TITLE
Update remaining Python 3.11 references to 3.12

### DIFF
--- a/.github/actions/helm-lint/action.yaml
+++ b/.github/actions/helm-lint/action.yaml
@@ -13,7 +13,7 @@ runs:
     # yamllint (https://github.com/adrienverge/yamllint) which require Python
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         check-latest: true
 
     - name: Set up chart-testing

--- a/.github/workflows/fleets-integration-tests.yaml
+++ b/.github/workflows/fleets-integration-tests.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install tox
         run: pip install tox>=4.0.0
       - name: Build fleet-node base image
@@ -40,7 +40,7 @@ jobs:
       - name: Verify CE project provisioned
         run: docker compose -f docker-compose-fleets-test.yaml exec -T gateway python manage.py sync_ce_project
       - name: Run fleets integration tests
-        run: tox -c tests/tox.ini -e py311-fleets
+        run: tox -c tests/tox.ini -e py312-fleets
       - name: Print logs on failure
         if: failure()
         run: |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Stability](https://img.shields.io/badge/stability-alpha-f4d03f.svg)](https://github.com/Qiskit/qiskit-serverless/releases)
 [![License](https://img.shields.io/github/license/qiskit-community/quantum-prototype-template?label=License)](https://github.com/qiskit-community/quantum-prototype-template/blob/main/LICENSE.txt)
 [![Code style: Black](https://img.shields.io/badge/Code%20style-Black-000.svg)](https://github.com/psf/black)
-[![Python](https://img.shields.io/badge/Python-3.11-informational)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/Python-3.12-informational)](https://www.python.org/)
 [![Qiskit](https://img.shields.io/badge/Qiskit-%E2%89%A5%201.0.0-6133BD)](https://github.com/Qiskit/qiskit)
 
 # Qiskit Serverless

--- a/docker-compose-fleets-test.yaml
+++ b/docker-compose-fleets-test.yaml
@@ -18,7 +18,7 @@ x-gateway-env: &gateway-env
   IBM_CLOUD_API_KEY: fake-api-key-for-test
   CE_HMAC_SECRET_NAME: cos-hmac-secret
   LIMITS_MAX_FLEETS: "10"
-  FLEETS_DEFAULT_IMAGE: python:3.11-slim
+  FLEETS_DEFAULT_IMAGE: python:3.12-slim
   DEFAULT_COMPUTE_PROFILE: cx3d-4x16
   CE_DEFAULT_PROJECT_NAME: test-project
   CE_PROJECTS: '[{"project_id":"test-project-id","project_name":"test-project","region":"us-south","resource_group_id":"test-rg-id","subnet_pool_id":"test-subnet-pool-id","pds_name_state":"test-pds-state","pds_name_users":"test-pds-users","pds_name_providers":"test-pds-providers","cos_instance_name":"test-cos-instance","cos_key_name":"test-cos-key","cos_bucket_task_store_name":"task-store-bucket","cos_bucket_user_data_name":"user-data-bucket","cos_bucket_provider_data_name":"provider-data-bucket"}]'

--- a/docs/local_setup/fleets_integration_tests.rst
+++ b/docs/local_setup/fleets_integration_tests.rst
@@ -52,7 +52,7 @@ What is covered
 Running the tests
 -----------------
 
-**Prerequisites:** a Docker runtime with Compose (Docker or Podman), Python 3.11,
+**Prerequisites:** a Docker runtime with Compose (Docker or Podman), Python 3.12,
 and ``tox``.
 
 From the repository root:
@@ -71,7 +71,7 @@ From the repository root:
    curl --retry 30 --retry-delay 2 --retry-all-errors --fail http://localhost:8000/liveness/
 
    # 4. Run the integration tests
-   tox -c tests/tox.ini -e py311-fleets
+   tox -c tests/tox.ini -e py312-fleets
 
    # 5. Tear down (``-v`` also removes the volumes)
    docker compose -f docker-compose-fleets-test.yaml down -v

--- a/tests/fleets/test_fleets_jobs.py
+++ b/tests/fleets/test_fleets_jobs.py
@@ -215,7 +215,7 @@ class TestFleetsJobs:
         fn = QiskitFunction(
             title=unique_title,
             provider=test_provider,
-            image="python:3.11-slim",
+            image="python:3.12-slim",
             runner="fleets",
         )
         serverless_client.upload(fn)

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -2,7 +2,7 @@
 min_version = 4.3.3
 requires =
     tox-ignore-env-name-mismatch ~= 0.2.0
-envlist = py312, py312-external, py311-fleets, lint
+envlist = py312, py312-external, py312-fleets, lint
 # CI: skip-next-line
 skipsdist = true
 # CI: skip-next-line
@@ -81,7 +81,7 @@ passenv =
     RUNTIME_API_BASE_URL
     RUNTIME_API_KEY
 
-[testenv:py311-fleets]
+[testenv:py312-fleets]
 commands =
   pip install -e ../client
   pip check


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

### Summary
Follow-up to #2376, which bumped the primary Python version across the project. This cleans up the remaining references, including those related to the fleets node.

### Details and comments

Changes:

- `README.md`: update Python badge from 3.11 to 3.12
- `.github/actions/helm-lint/action.yaml` and `.github/workflows/fleets-integration-tests.yaml`: pin CI to Python 3.12
- `tests/tox.ini` — rename `py311-fleets` env to `py312-fleets`
- `docker-compose-fleets-test.yaml`: update `FLEETS_DEFAULT_IMAGE` to `python:3.12-slim`
- `tests/fleets/test_fleets_jobs.py`: update provider image fixture to `python:3.12-slim`
- `docs/local_setup/fleets_integration_tests.rst`: update prerequisites and tox command

Not changed: `client/`:  the client still supports Python 3.11 and 3.10.

### Checklist

- [x] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have added a [release note](https://github.com/Qiskit/qiskit-serverless/blob/main/CONTRIBUTING.md#release-notes) for any user-facing change (new feature, bug fix, deprecation, or breaking change), or this PR has no user-facing changes.
