### PR TITLE
Allow get_runtime_service to use a private endpoint

### DIFF
--- a/client/qiskit_serverless/core/job.py
+++ b/client/qiskit_serverless/core/job.py
@@ -500,6 +500,10 @@ def get_runtime_service(
     ``get_runtime_service()``, which will automatically pull authentication data from the
     environment variables.
 
+    Set ``QISKIT_IBM_PRIVATE_ENDPOINT`` to ``true`` to reach the Runtime API through a
+    virtual private endpoint. It defaults to off, and the instance has to be a CRN for the
+    private host to be resolved.
+
     Args:
         channel: Optional QiskitRuntimeService channel argument
         token: Optional QiskitRuntimeService authorization token
@@ -516,6 +520,7 @@ def get_runtime_service(
         instance=instance or os.environ["QISKIT_IBM_INSTANCE"],
         token=token or os.environ["QISKIT_IBM_TOKEN"],
         url=url or os.environ.get("QISKIT_IBM_URL", None),
+        private_endpoint=os.environ.get("QISKIT_IBM_PRIVATE_ENDPOINT", "false").lower() == "true",
     )
 
 

--- a/client/tests/core/test_job.py
+++ b/client/tests/core/test_job.py
@@ -454,6 +454,7 @@ class TestGetRuntimeService:
             "QISKIT_IBM_CHANNEL": "ibm_quantum_platform",
             "QISKIT_IBM_INSTANCE": "test-crn",
             "QISKIT_IBM_TOKEN": "test-token",
+            "QISKIT_IBM_PRIVATE_ENDPOINT": "false",
         },
     )
     def test_get_runtime_service_from_env(self, mock_service_class):
@@ -469,6 +470,7 @@ class TestGetRuntimeService:
             instance="test-crn",
             token="test-token",
             url=None,
+            private_endpoint=False,
         )
 
     @patch("qiskit_serverless.core.job.ServerlessRuntimeService")
@@ -478,6 +480,7 @@ class TestGetRuntimeService:
             "QISKIT_IBM_CHANNEL": "ibm_quantum_platform",
             "QISKIT_IBM_INSTANCE": "test-crn",
             "QISKIT_IBM_TOKEN": "test-token",
+            "QISKIT_IBM_PRIVATE_ENDPOINT": "false",
         },
     )
     def test_get_runtime_service_with_explicit_params(self, mock_service_class):
@@ -498,6 +501,7 @@ class TestGetRuntimeService:
             instance="explicit-crn",
             token="explicit-token",
             url="https://custom.url",
+            private_endpoint=False,
         )
 
     @patch("qiskit_serverless.core.job.ServerlessRuntimeService")
@@ -508,6 +512,7 @@ class TestGetRuntimeService:
             "QISKIT_IBM_INSTANCE": "test-crn",
             "QISKIT_IBM_TOKEN": "test-token",
             "QISKIT_IBM_URL": "https://env.url",
+            "QISKIT_IBM_PRIVATE_ENDPOINT": "false",
         },
     )
     def test_get_runtime_service_with_url_from_env(self, mock_service_class):
@@ -523,6 +528,33 @@ class TestGetRuntimeService:
             instance="test-crn",
             token="test-token",
             url="https://env.url",
+            private_endpoint=False,
+        )
+
+    @patch("qiskit_serverless.core.job.ServerlessRuntimeService")
+    @patch.dict(
+        os.environ,
+        {
+            "QISKIT_IBM_CHANNEL": "ibm_quantum_platform",
+            "QISKIT_IBM_INSTANCE": "test-crn",
+            "QISKIT_IBM_TOKEN": "test-token",
+            "QISKIT_IBM_PRIVATE_ENDPOINT": "true",
+        },
+    )
+    def test_get_runtime_service_with_private_endpoint(self, mock_service_class):
+        """Test get_runtime_service() enables the private endpoint from the environment."""
+        mock_service_instance = Mock()
+        mock_service_class.return_value = mock_service_instance
+
+        service = get_runtime_service()
+
+        assert service is not None
+        mock_service_class.assert_called_once_with(
+            channel="ibm_quantum_platform",
+            instance="test-crn",
+            token="test-token",
+            url=None,
+            private_endpoint=True,
         )
 
     def test_get_runtime_service_missing_env_raises_error(self):

--- a/releasenotes/notes/runtime-service-private-endpoint-6a052c5bfbb17c36.yaml
+++ b/releasenotes/notes/runtime-service-private-endpoint-6a052c5bfbb17c36.yaml
@@ -1,13 +1,14 @@
 ---
 features:
   - |
-    ``get_runtime_service()`` now accepts a ``private_endpoint`` argument that defaults to the
-``QISKIT_IBM_PRIVATE_ENDPOINT`` environment variable. When the variable is set, the service
-connects through private URLs automatically. Existing usage is unchanged.
+    ``get_runtime_service()`` now reads the ``QISKIT_IBM_PRIVATE_ENDPOINT`` environment
+    variable and forwards it to ``QiskitRuntimeService`` as ``private_endpoint``. Set it to
+    ``true`` and the service connects through private URLs. Existing usage is unchanged, and
+    the instance has to be a CRN for the private host to be resolved.
 
     Example usage from within a Qiskit Function, with the variable set in the environment::
 
-    from qiskit_serverless import get_runtime_service
+        from qiskit_serverless import get_runtime_service
 
-    service = get_runtime_service()
-    backend = service.backend("my_backend")
+        service = get_runtime_service()
+        backend = service.backend("my_backend")

