### PR TITLE
Fix backoffice dashboard status colors and bar chart

### DIFF
--- a/gateway/api/static/admin/css/admin_dashboard.css
+++ b/gateway/api/static/admin/css/admin_dashboard.css
@@ -116,10 +116,6 @@
     background: var(--primary);
 }
 
-.qs-bar-fill--dim {
-    background: #a6c8ff; /* blue-20, for Failed/Stopped */
-}
-
 .qs-bar-val {
     font-size: 0.6875rem;
     font-weight: 600;

--- a/gateway/api/static/admin/css/admin_job_event_inline.css
+++ b/gateway/api/static/admin/css/admin_job_event_inline.css
@@ -9,7 +9,7 @@
     background-color: var(--event-color, #ff00ff);
 }
 
-.event-badge[data-event-status="QUEUED"] { --event-color: #8d8d8d; }
+.event-badge[data-event-status="QUEUED"] { --event-color: #8a3ffc; }
 .event-badge[data-event-status="PENDING"] { --event-color: #f0ad4e; }
 
 .event-badge[data-event-status="RUNNING"],

--- a/gateway/api/static/admin/css/admin_job_event_inline.css
+++ b/gateway/api/static/admin/css/admin_job_event_inline.css
@@ -9,7 +9,7 @@
     background-color: var(--event-color, #ff00ff);
 }
 
-.event-badge[data-event-status="QUEUED"] { --event-color: #f0ad4e; }
+.event-badge[data-event-status="QUEUED"] { --event-color: #8d8d8d; }
 .event-badge[data-event-status="PENDING"] { --event-color: #f0ad4e; }
 
 .event-badge[data-event-status="RUNNING"],

--- a/gateway/api/static/admin/css/carbon_theme.css
+++ b/gateway/api/static/admin/css/carbon_theme.css
@@ -924,7 +924,7 @@ body.login #content h1 {
     background-color: var(--qs-badge-bg, #6f6f6f);
 }
 
-.qs-status-badge[data-status="QUEUED"] { --qs-badge-bg: #8d8d8d; }
+.qs-status-badge[data-status="QUEUED"] { --qs-badge-bg: #8a3ffc; }
 
 .qs-status-badge[data-status="PENDING"] {
     --qs-badge-bg: #f0ad4e;

--- a/gateway/api/static/admin/css/carbon_theme.css
+++ b/gateway/api/static/admin/css/carbon_theme.css
@@ -924,7 +924,8 @@ body.login #content h1 {
     background-color: var(--qs-badge-bg, #6f6f6f);
 }
 
-.qs-status-badge[data-status="QUEUED"],
+.qs-status-badge[data-status="QUEUED"] { --qs-badge-bg: #8d8d8d; }
+
 .qs-status-badge[data-status="PENDING"] {
     --qs-badge-bg: #f0ad4e;
     color: #1c1c1c;

--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -425,6 +425,7 @@ CONTENT_SECURITY_POLICY = {
         "object-src": "'self'",
         "img-src": ("'self'", "data:"),
         "style-src-elem": "'self'",
+        "style-src-attr": "'unsafe-inline'",
         "script-src-elem": "'self'",
         "connect-src": "'self'",
         "worker-src": ("'self'", "blob:"),

--- a/gateway/templates/admin/app_index.html
+++ b/gateway/templates/admin/app_index.html
@@ -1,0 +1,22 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block bodyclass %}{{ block.super }} app-{{ app_label }}{% endblock %}
+
+{% block nav-breadcrumbs %}
+  <nav aria-label="{% translate 'Breadcrumbs' %}">
+    <div class="breadcrumbs">
+      <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+      &rsaquo;
+      {% for app in app_list %}
+        {{ app.name }}
+      {% endfor %}
+    </div>
+  </nav>
+{% endblock %}
+
+{% block content %}
+<div id="content-main" class="app-list">
+  {% include "admin/app_list.html" with app_list=app_list show_changelinks=True %}
+</div>
+{% endblock %}

--- a/gateway/templates/admin/index.html
+++ b/gateway/templates/admin/index.html
@@ -74,8 +74,7 @@
     <div class="qs-bar-row">
       <span class="qs-bar-label">{{ row.status|capfirst }}</span>
       <div class="qs-bar-track">
-        <div class="qs-bar-fill{% if row.status == 'FAILED' or row.status == 'STOPPED' %} qs-bar-fill--dim{% endif %}"
-             style="width:{{ row.pct }}%"></div>
+        <div class="qs-bar-fill" style="width:{{ row.pct }}%"></div>
       </div>
       <span class="qs-bar-val">{{ row.count }}</span>
       <span class="qs-bar-pct">{{ row.pct }}%</span>
@@ -92,8 +91,7 @@
     <div class="qs-bar-row">
       <span class="qs-bar-label">{{ row.name }}</span>
       <div class="qs-bar-track">
-        <div class="qs-bar-fill{% if row.name == 'Custom' %} qs-bar-fill--dim{% endif %}"
-             style="width:{{ row.pct }}%"></div>
+        <div class="qs-bar-fill" style="width:{{ row.pct }}%"></div>
       </div>
       <span class="qs-bar-val">{{ row.count }}</span>
       <span class="qs-bar-pct">{{ row.pct }}%</span>

--- a/gateway/tests/test_admin_dashboard.py
+++ b/gateway/tests/test_admin_dashboard.py
@@ -2,6 +2,7 @@
 
 import pytest
 from django.contrib.auth.models import User
+from django.test import Client
 
 from api.admin import get_dashboard_stats
 from core.models import CodeEngineProject, Job, Program, Provider
@@ -74,3 +75,17 @@ def test_get_dashboard_stats_pct_sums_to_100():
 
     total_pct = sum(row["pct"] for row in stats["jobs_by_status"])
     assert total_pct == 100
+
+
+@pytest.mark.django_db
+def test_app_index_shows_model_list_not_the_home_dashboard():
+    """The per-app admin page (/backoffice/api/) must show its model list, not the home KPI dashboard."""
+    user = User.objects.create_superuser(username="admin", password="x", email="a@a.com")
+
+    client = Client()
+    client.force_login(user)
+    response = client.get("/backoffice/api/")
+
+    body = response.content.decode()
+    assert '<a href="/backoffice/api/job/">Jobs</a>' in body
+    assert "qs-kpi-grid" not in body


### PR DESCRIPTION
### Summary
Several visual and rendering fixes to the Django admin ("backoffice") dashboard.

- `QUEUED` job status badges shared the same amber color as `PENDING`. `QUEUED` now gets its own purple, in both the job list and the job events timeline.
- The "Jobs by status" and "Jobs by provider" bar charts switched some rows (`FAILED`/`STOPPED`, and the `Custom` provider) to a lighter, hardcoded blue for no stated reason. All bars now use one consistent color.
- The bar widths, which are set via an inline `style="width:X%"` attribute, were always rendering at 100% regardless of the actual percentage. The site's CSP had no `style-src-attr` directive, so it fell back to `default-src: 'none'` and silently blocked every inline `style` attribute in the backoffice, not just this one. Added a scoped `style-src-attr: 'unsafe-inline'` directive (values here are always server-computed numbers, never user input).
- The per-app admin page (e.g. `/backoffice/api/`) was rendering the home dashboard (KPI cards, empty charts) instead of the app's model list, because Django's built-in `admin/app_index.html` extends `admin/index.html`, which this project overrides with the custom dashboard template. Added a dedicated `admin/app_index.html` template so per-app pages get their normal model list back.

### Details and comments
Verified the bar chart width fix and the app_index fix by rendering both pages with real data through Django's test client.