### PR TITLE
Allow filtering functions by provider name in list()

### DIFF
--- a/client/qiskit_serverless/core/client.py
+++ b/client/qiskit_serverless/core/client.py
@@ -157,8 +157,12 @@ class BaseClient(JobService, RunService, JsonSerializable, ABC):
         """Uploads program."""
 
     @abstractmethod
-    def functions(self, **kwargs) -> List[RunnableQiskitFunction]:
-        """Returns list of available programs."""
+    def functions(self, provider: Optional[str] = None, **kwargs) -> List[RunnableQiskitFunction]:
+        """Returns list of available programs.
+
+        Args:
+            provider: if given, only functions belonging to this provider are returned.
+        """
 
     @abstractmethod
     def function(self, title: str, provider: Optional[str] = None) -> Optional[RunnableQiskitFunction]:
@@ -174,12 +178,16 @@ class BaseClient(JobService, RunService, JsonSerializable, ABC):
         )
         return self.function(title, provider=provider)
 
-    def list(self, **kwargs) -> List[RunnableQiskitFunction]:
-        """Returns list of available programs."""
+    def list(self, provider: Optional[str] = None, **kwargs) -> List[RunnableQiskitFunction]:
+        """Returns list of available programs.
+
+        Args:
+            provider: if given, only functions belonging to this provider are returned.
+        """
         warnings.warn(
             "`list` method has been deprecated. "
             "And will be removed in future releases. "
             "Please, use `get_functions` instead.",
             DeprecationWarning,
         )
-        return self.functions(**kwargs)
+        return self.functions(provider=provider, **kwargs)

--- a/client/qiskit_serverless/core/clients/serverless_client.py
+++ b/client/qiskit_serverless/core/clients/serverless_client.py
@@ -602,13 +602,21 @@ class ServerlessClient(BaseClient):  # pylint: disable=too-many-public-methods
         return function_uploaded
 
     @_trace_functions("list")
-    def functions(self, **kwargs) -> List[RunnableQiskitFunction]:
-        """Returns list of available functions."""
+    def functions(self, provider: Optional[str] = None, **kwargs) -> List[RunnableQiskitFunction]:
+        """Returns list of available functions.
+
+        Args:
+            provider: if given, only functions belonging to this provider are returned,
+                e.g. ``functions(provider="q-ctrl")``.
+        """
+        params = dict(kwargs)
+        if provider:
+            params["provider"] = provider
         response_data = safe_json_request_as_list(
             request=lambda: requests.get(
                 f"{self.host}/api/{self.version}/programs",
                 headers=get_headers(token=self.token, instance=self.instance, channel=self.channel),
-                params=kwargs,
+                params=params,
                 timeout=REQUESTS_TIMEOUT,
             )
         )

--- a/client/tests/core/test_serverless_client_functions.py
+++ b/client/tests/core/test_serverless_client_functions.py
@@ -218,6 +218,20 @@ class TestFunctionsMethod:
         assert call_kwargs["params"] == {"limit": 5, "offset": 10, "provider": "test-provider"}
 
     @patch("qiskit_serverless.core.clients.serverless_client.requests.get")
+    def test_functions_passes_provider_filter(self, mock_get, mock_client):
+        """functions(provider=...) forwards the provider as a query parameter."""
+        mock_response = Mock()
+        mock_response.ok = True
+        mock_response.text = "[]"
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        mock_client.functions(provider="q-ctrl")
+
+        mock_get.assert_called_once()
+        assert mock_get.call_args[1]["params"] == {"provider": "q-ctrl"}
+
+    @patch("qiskit_serverless.core.clients.serverless_client.requests.get")
     def test_functions_returns_empty_list_when_no_functions(self, mock_get, mock_client):
         """functions() returns an empty list when no functions are available."""
         mock_response = Mock()

--- a/gateway/api/use_cases/programs/list.py
+++ b/gateway/api/use_cases/programs/list.py
@@ -20,26 +20,32 @@ class ListFunctionsUseCase:
         user: AbstractUser,
         accessible_functions: FunctionAccessResult,
         type_filter: str | None,
+        provider: str | None = None,
     ) -> list[Function]:
-        """Return functions the user can see, filtered by type_filter."""
+        """Return functions the user can see, filtered by type_filter and provider.
+
+        When provider is given, results are narrowed to that provider's functions. The
+        narrowing is applied after permission scoping, so it can only reduce the set the
+        user is already allowed to see -- an unknown or inaccessible provider yields [].
+        """
         if type_filter == TypeFilter.SERVERLESS:
