### PR TITLE
upgrade kind node to handle cve vulnerabilities

### DIFF
--- a/.github/workflows/kubernetes-deploy.yaml
+++ b/.github/workflows/kubernetes-deploy.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Kind and kubectl
         uses: helm/kind-action@v1
         with:
-          version: v0.29.0
+          version: v0.33.0
           install_only: true
       - name: Setup Python
         uses: actions/setup-python@v7

--- a/docs/custom_images/custom_function/local_cluster/deploy.sh
+++ b/docs/custom_images/custom_function/local_cluster/deploy.sh
@@ -7,7 +7,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.29.4
+  image: kindest/node:v1.34.11
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration

--- a/tests/kind-config.yaml
+++ b/tests/kind-config.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.29.4
+  image: kindest/node:v1.34.11
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

### Summary

.github/workflows/kubernetes-deploy.yaml | kind v0.29.0 → v0.33.0 (first release shipping containerd 2.1.4 with v4 config support, and the release that officially includes kindest/node:v1.34.11)
-- | --
tests/kind-config.yaml | updated version to v1.34.11




### Details and comments

updated doc for internal build with respect to kind version update

### Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a [release note](https://github.com/Qiskit/qiskit-serverless/blob/main/CONTRIBUTING.md#release-notes) for any user-facing change (new feature, bug fix, deprecation, or breaking change), or this PR has no user-facing changes.
