### PR TITLE
Fix swagger schema generation and redirect root to swagger

### DIFF
--- a/gateway/api/v1/views/jobs/get_runtime_jobs.py
+++ b/gateway/api/v1/views/jobs/get_runtime_jobs.py
@@ -30,6 +30,7 @@ class OutputSerializer(serializers.ModelSerializer):
     class Meta:
         model = RuntimeJob
         fields = ["runtime_job", "runtime_session"]
+        ref_name = "JobsGetRuntimeJobsOutputSerializer"
 
 
 def serialize_output(out_runtime_jobs: Any) -> dict[str, Any]:

--- a/gateway/api/v1/views/jobs/set_sub_status.py
+++ b/gateway/api/v1/views/jobs/set_sub_status.py
@@ -69,6 +69,7 @@ class OutputSerializer(serializers.ModelSerializer):
     class Meta:
         model = Job
         fields = ["id", "status", "program", "created", "sub_status"]
+        ref_name = "JobsSetSubStatusOutputSerializer"
 
 
 def serialize_output(job: Job) -> dict[str, Any]:

--- a/gateway/main/urls.py
+++ b/gateway/main/urls.py
@@ -20,6 +20,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import path, include, re_path
+from django.views.generic import RedirectView
 from rest_framework import permissions
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
@@ -82,6 +83,7 @@ List endpoints support `limit` and `offset` parameters (default: limit=10, offse
 )
 
 urlpatterns = [
+    path("", RedirectView.as_view(url="/swagger/", permanent=False), name="root-redirect"),
     path("readiness/", probes.readiness, name="readiness"),
     path("liveness/", probes.liveness, name="liveness"),
     path("version/", system.version, name="version"),

--- a/gateway/tests/main/test_urls.py
+++ b/gateway/tests/main/test_urls.py
@@ -1,0 +1,19 @@
+"""Tests for the top-level URL routing."""
+
+import pytest
+from django.test import Client
+
+
+@pytest.mark.django_db
+def test_root_redirects_to_swagger():
+    response = Client().get("/")
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/swagger/"
+
+
+@pytest.mark.django_db
+def test_swagger_schema_generates_without_error():
+    response = Client().get("/swagger/?format=openapi")
+
+    assert response.status_code == 200


### PR DESCRIPTION
### Summary
- `/swagger/` returned a 500. Two different `OutputSerializer` classes (in `get_runtime_jobs.py` and `set_sub_status.py`) implicitly shared the same drf_yasg `ref_name`, which drf_yasg rejects once both endpoints are included in schema generation. Gave each an explicit, unique `ref_name`, following the naming convention already used by the other serializers in these view modules.
- The site root (`/`) returned a 404, there was no route for it. It now redirects to `/swagger/`.

### Details and comments
Added a regression test for each: one confirming `/` redirects to `/swagger/`, one confirming `/swagger/?format=openapi` returns 200 instead of the schema generation error.