### PR TITLE
Add Fleets-specific per-user concurrent job limit

### DIFF
--- a/gateway/main/settings.py
+++ b/gateway/main/settings.py
@@ -327,6 +327,10 @@ FLEETS_GATEWAY_HOST = os.environ.get("FLEETS_GATEWAY_HOST", SITE_HOST)
 
 # resources limitations
 LIMITS_JOBS_PER_USER = int(os.environ.get("LIMITS_JOBS_PER_USER", "2"))
+# Per-user concurrent running-job limit for the Fleets (Code Engine) runner.
+# Fleets scales differently from Ray (no per-cluster capacity), so it gets its
+# own, higher default independent of the Ray-oriented LIMITS_JOBS_PER_USER.
+LIMITS_JOBS_PER_USER_FLEETS = int(os.environ.get("LIMITS_JOBS_PER_USER_FLEETS", "50"))
 LIMITS_ACTIVE_JOBS_PER_USER = int(os.environ.get("LIMITS_ACTIVE_JOBS_PER_USER", "50"))
 LIMITS_MAX_CLUSTERS = int(os.environ.get("LIMITS_MAX_CLUSTERS", "6"))
 LIMITS_GPU_CLUSTERS = int(os.environ.get("LIMITS_MAX_GPU_CLUSTERS", "1"))

