### PR TITLE
Read the Fleets task state without pinning the COS schema version

### DIFF
--- a/gateway/core/ibm_cloud/code_engine/fleets/cos.py
+++ b/gateway/core/ibm_cloud/code_engine/fleets/cos.py
@@ -21,22 +21,56 @@ from core.ibm_cloud.cos.cos_client import COSClient
 logger = logging.getLogger("FleetHandler")
 
 
-def queue_prefix(project_id: str, fleet_id: str) -> str:
+# Task-store schema versions, newest first. Code Engine writes the task state under a
+# version segment and only these two exist: v3 is the layout it is moving to, v2 the
+# layout of fleets created before the switch. Readers try them in this order.
+#
+# Cost, deliberately accepted: Code Engine still creates v2 fleets by default, so a
+# reader pays one empty v3 listing per poll before v2 answers. That doubles the listing
+# cost per running job for the transition, and it disappears on its own once Code Engine
+# switches to v3, because the first probe then answers. Memoizing the version per fleet
+# would remove it sooner at the price of process-wide mutable state.
+TASK_STORE_VERSIONS = ("v3", "v2")
+
+
+def queue_prefix(project_id: str, fleet_id: str, version: str = TASK_STORE_VERSIONS[0]) -> str:
     """Build the COS task-state queue key prefix for a fleet.
 
-    Single source for the ``ce/{project_id}/{fleet_id}/v2/queue/`` layout shared
-    by the status reader (FleetsRunner) and the fleets mock, so they cannot
+    Single source for the ``ce/{project_id}/{fleet_id}/{version}/queue/`` layout
+    shared by the status reader (FleetsRunner) and the fleets mock, so they cannot
     drift. The fleet-worker test image is a separate container and keeps a
     documented mirror of this format.
 
     Args:
         project_id: The CE project UUID.
         fleet_id: The fleet UUID.
+        version: Task-store schema version segment. Defaults to the newest.
 
     Returns:
         The queue key prefix, ending in a trailing slash.
     """
-    return f"ce/{project_id}/{fleet_id}/v2/queue/"
+    return f"ce/{project_id}/{fleet_id}/{version}/queue/"
+
+
+def task_state_from_key(prefix: str, key: str) -> str | None:
+    """Return the task state a queue key encodes, or ``None``.
+
+    The state is the first path segment after ``prefix``, whichever schema version
+    ``prefix`` carries, so no caller has to parse the version. Everything deeper in
+    the key (worker name, timestamps, task index, batch name) cannot be mistaken
+    for the state, which matters because the batch name is user supplied.
+
+    Args:
+        prefix: Queue prefix the key was listed under, ending in ``queue/``.
+        key: A COS object key.
+
+    Returns:
+        The lowercased state segment, or ``None`` when the key does not sit under
+        ``prefix`` or carries no state, such as a directory marker.
+    """
+    if not key.startswith(prefix):
+        return None
+    return key[len(prefix) :].split("/", 1)[0].strip().lower() or None
 
 
 class JobCOS:

--- a/gateway/core/services/runners/fleets_mock.py
+++ b/gateway/core/services/runners/fleets_mock.py
@@ -36,7 +36,7 @@ from ibm_botocore.exceptions import BotoCoreError, ClientError as BotoClientErro
 
 from core.ibm_cloud.clients import IBMCloudClientProvider
 from core.ibm_cloud.code_engine.ce_client.rest import ApiException
-from core.ibm_cloud.code_engine.fleets.cos import JobCOS, queue_prefix
+from core.ibm_cloud.code_engine.fleets.cos import JobCOS, queue_prefix, task_state_from_key
 from core.ibm_cloud.cos.cos_client import COSClient, CosHmacCredentials
 from core.models import CodeEngineProject
 
@@ -315,21 +315,25 @@ def _mock_get_job_status(self, identifier):  # pylint: disable=unused-argument
     bucket = _task_store_bucket(self.project_id)
     prefix = queue_prefix(self.project_id, fleet_id)
 
-    # Status segments the worker writes, in priority order. No '/canceling/':
-    # the harness never produces a canceling key (cancel writes '/canceled/'
-    # directly), so a branch for it would be dead code.
+    # Task states the worker writes, mapped to the CE API status strings this
+    # endpoint reports (the API says "successful" where the queue says
+    # "succeeded"). No "canceling": the harness never produces one, because cancel
+    # writes a "canceled" key directly. Defaults to "pending" on an empty listing
+    # because that is what the real CE API reports for a fresh fleet, unlike
+    # FleetsRunner.status() which returns None for "no state yet".
+    state_to_api_status = {
+        "succeeded": "successful",
+        "failed": "failed",
+        "canceled": "canceled",
+        "running": "running",
+        "pending": "pending",
+    }
     status = "pending"
     try:
         resp = s3.list_objects_v2(Bucket=bucket, Prefix=prefix)