-            return list(Function.objects.user_functions(user))
-
-        if type_filter == TypeFilter.CATALOG:
-            return list(
-                Function.objects.provider_functions().with_permission(
-                    user,
-                    accessible_functions=accessible_functions,
-                    legacy_permission_name=RUN_PROGRAM_PERMISSION,
-                    permission=PLATFORM_PERMISSION_READ,
-                )
+            queryset = Function.objects.user_functions(user)
+        elif type_filter == TypeFilter.CATALOG:
+            queryset = Function.objects.provider_functions().with_permission(
+                user,
+                accessible_functions=accessible_functions,
+                legacy_permission_name=RUN_PROGRAM_PERMISSION,
+                permission=PLATFORM_PERMISSION_READ,
             )
-
-        return list(
-            Function.objects.with_permission(
+        else:
+            queryset = Function.objects.with_permission(
                 user,
                 accessible_functions=accessible_functions,
                 legacy_permission_name=VIEW_PROGRAM_PERMISSION,
                 permission=PLATFORM_PERMISSION_READ,
             )
-        )
+
+        if provider:
+            queryset = queryset.filter(provider__name=provider)
+
+        return list(queryset)

--- a/gateway/api/v1/views/programs/list.py
+++ b/gateway/api/v1/views/programs/list.py
@@ -55,6 +55,13 @@ class OutputSerializer(serializers.ModelSerializer):
             type=openapi.TYPE_STRING,
             required=False,
         ),
+        openapi.Parameter(
+            "provider",
+            openapi.IN_QUERY,
+            description="Return only functions belonging to this provider",
+            type=openapi.TYPE_STRING,
+            required=False,
+        ),
     ],
     responses={status.HTTP_200_OK: OutputSerializer(many=True)},
 )
@@ -64,15 +71,22 @@ class OutputSerializer(serializers.ModelSerializer):
 def list_programs(request: Request) -> Response:
     """List Qiskit Functions accessible to the authenticated user."""
     type_filter = request.query_params.get("filter")
+    provider = request.query_params.get("provider")
     user = cast(AbstractUser, request.user)
     accessible_functions = cast(FunctionAccessResult, request.auth.accessible_functions)
     logger.info(
-        "[programs-list] user_id=%s filter=%s accessible_functions=%s",
+        "[programs-list] user_id=%s filter=%s provider=%s accessible_functions=%s",
         user.id,
         type_filter,
+        provider,
         accessible_functions,
     )
 
-    functions = ListFunctionsUseCase().execute(user, accessible_functions, type_filter)
-    logger.info("[programs-list] user_id=%s filter=%s | Functions listed ok", user.id, type_filter)
+    functions = ListFunctionsUseCase().execute(user, accessible_functions, type_filter, provider)
+    logger.info(
+        "[programs-list] user_id=%s filter=%s provider=%s | Functions listed ok",
+        user.id,
+        type_filter,
+        provider,
+    )
     return Response(OutputSerializer(functions, many=True).data)

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -330,6 +330,38 @@ class TestProgramApi(APITestCase):
         assert len(programs_response.data) == 1
         assert programs_response.data[0].get("title") == "Program"
 
+    def test_provider_programs_filtered_by_provider(self):
+        """Tests the provider query param narrows the catalog list to one provider."""
+
+        user = TestUtils.authorize_client(user="test_user_4", client=self.client)
+        TestUtils.get_or_create_group(group="runner", permissions=[self.runner_permission])
+        TestUtils.add_user_to_group(user=user, group="runner")
+
+        # Two accessible provider functions under different providers.
+        TestUtils.create_program(
+            program_title="Ibm-Program",
+            author="test_user_3",
+            provider="ibm",
+            instances=["runner"],
+        )
+        TestUtils.create_program(
+            program_title="QCtrl-Program",
+            author="test_user_3",
+            provider="q-ctrl",
+            instances=["runner"],
+        )
+
+        programs_response = self.client.get(
+            reverse("v1:programs-list"),
+            {"filter": "catalog", "provider": "q-ctrl"},
+            format="json",
+        )
+
+        assert programs_response.status_code == status.HTTP_200_OK
+        assert len(programs_response.data) == 1
+        assert programs_response.data[0].get("title") == "QCtrl-Program"
+        assert programs_response.data[0].get("provider") == "q-ctrl"
+
     def test_run(self):
         """Tests run existing authorized."""
 

