### PR TITLE
Fix/fleets get image artifact

### DIFF
--- a/.github/workflows/update-component-versions.yaml
+++ b/.github/workflows/update-component-versions.yaml
@@ -39,6 +39,7 @@ jobs:
           sed -i "s/version: ${OLDNUM}/version: ${NEWNUM}/" charts/qiskit-serverless/charts/gateway/Chart.yaml
           sed -i "s/appVersion: \"${OLDNUM}\"/appVersion: \"${NEWNUM}\"/" charts/qiskit-serverless/charts/gateway/Chart.yaml
           sed -i "s/ray-node:${OLDNUM}/ray-node:${NEWNUM}/" charts/qiskit-serverless/charts/gateway/values.yaml
+          sed -i "s/fleet-node:${OLDNUM}/fleet-node:${NEWNUM}/" charts/qiskit-serverless/charts/gateway/values.yaml
           sed -i "s/tag: \"${OLDNUM}\"/tag: \"${NEWNUM}\"/" charts/qiskit-serverless/values.yaml
           sed -i "s/ray-node:${OLDNUM}/ray-node:${NEWNUM}/" charts/qiskit-serverless/values.yaml
           sed -i "s/version: ${OLDNUM}/version: ${NEWNUM}/" charts/qiskit-serverless/values.yaml

--- a/charts/qiskit-serverless/charts/gateway/values.yaml
+++ b/charts/qiskit-serverless/charts/gateway/values.yaml
@@ -97,6 +97,7 @@ ce:
   fleetsGatewayHost: "http://127.0.0.1:8000"
   defaultProjectName: ""
   defaultComputeProfile: "bx3d-24x120"
+  fleetsDefaultImage: "private.icr.io/quantum-public/qiskit-serverless/fleet-node:0.34.0"
   fleetsDefaultMaxInstances: 1
 
 secrets:

--- a/gateway/core/services/runners/fleets_runner.py
+++ b/gateway/core/services/runners/fleets_runner.py
@@ -632,14 +632,19 @@ class FleetsRunner(AbstractRunner):
     def _get_image(self) -> str:
         """Return the container image for the fleet.
 
-        Uses ``program.image`` if set, otherwise falls back to
-        ``settings.FLEETS_DEFAULT_IMAGE``.
+        Custom jobs (artifact set) always run on the default fleet-node image —
+        ``program.image`` is the provider's runtime container and must not be
+        used when the gateway is supplying the entrypoint from an artifact.
+        Provider jobs (image set, no artifact) use ``program.image``.
+        Imageless jobs fall back to ``settings.FLEETS_DEFAULT_IMAGE``.
 
         Returns:
             Image reference string.
         """
         if not self.job.program:
             raise RunnerError("Job has no program assigned")
+        if self.job.program.artifact:
+            return settings.FLEETS_DEFAULT_IMAGE
         if self.job.program.image:
             return self.job.program.image
         return settings.FLEETS_DEFAULT_IMAGE

--- a/gateway/tests/core/services/runners/test_fleets_runner.py
+++ b/gateway/tests/core/services/runners/test_fleets_runner.py
@@ -417,6 +417,18 @@ def test_submit_uses_settings_default_image_when_no_program_image():
     assert mock_handler.submit_job.call_args.kwargs["image_reference"] == "fallback-image:v2"
 
 
+def test_submit_uses_default_image_when_artifact_set_even_if_image_also_set():
+    """Custom jobs (artifact set) always use FLEETS_DEFAULT_IMAGE, ignoring program.image."""
+    runner, mock_handler = _make_submit_runner()
+    runner.job.program.artifact = MagicMock()
+    runner.job.program.image = "provider-image:latest"
+
+    with _patch_settings(FLEETS_DEFAULT_IMAGE="fleet-node:latest"), patch.object(runner, "_upload_program_to_cos"):
+        runner.submit()
+
+    assert mock_handler.submit_job.call_args.kwargs["image_reference"] == "fleet-node:latest"
+
+
 def test_submit_uses_config_workers_as_max_instances():
     """submit() uses job.config.workers as scale_max_instances when set."""
     runner, mock_handler = _make_submit_runner()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

### Summary

This PR fixes a bug and adds a new deployment value to the reference chart for consistency with ray (although it won't change much in practice).

The bug: `_get_image()` in `FleetsRunner` previously returned `program.image` whenever it was set, even for custom function jobs where `program.artifact` is also set. For artifact jobs the gateway supplies the entrypoint, so`program.image` is the provider's runtime container and should be ignored. The fix checks `program.artifact` first and always falls back to `FLEETS_DEFAULT_IMAGE` for those jobs, mirroring how the Ray runner handles non-provider jobs.

The consistency changes:

- Adds a missing `fleetsDefaultImage` default to `charts/gateway/values.yaml`, parallel to `application.ray.nodeImage`.
- Adds a `sed` line to `update-component-versions.yaml` so `fleetsDefaultImage` in the chart gets bumped on each release alongside `ray-node`.

### Details and comments

- New unit test `test_submit_uses_default_image_when_artifact_set_even_if_image_also_set` covers the fixed case.
- All existing image-selection tests pass.

### Checklist

- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a [release note](https://github.com/Qiskit/qiskit-serverless/blob/main/CONTRIBUTING.md#release-notes) for any user-facing change (new feature, bug fix, deprecation, or breaking change), or this PR has no user-facing changes.