-        keys = [obj["Key"] for obj in resp.get("Contents", [])]
-        for pattern, mapped in [
-            ("/succeeded/", "successful"),
-            ("/failed/", "failed"),
-            ("/canceled/", "canceled"),
-            ("/running/", "running"),
-            ("/pending/", "pending"),
-        ]:
-            if any(pattern in k for k in keys):
+        states = {task_state_from_key(prefix, obj["Key"]) for obj in resp.get("Contents", [])}
+        for state, mapped in state_to_api_status.items():
+            if state in states:
                 status = mapped
                 break
     except BotoClientError:

--- a/gateway/core/services/runners/fleets_runner.py
+++ b/gateway/core/services/runners/fleets_runner.py
@@ -30,7 +30,12 @@ from core.services.runners.abstract_runner import AbstractRunner, RunnerError
 from core.ibm_cloud import get_ce_auth, get_cos_client
 from core.utils import decrypt_env_vars
 from core.ibm_cloud.code_engine.fleets.handler import FleetHandler
-from core.ibm_cloud.code_engine.fleets.cos import JobCOS, queue_prefix
+from core.ibm_cloud.code_engine.fleets.cos import (
+    TASK_STORE_VERSIONS,
+    JobCOS,
+    queue_prefix,
+    task_state_from_key,
+)
 from core.ibm_cloud.code_engine.fleets.utils import (
     FleetJobPaths,
     build_job_paths,
@@ -39,6 +44,12 @@ from core.ibm_cloud.code_engine.fleets.utils import (
 )
 
 logger = logging.getLogger("FleetsRunner")
+
+# Fleets already warned about an unresolved task state. The scheduler is a single
+# long-lived, single-threaded process, so this keeps one warning per fleet instead of
+# one per poll. Bounded because a scheduler runs for weeks.
+_UNRESOLVED_WARNED: set[str] = set()
+_WARNED_FLEETS_LIMIT = 10_000
 
 
 def _retry_on_rate_limit(fn, retries=3, delays=(0.5, 1.0, 2.0)):
@@ -214,23 +225,30 @@ class FleetsRunner(AbstractRunner):
             logger.error("Failed to submit job_id=[%s]: %s", self.job.id, ex)
             raise RunnerError(f"Failed to submit job_id=[{self.job.id}] to Code Engine Fleets", ex) from ex
 
-    _COS_STATUS_PRIORITY = [
-        ("/succeeded/", Job.SUCCEEDED),
-        ("/failed/", Job.FAILED),
-        ("/canceled/", Job.STOPPED),
-        ("/canceling/", Job.STOPPED),
-        ("/running/", Job.RUNNING),
-        ("/pending/", Job.PENDING),
-    ]
+    # Task states Code Engine writes under ``{version}/queue/``, mapped to job
+    # statuses, in PRIORITY ORDER: a terminal state wins over running or pending when
+    # more than one state key is present. A tuple rather than a dict so the ordering
+    # is structural; sorting a dict of these alphabetically would put "pending" ahead
+    # of "succeeded" and report finished jobs as pending.
+    _STATE_TO_JOB_STATUS: tuple[tuple[str, str], ...] = (
+        ("succeeded", Job.SUCCEEDED),
+        ("failed", Job.FAILED),
+        ("canceled", Job.STOPPED),
+        ("canceling", Job.STOPPED),
+        ("running", Job.RUNNING),
+        ("pending", Job.PENDING),
+    )
 
     def status(self) -> str | None:
         """Return the job status by checking COS task state PDS bucket.
 
-        Reads keys under ``ce/{project_id}/{fleet_id}/v2/queue/`` and matches
-        against known status patterns in priority order.
+        Reads the task state from the first schema version in
+        ``TASK_STORE_VERSIONS`` that holds any key, so both the current and the
+        legacy layout work without pinning a version.
 
         Returns:
-            Mapped status string or ``None`` when COS has no state yet.
+            Mapped status string, or ``None`` when no state has been written yet,
+            the COS call failed, or no known state was found.
 
         Raises:
             RunnerError: On non-recoverable errors.
@@ -247,30 +265,94 @@ class FleetsRunner(AbstractRunner):
                 f"CodeEngineProject '{self._project.project_name}' has no cos_bucket_task_store_name configured"
             )
 
-        prefix = queue_prefix(self._project.project_id, self.job.fleet_id)
-        keys = self._list_task_state_keys(bucket, prefix)
+        prefix, keys = self._resolve_task_state_keys(bucket, self._project.project_id, self.job.fleet_id)
         if not keys:
-            # CE takes 10-15s after fleet creation to write the first queue/ key.
-            # Scheduler retries on next cycle.
+            # Either nothing written yet or the COS call failed; both are retried on
+            # the next scheduler cycle, and the scheduler bounds the wait.
+            logger.debug("Fleet [%s] has no task state key yet", self.job.fleet_id)
             return None
 
-        for pattern, status in self._COS_STATUS_PRIORITY:
-            for key in keys:
-                if pattern in key:
+        found: dict[str, str] = {}
+        for key in keys:
+            state = task_state_from_key(prefix, key)
+            if state:
+                found.setdefault(state, key)
+
+        for state, status in self._STATE_TO_JOB_STATUS:
+            if state in found:
+                _UNRESOLVED_WARNED.discard(self.job.fleet_id)
+                if status in Job.TERMINAL_STATUSES:
+                    # The segment after the state is the result code, so a terminal
+                    # state alone does not prove the task exited zero. Log the whole
+                    # key to keep that answerable from production logs. Taking any
+                    # terminal key is only correct because a job runs a single task
+                    # (tasks_specification indices "0" in submit()).
+                    logger.info("Fleet [%s] reached %s from key %s", self.job.fleet_id, status, found[state])
+                else:
                     logger.debug("Fleet [%s] COS status: %s", self.job.fleet_id, status)
-                    return status
+                return status
 
-        raise RunnerError(f"Unrecognized COS task state for fleet [{self.job.fleet_id}]: {keys}")
+        self._warn_unresolved_state(prefix, keys, found)
+        return None
 
-    def _list_task_state_keys(self, bucket: str, prefix: str) -> list[str]:
-        """List task state keys from COS, returning empty list on failure.
+    def _warn_unresolved_state(self, prefix: str, keys: list[str], found: dict[str, str]) -> None:
+        """Report a listing that held keys but no state this gateway recognises.
+
+        Warns once per fleet rather than once per poll: the scheduler re-polls every
+        running job roughly every second, and the condition this reports, a Code Engine
+        state rename, would hit every fleet at once and bury the logs exactly when they
+        are needed.
+
+        Args:
+            prefix: The queue prefix that was read.
+            keys: The keys found under it.
+            found: States parsed from those keys, mapped to the key that produced each.
+        """
+        message = "Fleet [%s] has %s task state key(s) under %s but no known state (found %s, samples %s)"
+        args = (self.job.fleet_id, len(keys), prefix, sorted(found), keys[:3])
+        if self.job.fleet_id in _UNRESOLVED_WARNED:
+            logger.debug(message, *args)
+            return
+        if len(_UNRESOLVED_WARNED) >= _WARNED_FLEETS_LIMIT:
+            _UNRESOLVED_WARNED.clear()
+        _UNRESOLVED_WARNED.add(self.job.fleet_id)
+        logger.warning(message, *args)
+
+    def _resolve_task_state_keys(self, bucket: str, project_id: str, fleet_id: str) -> tuple[str, list[str]]:
+        """Find the queue prefix holding this fleet's task state, with its keys.
+
+        Args:
+            bucket: COS bucket name to query.
+            project_id: The CE project UUID.
+            fleet_id: The fleet UUID.
+
+        Returns:
+            The prefix that was read and the keys under it. The key list is empty
+            when no version holds any state yet, or when a COS call failed.
+        """
+        prefix = ""
+        for version in TASK_STORE_VERSIONS:
+            prefix = queue_prefix(project_id, fleet_id, version)
+            keys = self._list_task_state_keys(bucket, prefix)
+            if keys is None:
+                # COS is unreachable, so probing the other versions would only
+                # repeat the same failure and the same warning.
+                return prefix, []
+            if keys:
+                return prefix, keys
+        return prefix, []
+
+    def _list_task_state_keys(self, bucket: str, prefix: str) -> list[str] | None:
+        """List task state keys from COS.
 
         Args:
             bucket: COS bucket name to query.
             prefix: Key prefix to filter results.
 
         Returns:
-            List of matching key strings, or an empty list if the COS call fails.
+            The matching keys, or ``None`` when the COS call failed. An empty list
+            means the prefix genuinely holds nothing, which callers must be able to
+            tell apart from a failure.
         """
         try:
             return self._get_cos().list_keys(bucket_name=bucket, prefix=prefix)
@@ -279,12 +361,12 @@ class FleetsRunner(AbstractRunner):
             logger.warning(
                 "COS list_keys failed for fleet [%s] (code=%s); will retry on next cycle", self.job.fleet_id, code
             )
-            return []
+            return None
         except ValueError:
             raise
         except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.warning("COS list_keys failed for fleet [%s]: %s; will retry on next cycle", self.job.fleet_id, exc)
-            return []
+            return None
 
     def get_result_from_cos(self) -> str | None:
         """Retrieve job results from COS.

--- a/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
+++ b/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
@@ -65,6 +65,10 @@ class UpdateFleetsJobsStatuses(SchedulerTask):
 
         if new_status is None:
             logger.debug("job_id=%s status poll returned None (no COS state yet), skipping update", job.id)
+            # Without this the job is immortal: no other scheduler task touches a
+            # PENDING or RUNNING Fleets job, so a status that never resolves would
+            # hold the user's concurrency slot forever.
+            self.stop_job_if_timeout(job)
             return False
 
         if new_status == Job.SUCCEEDED:

--- a/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_job_cos_unit.py
+++ b/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_job_cos_unit.py
@@ -22,7 +22,12 @@ import pytest
 from core.ibm_cloud.code_engine.ce_client.rest import ApiException
 from core.ibm_cloud import get_cos_client
 from core.ibm_cloud.clients import COS_PUBLIC_URL_TEMPLATE
-from core.ibm_cloud.code_engine.fleets.cos import JobCOS
+from core.ibm_cloud.code_engine.fleets.cos import (
+    TASK_STORE_VERSIONS,
+    JobCOS,
+    queue_prefix,
+    task_state_from_key,
+)
 
 _IBM_CLOUD_MOD = "core.ibm_cloud"
 
@@ -307,3 +312,52 @@ def test_get_cos_client_raises_when_hmac_secret_name_missing() -> None:
 
         with pytest.raises(ValueError, match="CE_HMAC_SECRET_NAME"):
             get_cos_client(project)
+
+
+class TestQueuePrefixAndState:
+    """The task-store layout helpers, which the status reader depends on."""
+
+    def test_queue_prefix_defaults_to_the_newest_version(self):
+        """A writer that names no version writes the layout Code Engine uses now."""
+        assert queue_prefix("proj", "fleet") == "ce/proj/fleet/v3/queue/"
+        assert TASK_STORE_VERSIONS[0] == "v3"
+
+    def test_queue_prefix_accepts_the_legacy_version(self):
+        """Readers walk older versions, so the prefix has to be buildable for them."""
+        assert queue_prefix("proj", "fleet", "v2") == "ce/proj/fleet/v2/queue/"
+
+    def test_state_is_the_segment_after_the_prefix(self):
+        """Segment orders differ per state, so only the first one may be read.
+
+        Keys are the real shapes observed on a v3 fleet: pending carries a retry
+        count, running a worker and two timestamps, succeeded a result code first.
+        """
+        prefix = queue_prefix("proj", "fleet")
+        cases = {
+            f"{prefix}pending/000-00000-0/default/0/2026-08-26T19:09:39Z/uuid": "pending",
+            f"{prefix}running/fleet-0/2026-08-26T19:10:14Z/2026-08-26T19:09:39Z/000-00000-0/default/uuid": "running",
+            f"{prefix}succeeded/exit_0/fleet-0/t2/t1/t0/000-00000-0/default/uuid": "succeeded",
+        }
+        for key, expected in cases.items():
+            assert task_state_from_key(prefix, key) == expected
+
+    def test_state_is_read_whatever_the_version_segment_is(self):
+        """The helper never parses the version, so any version works."""
+        for version in ("v2", "v3", "v9", "rev-two"):
+            prefix = queue_prefix("proj", "fleet", version)
+            assert task_state_from_key(prefix, f"{prefix}succeeded/exit_0/rest") == "succeeded"
+
+    def test_key_outside_the_prefix_has_no_state(self):
+        """A key from another version must not be read as if it were this one."""
+        assert task_state_from_key(queue_prefix("proj", "fleet", "v3"), "ce/proj/fleet/v2/queue/succeeded/0/x") is None
+
+    def test_directory_marker_has_no_state(self):
+        """A zero-byte marker for the prefix itself carries nothing."""
+        prefix = queue_prefix("proj", "fleet")
+        assert task_state_from_key(prefix, prefix) is None
+
+    def test_deeper_segments_cannot_be_mistaken_for_the_state(self):
+        """The batch name is user supplied, so it must not be able to forge a state."""
+        prefix = queue_prefix("proj", "fleet")
+        key = f"{prefix}pending/000-00000-0/succeeded/0/2026-08-26T19:09:39Z/uuid"
+        assert task_state_from_key(prefix, key) == "pending"

--- a/gateway/tests/core/services/runners/test_fleets_runner.py
+++ b/gateway/tests/core/services/runners/test_fleets_runner.py
@@ -22,6 +22,7 @@ from core.ibm_cloud.code_engine.ce_client.rest import ApiException
 from core.ibm_cloud.code_engine.fleets.utils import FleetJobPaths, build_job_paths
 from core.models import Job, Program
 from core.services.runners.abstract_runner import RunnerError
+from core.services.runners import fleets_runner as fleets_runner_module
 from core.services.runners.fleets_runner import FleetsRunner
 
 _RUNNER_MOD = "core.services.runners.fleets_runner"
@@ -154,6 +155,61 @@ def test_status_raises_runner_error_when_no_fleet_id():
         runner.status()
 
 
+@pytest.fixture(autouse=True)
+def _clear_unresolved_warned():
+    """Keep tests independent of the runner's per-fleet warning throttle.
+
+    The throttle is module state so the scheduler warns once per fleet rather than
+    once per poll, which would otherwise make these tests order dependent.
+    """
+    fleets_runner_module._UNRESOLVED_WARNED.clear()
+    yield
+    fleets_runner_module._UNRESOLVED_WARNED.clear()
+
+
+def _cos_by_version(keys_by_version):
+    """Build a ``list_keys`` stub that answers per task-store schema version.
+
+    status() lists one version prefix at a time, so a stub with a single
+    return_value would hand v2 keys back when the runner asked for v3.
+
+    Args:
+        keys_by_version: Mapping of version segment ("v3", "v2") to the keys that
+            version holds.
+
+    Returns:
+        A callable suitable for ``list_keys.side_effect``.
+    """
+
+    def _list_keys(*, bucket_name, prefix):  # pylint: disable=unused-argument
+        for version, keys in keys_by_version.items():
+            if f"/{version}/queue/" in prefix:
+                return keys
+        return []
+
+    return _list_keys
+
+
+_V3 = "ce/test-project-id/fleet-123/v3/queue/"
+_V2 = "ce/test-project-id/fleet-123/v2/queue/"
+_TASK = "000-00000-0/default/8d76aa17-efb0-56da-88fd-488e8444b46d"
+_WORKER = "fleet-123-0"
+_T0, _T1, _T2 = "2026-08-26T19:09:39Z", "2026-08-26T19:10:14Z", "2026-08-26T19:11:05Z"
+
+# Segment orders observed on real v3 fleets in staging (pending, running, succeeded, failed).
+# Note succeeded and failed use different result-code forms, "exit_0" against
+# "error_exit_1", and failed carries an extra retry segment, which is precisely why the
+# reader reads only the state segment and treats the rest as opaque. The canceled shape
+# is the documented one rather than a measured one: cancelling a real fleet wrote no
+# canceled queue key at all, on either schema version, so only our test harness
+# produces one.
+_V3_PENDING = f"{_V3}pending/000-00000-0/default/0/{_T0}/8d76aa17"
+_V3_RUNNING = f"{_V3}running/{_WORKER}/{_T1}/{_T0}/{_TASK}"
+_V3_SUCCEEDED = f"{_V3}succeeded/exit_0/{_WORKER}/{_T2}/{_T1}/{_T0}/{_TASK}"
+_V3_FAILED = f"{_V3}failed/error_exit_1/{_WORKER}/{_T2}/{_T1}/{_T0}/0/{_TASK}"
+_V3_CANCELED = f"{_V3}canceled/{_WORKER}/{_T2}/{_T1}/{_T0}/{_TASK}"
+
+
 def test_status_returns_none_when_cos_empty():
     """status() returns None when COS has no keys yet (fleet just created)."""
     runner, _ = _make_runner(fleet_id="fleet-123")
@@ -165,80 +221,97 @@ def test_status_returns_none_when_cos_empty():
 class TestCosStatusDetection:
     """Tests for COS-based fleet status detection."""
 
-    def test_cos_succeeded_returns_succeeded(self):
-        """status() returns SUCCEEDED when COS has a succeeded key."""
+    def test_v3_pending_returns_pending(self):
+        """status() returns PENDING from a v3 pending key."""
         runner, mock_handler = _make_runner(fleet_id="fleet-123")
-        runner._cos.list_keys.return_value = [
-            "ce/test-project-id/fleet-123/v2/queue/succeeded/0/fleet-123-0/2026-01-01T00:00:00Z/..."
-        ]
+        runner._cos.list_keys.side_effect = _cos_by_version({"v3": [_V3_PENDING]})
 
-        result = runner.status()
-
-        assert result == Job.SUCCEEDED
+        assert runner.status() == Job.PENDING
         mock_handler.get_job_status.assert_not_called()
 
-    def test_cos_failed_returns_failed(self):
-        """status() returns FAILED when COS has a failed key."""
-        runner, mock_handler = _make_runner(fleet_id="fleet-123")
-        runner._cos.list_keys.return_value = [
-            "ce/test-project-id/fleet-123/v2/queue/failed/1/fleet-123-0/2026-01-01T00:00:00Z/..."
-        ]
-
-        result = runner.status()
-
-        assert result == Job.FAILED
-        mock_handler.get_job_status.assert_not_called()
-
-    def test_cos_running_returns_running(self):
-        """status() returns RUNNING when COS has a running key."""
-        runner, mock_handler = _make_runner(fleet_id="fleet-123")
-        runner._cos.list_keys.return_value = [
-            "ce/test-project-id/fleet-123/v2/queue/running/fleet-123-0/2026-01-01T00:00:00Z/..."
-        ]
-
-        result = runner.status()
-
-        assert result == Job.RUNNING
-        mock_handler.get_job_status.assert_not_called()
-
-    def test_cos_pending_returns_pending(self):
-        """status() returns PENDING when COS has only a pending key."""
-        runner, mock_handler = _make_runner(fleet_id="fleet-123")
-        runner._cos.list_keys.return_value = [
-            "ce/test-project-id/fleet-123/v2/queue/pending/000-00000-0/2026-01-01T00:00:00Z/..."
-        ]
-
-        result = runner.status()
-
-        assert result == Job.PENDING
-        mock_handler.get_job_status.assert_not_called()
-
-    def test_cos_terminal_takes_priority_over_running(self):
-        """status() returns SUCCEEDED even if running key is also present."""
-        runner, mock_handler = _make_runner(fleet_id="fleet-123")
-        runner._cos.list_keys.return_value = [
-            "ce/test-project-id/fleet-123/v2/queue/running/fleet-123-0/...",
-            "ce/test-project-id/fleet-123/v2/queue/succeeded/0/fleet-123-0/...",
-        ]
-
-        result = runner.status()
-
-        assert result == Job.SUCCEEDED
-
-    def test_cos_unrecognized_keys_raises_runner_error(self):
-        """status() raises RunnerError when COS keys don't match any known pattern."""
+    def test_v3_running_returns_running(self):
+        """status() returns RUNNING from a v3 running key."""
         runner, _ = _make_runner(fleet_id="fleet-123")
-        runner._cos.list_keys.return_value = ["ce/test-project-id/fleet-123/v2/queue/unknown-state/..."]
+        runner._cos.list_keys.side_effect = _cos_by_version({"v3": [_V3_RUNNING]})
 
-        with pytest.raises(RunnerError, match="Unrecognized COS task state"):
-            runner.status()
+        assert runner.status() == Job.RUNNING
 
-    def test_cos_exception_returns_none(self):
-        """status() returns None when COS list_keys raises."""
+    def test_v3_succeeded_returns_succeeded(self):
+        """status() returns SUCCEEDED from a v3 succeeded key, result code and all."""
+        runner, _ = _make_runner(fleet_id="fleet-123")
+        runner._cos.list_keys.side_effect = _cos_by_version({"v3": [_V3_SUCCEEDED]})
+
+        assert runner.status() == Job.SUCCEEDED
+
+    def test_v3_failed_returns_failed(self):
+        """status() returns FAILED from a v3 failed key."""
+        runner, _ = _make_runner(fleet_id="fleet-123")
+        runner._cos.list_keys.side_effect = _cos_by_version({"v3": [_V3_FAILED]})
+
+        assert runner.status() == Job.FAILED
+
+    def test_v3_canceled_returns_stopped(self):
+        """status() returns STOPPED from a v3 canceled key."""
+        runner, _ = _make_runner(fleet_id="fleet-123")
+        runner._cos.list_keys.side_effect = _cos_by_version({"v3": [_V3_CANCELED]})
+
+        assert runner.status() == Job.STOPPED
+
+    def test_v2_keys_still_read_through_the_fallback(self):
+        """A fleet on the legacy layout is read when v3 holds nothing."""
+        runner, _ = _make_runner(fleet_id="fleet-123")
+        runner._cos.list_keys.side_effect = _cos_by_version(
+            {"v2": [f"{_V2}succeeded/0/{_WORKER}/2026-01-01T00:00:00Z/..."]}
+        )
+
+        assert runner.status() == Job.SUCCEEDED
+        assert runner._cos.list_keys.call_count == 2
+
+    def test_terminal_state_takes_priority_over_running(self):
+        """A terminal key wins even when a running key is present too."""
+        runner, _ = _make_runner(fleet_id="fleet-123")
+        runner._cos.list_keys.side_effect = _cos_by_version({"v3": [_V3_RUNNING, _V3_SUCCEEDED]})
+
+        assert runner.status() == Job.SUCCEEDED
+
+    def test_batch_name_cannot_forge_a_terminal_state(self):
+        """A batch named after a state does not change the answer.
+
+        The batch name is user supplied and appears deeper in the key, so only the
+        segment straight after ``queue/`` may decide the status.
+        """
+        runner, _ = _make_runner(fleet_id="fleet-123")
+        runner._cos.list_keys.side_effect = _cos_by_version(
+            {"v3": [f"{_V3}pending/000-00000-0/succeeded/0/{_T0}/8d76aa17"]}
+        )
+
+        assert runner.status() == Job.PENDING
+
+    def test_directory_marker_alone_returns_none(self):
+        """A zero-byte ``queue/`` marker carries no state."""
+        runner, _ = _make_runner(fleet_id="fleet-123")
+        runner._cos.list_keys.side_effect = _cos_by_version({"v3": [_V3]})
+
+        assert runner.status() is None
+
+    def test_unknown_state_returns_none_without_raising(self):
+        """An unrecognised state is reported as no status, never as a failure.
+
+        Raising here would make the scheduler mark the job FAILED, so a single
+        Code Engine rename would fail every in-flight job at once.
+        """
+        runner, _ = _make_runner(fleet_id="fleet-123")
+        runner._cos.list_keys.side_effect = _cos_by_version({"v3": [f"{_V3}unknown-state/x"]})
+
+        assert runner.status() is None
+
+    def test_cos_failure_does_not_probe_the_other_version(self):
+        """A COS fault stops the version walk instead of repeating the failure."""
         runner, _ = _make_runner(fleet_id="fleet-123")
         runner._cos.list_keys.side_effect = Exception("connection error")
 
         assert runner.status() is None
+        assert runner._cos.list_keys.call_count == 1
 
     def test_cos_client_error_returns_none(self):
         """status() returns None when COS raises ClientError."""

--- a/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
+++ b/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
@@ -131,6 +131,7 @@ class TestUpdateJobStatus:
 
         with (
             patch(f"{_MOD}.get_runner", return_value=mock_runner),
+            patch.object(task, "stop_job_if_timeout"),
             patch.object(task, "to_terminal") as mock_terminal,
             patch.object(task, "to_running") as mock_running,
         ):
@@ -150,6 +151,7 @@ class TestUpdateJobStatus:
 
         with (
             patch(f"{_MOD}.get_runner", return_value=mock_runner),
+            patch.object(task, "stop_job_if_timeout"),
             patch.object(task, "to_terminal") as mock_terminal,
         ):
             result = task.update_job_status(job)
@@ -157,6 +159,27 @@ class TestUpdateJobStatus:
         assert result is False
         mock_terminal.assert_not_called()
         assert job.status == Job.PENDING
+
+    def test_none_status_still_checks_the_timeout(self):
+        """A job whose status never resolves must still be bounded.
+
+        Nothing else in the scheduler touches a PENDING or RUNNING Fleets job, so
+        without this the job holds the user's concurrency slot forever. This is the
+        regression guard for that.
+        """
+        task = _make_task()
+        job = _make_fleets_job(status=Job.PENDING)
+
+        mock_runner = MagicMock()
+        mock_runner.status.return_value = None
+
+        with (
+            patch(f"{_MOD}.get_runner", return_value=mock_runner),
+            patch.object(task, "stop_job_if_timeout") as mock_timeout,
+        ):
+            task.update_job_status(job)
+
+        mock_timeout.assert_called_once_with(job)
 
     def test_unknown_status_calls_to_terminal_failed(self):
         task = _make_task()

--- a/releasenotes/notes/fleets-task-store-version-agnostic-08e848ab66518811.yaml
+++ b/releasenotes/notes/fleets-task-store-version-agnostic-08e848ab66518811.yaml
@@ -1,0 +1,23 @@
+---
+fixes:
+  - |
+    Fleets job status is now read from the Code Engine task store without pinning the
+    schema version. Code Engine has moved that layout from ``v2/queue/`` to
+    ``v3/queue/``, and the gateway listed the ``v2`` prefix only, so a fleet created on
+    the new layout returned no keys at all and its job stayed ``PENDING``. The reader
+    now tries the newest version first and falls back to the older one, so fleets on
+    either layout are tracked.
+  - |
+    A Fleets job whose status cannot be read no longer stays active forever. The
+    scheduler skipped its timeout check whenever a status poll returned nothing, so a
+    job with an unreadable task state, whether from the layout change, a Cloud Object
+    Storage outage or a task-store permission change, was never stopped and held one of
+    the user's concurrent job slots indefinitely. Such a job is now stopped once it
+    passes ``PROGRAM_TIMEOUT``, which releases the slot. Note this marks the job
+    ``STOPPED`` and does not itself tear down the Code Engine fleet; fleet cleanup is
+    unchanged by this release.
+upgrade:
+  - |
+    An unrecognised task state in the Code Engine task store no longer fails the job.
+    It is logged by name and treated as "no status yet", so a future Code Engine
+    change to the state names cannot mark every in-flight job as ``FAILED`` at once.

--- a/tests/fleets/_helpers.py
+++ b/tests/fleets/_helpers.py
@@ -102,24 +102,28 @@ def assert_presigned_cos_redirect(serverless_client, job_id, artifact):
     return fetched
 
 
-def wait_for_s3_key_substring(minio_client, bucket, substring, timeout=30):
-    """Poll a bucket until any object key contains ``substring``.
+def wait_for_s3_key_substring(minio_client, bucket, substrings, timeout=30):
+    """Poll a bucket until one object key contains every given substring.
+
+    Taking a list lets a caller pin the parts of a key it cares about without pinning
+    the parts it does not, such as the task-store schema version.
 
     Args:
         minio_client: A boto3 S3 client.
         bucket: The bucket to search.
-        substring: The substring an object key must contain.
+        substrings: Substrings that must all appear in the same object key.
         timeout: Maximum seconds to wait.
 
     Returns:
         True if a matching key appears within the timeout, else False.
     """
+    needles = list(substrings)
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
             for page in minio_client.get_paginator("list_objects_v2").paginate(Bucket=bucket):
                 for obj in page.get("Contents", []):
-                    if substring in obj["Key"]:
+                    if all(needle in obj["Key"] for needle in needles):
                         return True
         except ClientError:
             pass

--- a/tests/fleets/fleet-worker/worker.py
+++ b/tests/fleets/fleet-worker/worker.py
@@ -154,7 +154,10 @@ class FleetWorker:  # pylint: disable=too-few-public-methods
             logger.info("Fleet %s canceled — leaving the cancel key as terminal state", fleet_id)
         else:
             try:
-                self._write_cos_queue_key(project_id, fleet_id, f"{status}/{exit_code}")
+                # Measured in staging: real CE writes ``exit_<n>`` on success but
+                # ``error_exit_<n>`` on failure, so mirror both forms here.
+                code = f"exit_{exit_code}" if status == "succeeded" else f"error_exit_{exit_code}"
+                self._write_cos_queue_key(project_id, fleet_id, f"{status}/{code}")
             except (ClientError, BotoCoreError) as write_err:
                 logger.error("Failed to write terminal status for %s: %s", fleet_id, write_err)
 
@@ -320,9 +323,10 @@ class FleetWorker:  # pylint: disable=too-few-public-methods
     def _queue_prefix(project_id: str, fleet_id: str) -> str:
         """Build the COS task-state queue key prefix for a fleet.
 
-        Single source for the ``ce/{project}/{fleet}/v2/queue/`` layout so the
+        Single source for the ``ce/{project}/{fleet}/v3/queue/`` layout so the
         cancel reader and the status writer cannot drift apart. Must stay in
-        sync with the gateway FleetsRunner prefix.
+        sync with the gateway's TASK_STORE_VERSIONS[0] (fleets/cos.py); the
+        gateway reads v2 as well, but the harness only ever writes the newest.
 
         Args:
             project_id: The CE project UUID.
@@ -331,7 +335,7 @@ class FleetWorker:  # pylint: disable=too-few-public-methods
         Returns:
             The queue key prefix, ending in a trailing slash.
         """
-        return f"ce/{project_id}/{fleet_id}/v2/queue/"
+        return f"ce/{project_id}/{fleet_id}/v3/queue/"
 
     def _is_canceled(self, project_id: str, fleet_id: str) -> bool:
         """Check if a canceled queue key exists for this job.

--- a/tests/fleets/test_fleets_jobs.py
+++ b/tests/fleets/test_fleets_jobs.py
@@ -351,6 +351,9 @@ class TestFleetsJobs:
         # Verify the cancel actually propagated to the COS task-store (the layer
         # the worker consumes), not just the gateway's synchronous STOPPED write.
         fleet_id = row[1]
+        # Deliberately not pinning the task-store schema version: the gateway reads
+        # whichever version Code Engine wrote, so the test asserts the fleet and the
+        # state, not the layout revision.
         assert wait_for_s3_key_substring(
-            minio_client, "task-store-bucket", f"{fleet_id}/v2/queue/canceled/", timeout=30
+            minio_client, "task-store-bucket", [f"{fleet_id}/", "/queue/canceled/"], timeout=30
         ), f"cancel did not propagate to a COS canceled key for fleet {fleet_id}"


### PR DESCRIPTION
### Summary

Code Engine is moving the COS task-store layout from `v2/queue/` to `v3/queue/`. The gateway hardcoded `v2`, so a fleet on the new layout returns no keys and its job never finishes: `status()` returns `None`, the `None` branch skipped the timeout check, and no other scheduler task touches a PENDING or RUNNING Fleets job, so it held the user's concurrency slot indefinitely.

### Details and comments

The reader now tries v3 then v2 and takes the state from the first segment after `queue/`, so no version is pinned. Nothing else in the key is parsed, because segment counts and result codes differ per state (`succeeded/exit_0` against `failed/error_exit_1`).

An unrecognised state returns no status with a warning instead of raising. Raising marked the job FAILED irreversibly and emitted a billing event, so one rename upstream would have failed every in-flight job in a single scheduler tick.

Code Engine still creates v2 fleets today, so the fallback is the live path and this can merge ahead of the switch. Checked against real staging fleets on both layouts, and the fleets integration stack now writes v3 keys.
