### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,8 +108,6 @@ docs/superpowers/
 # any logs
 *.log
 
-# Local AI assistant files: per-user settings and generated planning docs.
-# Shared skills under .claude/skills/ are tracked on purpose.
 .claude/*
 !.claude/skills/
 HANDOFF-*.md

--- a/.gitignore
+++ b/.gitignore
@@ -107,8 +107,16 @@ docs/superpowers/
 
 # any logs
 *.log
-.claude/settings.local.json
-hooks/
+
+# Local AI assistant files: per-user settings and generated planning docs.
+# Shared skills under .claude/skills/ are tracked on purpose.
+.claude/*
+!.claude/skills/
+HANDOFF-*.md
+
+# Local hook scripts at the repo root. Anchored, so a Helm chart's
+# templates/hooks/ directory stays tracked.
+/hooks/
 
 # Nix local dev environment
 flake.nix


### PR DESCRIPTION
### Summary

Ignores the local files that AI coding assistants leave behind in a checkout, and anchors the existing `hooks/` pattern to the repo root so it cannot swallow a Helm chart's `templates/hooks/` directory.

### Details and comments

Three changes, all in `.gitignore`.

`.claude/*` with `!.claude/skills/` replaces the single `.claude/settings.local.json` line. These tools write per-user settings, local planning docs and worktrees under `.claude/`, and none of that belongs in the repo, while `.claude/skills/` holds skills the team shares and stays tracked. Note that `.claude/` on its own would not work here: git does not descend into an excluded directory, so the negation would never be evaluated.

`HANDOFF-*.md` covers the hand-off notes those tools write between sessions.

`hooks/` becomes `/hooks/`. Without the leading slash the pattern matches any directory called `hooks` at any depth, and `templates/hooks/` is a Helm convention, so a chart hook added later would be ignored in silence. Nothing tracked matches it today, so this fixes a latent problem rather than a live one. The line was added for the `hooks/` directory at the repo root, and that keeps working.
