### PR TITLE
Fleets: inject private URLs into job containers

### DIFF
--- a/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
+++ b/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
@@ -309,6 +309,14 @@ spec:
               value: {{ .Values.ce.defaultComputeProfile | quote }}
             - name: FLEETS_DEFAULT_MAX_INSTANCES
               value: {{ .Values.ce.fleetsDefaultMaxInstances | quote }}
+            - name: FLEETS_RUNTIME_IAM_URL
+              value: {{ .Values.ce.fleetsRuntimeIamUrl | quote }}
+            - name: FLEETS_RUNTIME_GLOBAL_SEARCH_URL
+              value: {{ .Values.ce.fleetsRuntimeGlobalSearchUrl | quote }}
+            - name: FLEETS_RUNTIME_GLOBAL_CATALOG_URL
+              value: {{ .Values.ce.fleetsRuntimeGlobalCatalogUrl | quote }}
+            - name: FLEETS_RUNTIME_EXPERIMENTAL
+              value: {{ .Values.ce.fleetsRuntimeExperimental | quote }}
             {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -517,6 +525,14 @@ spec:
               value: {{ .Values.ce.defaultComputeProfile | quote }}
             - name: FLEETS_DEFAULT_MAX_INSTANCES
               value: {{ .Values.ce.fleetsDefaultMaxInstances | quote }}
+            - name: FLEETS_RUNTIME_IAM_URL
+              value: {{ .Values.ce.fleetsRuntimeIamUrl | quote }}
+            - name: FLEETS_RUNTIME_GLOBAL_SEARCH_URL
+              value: {{ .Values.ce.fleetsRuntimeGlobalSearchUrl | quote }}
+            - name: FLEETS_RUNTIME_GLOBAL_CATALOG_URL
+              value: {{ .Values.ce.fleetsRuntimeGlobalCatalogUrl | quote }}
+            - name: FLEETS_RUNTIME_EXPERIMENTAL
+              value: {{ .Values.ce.fleetsRuntimeExperimental | quote }}
             {{- end }}
             - name: EVENT_STREAMS_ENABLED
               value: {{ .Values.application.eventStreams.enabled | default false | quote }}

--- a/charts/qiskit-serverless/charts/gateway/values.yaml
+++ b/charts/qiskit-serverless/charts/gateway/values.yaml
@@ -99,6 +99,10 @@ ce:
   defaultComputeProfile: "bx3d-24x120"
   fleetsDefaultImage: "private.icr.io/quantum-public/qiskit-serverless/fleet-node:0.35.0"
   fleetsDefaultMaxInstances: 1
+  fleetsRuntimeIamUrl: ""
+  fleetsRuntimeGlobalSearchUrl: ""
+  fleetsRuntimeGlobalCatalogUrl: ""
+  fleetsRuntimeExperimental: "false"
 
 secrets:
   secretKey:

--- a/gateway/core/ibm_cloud/code_engine/fleets/utils.py
+++ b/gateway/core/ibm_cloud/code_engine/fleets/utils.py
@@ -211,6 +211,7 @@ def build_run_env_variables(
             "RESULTS_PATH": paths.container_result_path,
             "LOG_FLUSH_INTERVAL_SECONDS": str(flush_interval),
             "LOG_SIZE_LIMIT_BYTES": str(getattr(settings, "FUNCTIONS_LOGS_SIZE_LIMIT", 52428800)),
+            "QISKIT_IBM_PRIVATE_ENDPOINT": "true",
         }
     )
     if paths.container_private_log_path is not None:

--- a/gateway/core/ibm_cloud/code_engine/fleets/utils.py
+++ b/gateway/core/ibm_cloud/code_engine/fleets/utils.py
@@ -194,6 +194,15 @@ def build_run_env_variables(
     if gateway_host:
         env["ENV_JOB_GATEWAY_HOST"] = gateway_host
 
+    if iam_url := getattr(settings, "FLEETS_IAM_URL", ""):
+        env["IAM_URL"] = iam_url
+    if global_search_url := getattr(settings, "FLEETS_GLOBAL_SEARCH_URL", ""):
+        env["GLOBAL_SEARCH_URL"] = global_search_url
+    if global_catalog_url := getattr(settings, "FLEETS_GLOBAL_CATALOG_URL", ""):
+        env["GLOBAL_CATALOG_URL"] = global_catalog_url
+    if getattr(settings, "FLEETS_EXPERIMENTAL", False):
+        env["QISKIT_FUNCTIONS_EXPERIMENTAL"] = "true"
+
     flush_interval = getattr(settings, "FLEETS_LOG_FLUSH_INTERVAL_SECONDS", 15)
     env.update(
         {

--- a/gateway/core/ibm_cloud/code_engine/fleets/utils.py
+++ b/gateway/core/ibm_cloud/code_engine/fleets/utils.py
@@ -194,13 +194,13 @@ def build_run_env_variables(
     if gateway_host:
         env["ENV_JOB_GATEWAY_HOST"] = gateway_host
 
-    if iam_url := getattr(settings, "FLEETS_IAM_URL", ""):
+    if iam_url := getattr(settings, "FLEETS_RUNTIME_IAM_URL", ""):
         env["IAM_URL"] = iam_url
-    if global_search_url := getattr(settings, "FLEETS_GLOBAL_SEARCH_URL", ""):
+    if global_search_url := getattr(settings, "FLEETS_RUNTIME_GLOBAL_SEARCH_URL", ""):
         env["GLOBAL_SEARCH_URL"] = global_search_url
-    if global_catalog_url := getattr(settings, "FLEETS_GLOBAL_CATALOG_URL", ""):
+    if global_catalog_url := getattr(settings, "FLEETS_RUNTIME_GLOBAL_CATALOG_URL", ""):
         env["GLOBAL_CATALOG_URL"] = global_catalog_url
-    if getattr(settings, "FLEETS_EXPERIMENTAL", False):
+    if getattr(settings, "FLEETS_RUNTIME_EXPERIMENTAL", False):
         env["QISKIT_FUNCTIONS_EXPERIMENTAL"] = "true"
 
     flush_interval = getattr(settings, "FLEETS_LOG_FLUSH_INTERVAL_SECONDS", 15)

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -467,13 +467,13 @@ FLEETS_DEFAULT_MAX_INSTANCES = int(os.environ.get("FLEETS_DEFAULT_MAX_INSTANCES"
 
 CE_HMAC_SECRET_NAME = os.environ.get("CE_HMAC_SECRET_NAME", None)
 
-# IBM Cloud service URLs injected into every Fleets job container.
+# Qiskit IBM Runtime service URLs injected into every Fleets job container.
 # Set via Helm in the internal repo; empty strings mean "don't inject".
-FLEETS_IAM_URL = os.environ.get("FLEETS_IAM_URL", "")
-FLEETS_GLOBAL_SEARCH_URL = os.environ.get("FLEETS_GLOBAL_SEARCH_URL", "")
-FLEETS_GLOBAL_CATALOG_URL = os.environ.get("FLEETS_GLOBAL_CATALOG_URL", "")
+FLEETS_RUNTIME_IAM_URL = os.environ.get("FLEETS_RUNTIME_IAM_URL", "")
+FLEETS_RUNTIME_GLOBAL_SEARCH_URL = os.environ.get("FLEETS_RUNTIME_GLOBAL_SEARCH_URL", "")
+FLEETS_RUNTIME_GLOBAL_CATALOG_URL = os.environ.get("FLEETS_RUNTIME_GLOBAL_CATALOG_URL", "")
 # Set to "true" on staging to enable experimental features in the container.
-FLEETS_EXPERIMENTAL = os.environ.get("FLEETS_EXPERIMENTAL", "false").lower() == "true"
+FLEETS_RUNTIME_EXPERIMENTAL = os.environ.get("FLEETS_RUNTIME_EXPERIMENTAL", "false").lower() == "true"
 CE_DEFAULT_PROJECT_NAME = os.environ.get("CE_DEFAULT_PROJECT_NAME", "")
 
 # Set to "true" to use the public COS endpoint instead of the private VPC endpoint.

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -466,6 +466,14 @@ DEFAULT_COMPUTE_PROFILE = os.environ.get("DEFAULT_COMPUTE_PROFILE", "bx3d-24x120
 FLEETS_DEFAULT_MAX_INSTANCES = int(os.environ.get("FLEETS_DEFAULT_MAX_INSTANCES", "1"))
 
 CE_HMAC_SECRET_NAME = os.environ.get("CE_HMAC_SECRET_NAME", None)
+
+# IBM Cloud service URLs injected into every Fleets job container.
+# Set via Helm in the internal repo; empty strings mean "don't inject".
+FLEETS_IAM_URL = os.environ.get("FLEETS_IAM_URL", "")
+FLEETS_GLOBAL_SEARCH_URL = os.environ.get("FLEETS_GLOBAL_SEARCH_URL", "")
+FLEETS_GLOBAL_CATALOG_URL = os.environ.get("FLEETS_GLOBAL_CATALOG_URL", "")
+# Set to "true" on staging to enable experimental features in the container.
+FLEETS_EXPERIMENTAL = os.environ.get("FLEETS_EXPERIMENTAL", "false").lower() == "true"
 CE_DEFAULT_PROJECT_NAME = os.environ.get("CE_DEFAULT_PROJECT_NAME", "")
 
 # Set to "true" to use the public COS endpoint instead of the private VPC endpoint.

--- a/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_fleet_utils.py
+++ b/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_fleet_utils.py
@@ -286,6 +286,13 @@ def test_build_run_env_variables_gateway_host_override():
     assert by_name["ENV_JOB_GATEWAY_HOST"] == "https://fleets.example.com"
 
 
+def test_build_run_env_variables_always_sets_private_endpoint():
+    """build_run_env_variables always injects QISKIT_IBM_PRIVATE_ENDPOINT=true."""
+    result = build_run_env_variables(_make_paths(), {})
+    by_name = {e["name"]: e["value"] for e in result}
+    assert by_name["QISKIT_IBM_PRIVATE_ENDPOINT"] == "true"
+
+
 def test_build_run_env_variables_flush_interval_default():
     """build_run_env_variables defaults LOG_FLUSH_INTERVAL_SECONDS to 15."""
     result = build_run_env_variables(_make_paths(), {})


### PR DESCRIPTION
## Summary

This PR adds 4 new gateway settings driven by env vars: 

 - `FLEETS_RUNTIME_IAM_URL`
 - `FLEETS_RUNTIME_GLOBAL_SEARCH_URL`
 - `FLEETS_RUNTIME_GLOBAL_CATALOG_URL`
 - `FLEETS_RUNTIME_EXPERIMENTAL`

When these variables are set,  `build_run_env_variables()` will inject the corresponding `qiskit-ibm-runtime` env. variables in the Fleets job container:

| qiskit-serverless | qiskit-ibm-runtime |
|---|---|
| `FLEETS_RUNTIME_IAM_URL` | `IAM_URL` |
| `FLEETS_RUNTIME_GLOBAL_SEARCH_URL` | `GLOBAL_SEARCH_URL` |
| `FLEETS_RUNTIME_GLOBAL_CATALOG_URL` | `GLOBAL_CATALOG_URL` |
| `FLEETS_RUNTIME_EXPERIMENTAL` | `QISKIT_FUNCTIONS_EXPERIMENTAL` |


This enables Fleets jobs to access Qiskit IBM Runtime via private endpoints through the VPE (Virtual Private Endpoint) setup in Code Engine. The setup is different for production and staging. The internal Helm chart will set the correct private IBM Cloud service endpoints per environment:

  - **prod**: `FLEETS_RUNTIME_IAM_URL` (prod endpoint), `FLEETS_RUNTIME_GLOBAL_SEARCH_URL`, `FLEETS_RUNTIME_GLOBAL_CATALOG_URL`
  - **staging**: `FLEETS_RUNTIME_IAM_URL` (test endpoint), `FLEETS_RUNTIME_EXPERIMENTAL=true` (this will skip global search and global catalog endpoints)

## Requirements

`qiskit-ibm-runtime >= 0.49.0` is required in the Fleets job container to support these private endpoint variables. This is satisfied via the client dependency (`qiskit-ibm-runtime>=0.47.0, <0.50.0` in `client/requirements.txt`).