### PR TITLE
Add job started at

### DIFF
--- a/gateway/core/ibm_cloud/event_streams/kafka_event_streams_client.py
+++ b/gateway/core/ibm_cloud/event_streams/kafka_event_streams_client.py
@@ -169,8 +169,8 @@ class KafkaEventStreamsClient(EventStreamsClient):
             "instance_crn": job.instance_crn,
             "resource_id": str(job.id),
             "job_started": job_started,
+            "job_started_at": job.running_started_at.isoformat() if job.running_started_at else None,
             "job_completed": job_completed,
-            "job_started_at": job.running_started_at,
         }
         if business_model is not None:
             data["business_model"] = business_model

--- a/gateway/core/ibm_cloud/event_streams/kafka_event_streams_client.py
+++ b/gateway/core/ibm_cloud/event_streams/kafka_event_streams_client.py
@@ -152,7 +152,7 @@ class KafkaEventStreamsClient(EventStreamsClient):
 
     def _publish(
         self,
-        job,
+        job: Job,
         *,
         metric_type: str,
         metric_value: int,
@@ -170,6 +170,7 @@ class KafkaEventStreamsClient(EventStreamsClient):
             "resource_id": str(job.id),
             "job_started": job_started,
             "job_completed": job_completed,
+            "job_started_at": job.running_started_at,
         }
         if business_model is not None:
             data["business_model"] = business_model

--- a/gateway/tests/core/services/ibm_cloud/event_streams/test_event_streams_client.py
+++ b/gateway/tests/core/services/ibm_cloud/event_streams/test_event_streams_client.py
@@ -130,6 +130,7 @@ class TestKafkaEventStreamsClient:
             "resource_id": str(job.id),
             "job_started": True,
             "job_completed": False,
+            "job_started_at": job.running_started_at,
         }
         assert call_kwargs["key"] == str(job.id).encode("utf-8")
         mock_producer.flush.assert_called_once()
@@ -162,6 +163,7 @@ class TestKafkaEventStreamsClient:
         assert published["data"]["metric_value"] == 5_000
         assert published["data"]["job_started"] is False
         assert published["data"]["job_completed"] is False
+        assert published["data"]["job_started_at"] == started_at
 
     def test_emit_job_completed_computes_usage_milliseconds(self):
         started_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
@@ -191,6 +193,7 @@ class TestKafkaEventStreamsClient:
         assert published["data"]["metric_value"] == 30_000
         assert published["data"]["job_started"] is False
         assert published["data"]["job_completed"] is True
+        assert published["data"]["job_started_at"] == started_at
 
     def test_emit_raises_when_flush_times_out(self):
         job = _make_job()
@@ -239,6 +242,7 @@ class TestKafkaEventStreamsClient:
 
         published = json.loads(mock_producer.produce.call_args[1]["value"])
         assert published["data"]["metric_value"] == 0
+        assert published["data"]["job_started_at"] is None
 
     def test_emit_license_fee_publishes_correct_payload(self):
         job = _make_job()
@@ -280,6 +284,7 @@ class TestKafkaEventStreamsClient:
             "resource_id": str(job.id),
             "job_started": True,
             "job_completed": True,
+            "job_started_at": job.running_started_at,
             "business_model": "licensed",
         }
         assert call_kwargs["key"] == str(job.id).encode("utf-8")
@@ -343,3 +348,4 @@ class TestKafkaEventStreamsClient:
 
         published = json.loads(mock_producer.produce.call_args[1]["value"])
         assert "business_model" not in published["data"]
+        assert published["data"]["job_started_at"] == job.running_started_at

--- a/gateway/tests/core/services/ibm_cloud/event_streams/test_event_streams_client.py
+++ b/gateway/tests/core/services/ibm_cloud/event_streams/test_event_streams_client.py
@@ -130,7 +130,7 @@ class TestKafkaEventStreamsClient:
             "resource_id": str(job.id),
             "job_started": True,
             "job_completed": False,
-            "job_started_at": job.running_started_at,
+            "job_started_at": job.running_started_at.isoformat(),
         }
         assert call_kwargs["key"] == str(job.id).encode("utf-8")
         mock_producer.flush.assert_called_once()
@@ -163,7 +163,7 @@ class TestKafkaEventStreamsClient:
         assert published["data"]["metric_value"] == 5_000
         assert published["data"]["job_started"] is False
         assert published["data"]["job_completed"] is False
-        assert published["data"]["job_started_at"] == started_at
+        assert published["data"]["job_started_at"] == started_at.isoformat()
 
     def test_emit_job_completed_computes_usage_milliseconds(self):
         started_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
@@ -193,7 +193,7 @@ class TestKafkaEventStreamsClient:
         assert published["data"]["metric_value"] == 30_000
         assert published["data"]["job_started"] is False
         assert published["data"]["job_completed"] is True
-        assert published["data"]["job_started_at"] == started_at
+        assert published["data"]["job_started_at"] == started_at.isoformat()
 
     def test_emit_raises_when_flush_times_out(self):
         job = _make_job()
@@ -284,7 +284,7 @@ class TestKafkaEventStreamsClient:
             "resource_id": str(job.id),
             "job_started": True,
             "job_completed": True,
-            "job_started_at": job.running_started_at,
+            "job_started_at": job.running_started_at.isoformat(),
             "business_model": "licensed",
         }
         assert call_kwargs["key"] == str(job.id).encode("utf-8")
@@ -348,4 +348,4 @@ class TestKafkaEventStreamsClient:
 
         published = json.loads(mock_producer.produce.call_args[1]["value"])
         assert "business_model" not in published["data"]
-        assert published["data"]["job_started_at"] == job.running_started_at
+        assert published["data"]["job_started_at"] == job.running_started_at.isoformat()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

### Summary

Add "job_started_at" as new data for kafka events

### Details and comments



### Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a [release note](https://github.com/Qiskit/qiskit-serverless/blob/main/CONTRIBUTING.md#release-notes) for any user-facing change (new feature, bug fix, deprecation, or breaking change), or this PR has no user-facing changes.
