### PR TITLE
Keep the default_compute_profile column so a previous release can still be deployed

### DIFF
--- a/gateway/api/migrations/0057_computeprofile_and_more.py
+++ b/gateway/api/migrations/0057_computeprofile_and_more.py
@@ -49,9 +49,18 @@ class Migration(migrations.Migration):
                 ("memory", models.CharField(help_text="Memory in GB (e.g., 120)", max_length=64)),
             ],
         ),
-        migrations.RemoveField(
-            model_name="program",
-            name="default_compute_profile",
+        # The column is dropped from Django's state only, and left in place in the
+        # database, so a previous release can still be deployed: its Program model
+        # still declares the field, and Django lists every declared column in each
+        # SELECT. The real DROP COLUMN happens in a later release.
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveField(
+                    model_name="program",
+                    name="default_compute_profile",
+                ),
+            ],
+            database_operations=[],
         ),
         migrations.AddField(
             model_name="job",

--- a/releasenotes/notes/add-function-size-and-compute-profile-models-1562cb724e32f451.yaml
+++ b/releasenotes/notes/add-function-size-and-compute-profile-models-1562cb724e32f451.yaml
@@ -18,6 +18,8 @@ upgrade:
   - |
     The ``default_compute_profile`` field has been removed from Qiskit
     Functions. It was only ever settable through the admin backoffice and was
-    read by no code path — the Fleets runner resolves its default from the
-    ``DEFAULT_COMPUTE_PROFILE`` setting — so no data migration is required. Any
-    values stored in the column are dropped when the migration runs.
+    read by no code path, since the Fleets runner resolves its default from the
+    ``DEFAULT_COMPUTE_PROFILE`` setting, so no data migration is required. The
+    ``api_program.default_compute_profile`` column is kept in the database for
+    now and will be dropped in a later release, so that rolling back to a
+    previous release keeps working.


### PR DESCRIPTION
### Summary

Migration `0057` drops the `api_program.default_compute_profile` column. That single operation makes the release impossible to roll back: the previous release still declares `default_compute_profile` on its `Program` model, and Django lists every declared column in each `SELECT`, so once the column is gone every query touching `Program` fails with `column api_program.default_compute_profile does not exist`. It is not enough that no code path reads the value.

This PR keeps the column in the database and removes it from Django's state only, wrapping the `RemoveField` in `SeparateDatabaseAndState`. The real `DROP COLUMN` is deferred to a later release (follow-up draft PR).

### Details and comments

The rest of migration `0057` is already safe to roll back, and stays as it is: the two new tables are invisible to older code, and `job.compute_profile_fk` and `program.default_size` are nullable, so inserts that do not mention them leave a `NULL` behind.

Two things worth noting about why the drop needs deferring:

Rolling an image back does not undo a migration. Both `entrypoint-gateway.sh` and `entrypoint-scheduler.sh` only ever run `migrate_with_lock` forward, so a previous release would come back up against a schema it cannot read, and it would need a manual `ALTER TABLE` to recover.

The blast radius is not limited to the API. The scheduler reads `job.program.provider` on every loop iteration (`scheduler/tasks/update_fleets_jobs_statuses.py`), which loads the full `Program` row, so it fails too. This also affects a plain rolling update, not just a rollback: the first new pod applies the migration in its entrypoint while pods from the previous release are still serving.

The column is left as it was, `varchar(255) NULL`, so the new release inserts into `api_program` without mentioning it. Nothing reads it: the Fleets runner resolves its default from the `DEFAULT_COMPUTE_PROFILE` setting.

Django's `SeparateDatabaseAndState.state_forwards` delegates to `state_operations`, so the migration graph state is identical to before and `makemigrations --check` still reports no pending changes.