--- a/gateway/tests/api/use_cases/programs/test_list.py
+++ b/gateway/tests/api/use_cases/programs/test_list.py
@@ -4,7 +4,9 @@ import pytest
 from django.contrib.auth.models import User
 
 from api.use_cases.programs.list import ListFunctionsUseCase
+from core.domain.authorization.function_access_entry import FunctionAccessEntry
 from core.domain.authorization.function_access_result import FunctionAccessResult
+from core.domain.business_models import BusinessModel
 from core.models import Program, Provider, PLATFORM_PERMISSION_READ
 from tests.utils import create_function_access_result
 
@@ -69,5 +71,41 @@ class TestListFunctionsUseCase:
         accessible = FunctionAccessResult(use_legacy_authorization=False, functions=[])
 
         result = ListFunctionsUseCase().execute(user, accessible, None)
+
+        assert result == []
+
+    def test_provider_filter_narrows_catalog_to_that_provider(self, user):
+        provider_a = Provider.objects.create(name="provider-a")
+        provider_b = Provider.objects.create(name="provider-b")
+        Program.objects.create(title="fn-a", author=user, provider=provider_a)
+        Program.objects.create(title="fn-b", author=user, provider=provider_b)
+        accessible = FunctionAccessResult(
+            use_legacy_authorization=False,
+            functions=[
+                FunctionAccessEntry(
+                    provider_name="provider-a",
+                    function_title="fn-a",
+                    business_model=BusinessModel.SUBSIDIZED,
+                    permissions={PLATFORM_PERMISSION_READ},
+                ),
+                FunctionAccessEntry(
+                    provider_name="provider-b",
+                    function_title="fn-b",
+                    business_model=BusinessModel.SUBSIDIZED,
+                    permissions={PLATFORM_PERMISSION_READ},
+                ),
+            ],
+        )
+
+        result = ListFunctionsUseCase().execute(user, accessible, "catalog", provider="provider-a")
+
+        assert [f.title for f in result] == ["fn-a"]
+
+    def test_provider_filter_does_not_bypass_permissions(self, user, provider):
+        # The function exists under the provider, but the user has no access to it.
+        Program.objects.create(title="provider-fn", author=user, provider=provider)
+        accessible = FunctionAccessResult(use_legacy_authorization=False, functions=[])
+
+        result = ListFunctionsUseCase().execute(user, accessible, "catalog", provider="my-provider")
 
         assert result == []

--- a/releasenotes/notes/list-functions-by-provider-cf1bd3b1a853c299.yaml
+++ b/releasenotes/notes/list-functions-by-provider-cf1bd3b1a853c299.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Listing Qiskit Functions now accepts a ``provider`` argument that returns only the
+    functions belonging to that provider::
+
+        client.functions(provider="q-ctrl")
+
+    The filter narrows the functions the caller can already see, so it never widens access,
+    and a provider the caller has no functions under returns an empty list.


### PR DESCRIPTION
## Summary

Closes internal issue.

As users gain access to more Qiskit Functions, the output of `catalog.list()` / `client.functions()` grows long and hard to scan, even more when `-dev` variants are included. This adds a `provider` filter so a user can narrow the list to a single provider:

```python
client.functions(provider="q-ctrl")
# -> [QiskitFunction(q-ctrl/performance-management),
#     QiskitFunction(q-ctrl/performance-management-dev), ...]
```

## Changes

- **Gateway view** (`api/v1/views/programs/list.py`): reads the `provider` query param, passes it to the use case, and documents it in the OpenAPI schema.
- **Use case** (`api/use_cases/programs/list.py`): applies `provider__name` filtering **after** permission scoping across all three branches (serverless / catalog / default), so it can only narrow the set the caller may already see — never widen access. An unknown or inaccessible provider yields an empty list. Reuses the existing `FunctionsQuerySet` filtering; no manager change.
- **Client** (`core/clients/serverless_client.py`, `core/client.py`): adds an explicit `provider` argument to `functions()` and the deprecated `list()`, for discoverability in the signature/docstring/autocomplete. Backwards compatible (the param was already forwarded via `**kwargs`).

## Tests

- Use case: provider filter narrows to one provider; provider filter does not bypass permissions.
- Integration: `GET /programs?filter=catalog&provider=q-ctrl` returns only that provider's functions.
- Client: `functions(provider="q-ctrl")` forwards `?provider=q-ctrl`.

## Release note

`releasenotes/notes/list-functions-by-provider-*.yaml` (features).