--- a/releasenotes/notes/runtime-service-private-endpoint-6a052c5bfbb17c36.yaml
+++ b/releasenotes/notes/runtime-service-private-endpoint-6a052c5bfbb17c36.yaml
@@ -1,0 +1,19 @@
+---
+features:
+  - |
+    ``get_runtime_service()`` now reads a ``QISKIT_IBM_PRIVATE_ENDPOINT`` environment
+    variable and forwards it to ``QiskitRuntimeService`` as ``private_endpoint``. Set it to
+    ``true`` to reach the Qiskit Runtime API through a virtual private endpoint. Any other
+    value, or leaving it unset, keeps the current public endpoint behaviour.
+
+    This is the only way to select the private Runtime API host: ``QISKIT_IBM_URL`` is the
+    raw IBM Cloud URL that gets rewritten into an API host, so pointing it at a private
+    host does not work. Note the instance must be a CRN for the private host to be
+    resolved.
+
+    Example usage from within a Qiskit Function, with the variable set in the environment::
+
+        from qiskit_serverless import get_runtime_service
+
+        service = get_runtime_service()
+        backend = service.backend("my_backend")

--- a/releasenotes/notes/runtime-service-private-endpoint-6a052c5bfbb17c36.yaml
+++ b/releasenotes/notes/runtime-service-private-endpoint-6a052c5bfbb17c36.yaml
@@ -1,19 +1,13 @@
 ---
 features:
   - |
-    ``get_runtime_service()`` now reads a ``QISKIT_IBM_PRIVATE_ENDPOINT`` environment
-    variable and forwards it to ``QiskitRuntimeService`` as ``private_endpoint``. Set it to
-    ``true`` to reach the Qiskit Runtime API through a virtual private endpoint. Any other
-    value, or leaving it unset, keeps the current public endpoint behaviour.
-
-    This is the only way to select the private Runtime API host: ``QISKIT_IBM_URL`` is the
-    raw IBM Cloud URL that gets rewritten into an API host, so pointing it at a private
-    host does not work. Note the instance must be a CRN for the private host to be
-    resolved.
+    ``get_runtime_service()`` now accepts a ``private_endpoint`` argument that defaults to the
+``QISKIT_IBM_PRIVATE_ENDPOINT`` environment variable. When the variable is set, the service
+connects through private URLs automatically. Existing usage is unchanged.
 
     Example usage from within a Qiskit Function, with the variable set in the environment::
 
-        from qiskit_serverless import get_runtime_service
+    from qiskit_serverless import get_runtime_service
 
-        service = get_runtime_service()
-        backend = service.backend("my_backend")
+    service = get_runtime_service()
+    backend = service.backend("my_backend")


### PR DESCRIPTION
### Summary

`get_runtime_service()` could not reach the Qiskit Runtime API through a virtual private endpoint. It builds a `ServerlessRuntimeService` from environment variables and had no way to pass `private_endpoint`, which is the only thing that selects the private API host. This adds a `QISKIT_IBM_PRIVATE_ENDPOINT` environment variable that gets forwarded as `private_endpoint`, so a function can use a VPE without changing any code.

Defaults to off, so nothing changes for existing callers.

### Details and comments

`QISKIT_IBM_URL` cannot be used for this. It is the raw IBM Cloud URL that qiskit-ibm-runtime rewrites into an API host, so pointing it at a private host produces a mangled URL. The library reads no environment variable of its own for the flag: its env-var account path builds the account without `private_endpoint`, and while a saved account file does carry the field, environment variables take precedence over the file, so any container that exports `QISKIT_IBM_TOKEN` silently ignores it. Passing the flag explicitly is the only route.

The boolean parsing follows the convention already used in `gateway/main/settings.py`, where `os.environ.get(..., "false").lower() == "true"` appears in `EVENT_STREAMS_ENABLED`, `RAY_CLUSTER_MODE_LOCAL`, `SECURE_HSTS_*` and `CE_COS_USE_PUBLIC_ENDPOINT`. It accepts the literal `true` in any case, and treats anything else as off.

One caveat is called out in the docstring and the release note: the instance has to be a CRN. The upstream rewrite is guarded by `is_crn(instance)`, so with an instance name the flag silently does nothing and the raw URL is returned unchanged.

Verified by calling the upstream resolver directly, since the unit tests mock the service class and can only check that the argument is forwarded:

```
us-east, flag off -> https://quantum.cloud.ibm.com/api/v1
us-east, flag ON  -> https://private.us-east.quantum.cloud.ibm.com/api/v1
eu-de,   flag ON  -> https://private.eu-de.quantum.cloud.ibm.com/api/v1
name instead of CRN, flag ON -> https://cloud.ibm.com
```

Three existing tests in `TestGetRuntimeService` assert the exact keyword arguments, so they gained `private_endpoint=False`. Their `patch.dict` blocks now set `QISKIT_IBM_PRIVATE_ENDPOINT` explicitly as well, because `patch.dict` merges rather than replaces and `pytest-randomly` is in use, so without it a developer who exports the variable would see failures that CI does not reproduce. One new test covers the enabled case.

`private_endpoint` is read from the environment only, while the other four values can also be passed as arguments. That keeps the change small and covers the deployment case, where the environment is what we control. Adding an optional parameter that takes precedence over the variable would be a small follow-up if a caller ever needs to set it programmatically.

Gateway side injection of the variable is being handled separately.

Checked with `tox -epy311`, `-epy312`, `-epy313` (340 passed, 5 skipped each), `tox -elint` (black, pylint 10.00/10, mypy clean) and `tox -ecoverage` (80 percent against the 70 percent gate).