--- a/gateway/scheduler/schedule.py
+++ b/gateway/scheduler/schedule.py
@@ -120,14 +120,22 @@ def get_jobs_to_schedule_fair_share(slots: int, gpu: bool, runner: str = Program
 
     max_limit = min(slots, settings.LIMITS_MAX_FLEETS)
 
+    # Per-user concurrency is tracked independently per runner: Fleets and Ray
+    # have separate limits and separate running-job tallies, so a user's Fleets
+    # jobs don't count against their Ray budget and vice versa.
+    if runner == Program.FLEETS:
+        jobs_per_user = settings.LIMITS_JOBS_PER_USER_FLEETS
+    else:
+        jobs_per_user = settings.LIMITS_JOBS_PER_USER
+
     running_jobs_per_user = (
-        Job.objects.filter(status__in=Job.RUNNING_STATUSES).values("author").annotate(running_jobs_count=Count("id"))
+        Job.objects.filter(status__in=Job.RUNNING_STATUSES, runner=runner)
+        .values("author")
+        .annotate(running_jobs_count=Count("id"))
     )
 
     users_at_max_capacity = [
-        entry["author"]
-        for entry in running_jobs_per_user
-        if entry["running_jobs_count"] >= settings.LIMITS_JOBS_PER_USER
+        entry["author"] for entry in running_jobs_per_user if entry["running_jobs_count"] >= jobs_per_user
     ]
 
     author_date_pull = (

--- a/gateway/tests/scheduler/test_schedule.py
+++ b/gateway/tests/scheduler/test_schedule.py
@@ -11,7 +11,7 @@ from django.core.management import call_command
 from ray.dashboard.modules.job.common import JobStatus
 from rest_framework.test import APITestCase
 
-from core.models import Job, ComputeResource, JobEvent
+from core.models import Job, ComputeResource, JobEvent, Program
 from core.services.runners import RunnerError
 from core.services.storage import get_logs_storage
 
@@ -72,6 +72,46 @@ class TestScheduleApi(APITestCase):
         assert len(jobs) == 2
         assert str(job1.id) in job_ids  # `test4_user` job
         assert str(job6.id) in job_ids  # `test_user` job
+
+    def test_fair_share_per_user_limit_is_runner_scoped(self, settings):
+        """A user's Ray and Fleets running jobs are counted independently.
+
+        With LIMITS_JOBS_PER_USER=2, a user with 2 running Ray jobs is at the Ray
+        cap but must still be schedulable for Fleets, because Fleets has its own,
+        separate per-user tally and limit.
+        """
+        settings.LIMITS_JOBS_PER_USER = 2
+        settings.LIMITS_JOBS_PER_USER_FLEETS = 2
+
+        user = TestUtils.get_user_and_username("mixed_user")[0]
+        program = TestUtils.create_program(program_title="Program", author=user)
+
+        # 2 running Ray jobs -> user is at the Ray cap.
+        TestUtils.create_job(author=user, program=program, status=Job.RUNNING, runner=Program.RAY)
+        TestUtils.create_job(author=user, program=program, status=Job.RUNNING, runner=Program.RAY)
+        # 1 queued Fleets job -> should NOT be blocked by the Ray running jobs.
+        fleets_job = TestUtils.create_job(author=user, program=program, status=Job.QUEUED, runner=Program.FLEETS)
+
+        fleets_jobs = get_jobs_to_schedule_fair_share(slots=5, gpu=False, runner=Program.FLEETS)
+
+        assert fleets_job in fleets_jobs
+
+    def test_fair_share_uses_fleets_specific_limit(self, settings):
+        """Fleets scheduling uses LIMITS_JOBS_PER_USER_FLEETS, not LIMITS_JOBS_PER_USER."""
+        settings.LIMITS_JOBS_PER_USER = 2
+        settings.LIMITS_JOBS_PER_USER_FLEETS = 5
+
+        user = TestUtils.get_user_and_username("fleets_heavy_user")[0]
+        program = TestUtils.create_program(program_title="Program", author=user)
+
+        # 3 running Fleets jobs: over the Ray limit (2) but under the Fleets limit (5).
+        for _ in range(3):
+            TestUtils.create_job(author=user, program=program, status=Job.RUNNING, runner=Program.FLEETS)
+        fleets_job = TestUtils.create_job(author=user, program=program, status=Job.QUEUED, runner=Program.FLEETS)
+
+        fleets_jobs = get_jobs_to_schedule_fair_share(slots=5, gpu=False, runner=Program.FLEETS)
+
+        assert fleets_job in fleets_jobs
 
     @patch("scheduler.schedule.get_runner")
     def test_execute_ray_job_success(self, mock_get_runner_client):

--- a/gateway/tests/scheduler/test_schedule.py
+++ b/gateway/tests/scheduler/test_schedule.py
@@ -8,6 +8,7 @@ from prometheus_client import CollectorRegistry
 
 import pytest
 from django.core.management import call_command
+from django.test import override_settings
 from ray.dashboard.modules.job.common import JobStatus
 from rest_framework.test import APITestCase
 
@@ -73,16 +74,14 @@ class TestScheduleApi(APITestCase):
         assert str(job1.id) in job_ids  # `test4_user` job
         assert str(job6.id) in job_ids  # `test_user` job
 
-    def test_fair_share_per_user_limit_is_runner_scoped(self, settings):
+    @override_settings(LIMITS_JOBS_PER_USER=2, LIMITS_JOBS_PER_USER_FLEETS=2)
+    def test_fair_share_per_user_limit_is_runner_scoped(self):
         """A user's Ray and Fleets running jobs are counted independently.
 
         With LIMITS_JOBS_PER_USER=2, a user with 2 running Ray jobs is at the Ray
         cap but must still be schedulable for Fleets, because Fleets has its own,
         separate per-user tally and limit.
         """
-        settings.LIMITS_JOBS_PER_USER = 2
-        settings.LIMITS_JOBS_PER_USER_FLEETS = 2
-
         user = TestUtils.get_user_and_username("mixed_user")[0]
         program = TestUtils.create_program(program_title="Program", author=user)
 
@@ -96,11 +95,9 @@ class TestScheduleApi(APITestCase):
 
         assert fleets_job in fleets_jobs
 
-    def test_fair_share_uses_fleets_specific_limit(self, settings):
+    @override_settings(LIMITS_JOBS_PER_USER=2, LIMITS_JOBS_PER_USER_FLEETS=5)
+    def test_fair_share_uses_fleets_specific_limit(self):
         """Fleets scheduling uses LIMITS_JOBS_PER_USER_FLEETS, not LIMITS_JOBS_PER_USER."""
-        settings.LIMITS_JOBS_PER_USER = 2
-        settings.LIMITS_JOBS_PER_USER_FLEETS = 5
-
         user = TestUtils.get_user_and_username("fleets_heavy_user")[0]
         program = TestUtils.create_program(program_title="Program", author=user)
 


### PR DESCRIPTION
## Summary

The per-user concurrent running-job cap `LIMITS_JOBS_PER_USER` (default **2**) was:
- **shared across all runners**, and
- counted a user's running jobs **without regard to runner**.

Fleets (Code Engine) scales differently from Ray, it has no per-cluster capacity, so this limit is artificial and not necessary.

## Changes

- **New setting** `LIMITS_JOBS_PER_USER_FLEETS` (env var, default **50**) in `gateway/main/settings.py`.
- **`get_jobs_to_schedule_fair_share` is now runner-aware** (`gateway/scheduler/schedule.py`):
  - picks the per-user limit by runner (Fleets → `LIMITS_JOBS_PER_USER_FLEETS`, everything else → `LIMITS_JOBS_PER_USER`), and
  - scopes the running-jobs tally to the same runner, so Fleets and Ray per-user budgets are tracked **independently**.
- **Tests** added in `gateway/tests/scheduler/test_schedule.py` covering (a) a user's Ray jobs no longer blocking their Fleets jobs, and (b) Fleets using the new higher limit.

Ray behavior is unchanged (still default 2, now counted only against Ray jobs).

## For staging

Set `LIMITS_JOBS_PER_USER_FLEETS` on the scheduler, or rely on the new default of 50.