### PR TITLE
Minor fixesin the job admin Timeline

### DIFF
--- a/gateway/api/admin.py
+++ b/gateway/api/admin.py
@@ -6,6 +6,7 @@ import uuid
 
 from django import forms
 from django.contrib import admin, messages
+from django.core.cache import cache
 from django.db.models import Count, F, Q
 from django.utils.html import format_html
 from django.urls import path, reverse
@@ -40,6 +41,12 @@ logger = logging.getLogger("gateway.admin")
 
 # How many jobs the "Timeline" admin action can carry in the redirect query string
 MAX_TIMELINE_JOBS = 200
+
+# The admin home page is hit far more often than the Timeline page itself, so the recent-Fleets
+# widget it embeds (query plus SVG build plus overlap detection) is cached for a short while
+# instead of being rebuilt on every single load.
+RECENT_TIMELINE_CACHE_KEY = "admin_dashboard_recent_fleets_timeline"
+RECENT_TIMELINE_CACHE_TTL_SECONDS = 30
 
 
 def get_dashboard_stats():
@@ -488,11 +495,17 @@ class JobAdmin(admin.ModelAdmin):
         The selection travels in the query string, so it has to be capped: "select all" on an
         unfiltered changelist would build a URL long enough for the webserver to reject the
         request with a 502 instead of showing an error.
+
+        The cap is detected from a single query (fetch one row past the limit) rather than a
+        separate `.count()` plus a slice: two independent queries against the same queryset could
+        observe different rows if something else inserts or deletes a matching job in between,
+        which would make the "showing N of TOTAL" message describe a total inconsistent with the
+        ids actually captured.
         """
-        total = queryset.count()
-        ids = list(queryset.values_list("id", flat=True)[:MAX_TIMELINE_JOBS])
-        if total > MAX_TIMELINE_JOBS:
-            messages.warning(request, f"Showing the first {MAX_TIMELINE_JOBS} of {total} selected jobs.")
+        ids = list(queryset.values_list("id", flat=True)[: MAX_TIMELINE_JOBS + 1])
+        if len(ids) > MAX_TIMELINE_JOBS:
+            ids = ids[:MAX_TIMELINE_JOBS]
+            messages.warning(request, f"Showing the first {MAX_TIMELINE_JOBS} of the selected jobs.")
         return redirect(f"{reverse('admin:job_timeline_view')}?ids={','.join(str(i) for i in ids)}")
 
     def get_urls(self):
@@ -672,14 +685,17 @@ class QiskitAdminSite(admin.AdminSite):
     def index(self, request, extra_context=None):
         extra_context = extra_context or {}
         extra_context["dashboard_stats"] = get_dashboard_stats()
-        recent_jobs = list(
-            Job.objects.filter(runner=Program.FLEETS)
-            .select_related("author")
-            .prefetch_related("job_events")
-            .order_by("-created")[:20]
-        )
-        if recent_jobs:
-            extra_context.update(render_job_timeline(recent_jobs))
+        timeline_context = cache.get(RECENT_TIMELINE_CACHE_KEY)
+        if timeline_context is None:
+            recent_jobs = list(
+                Job.objects.filter(runner=Program.FLEETS)
+                .select_related("author")
+                .prefetch_related("job_events")
+                .order_by("-created")[:20]
+            )
+            timeline_context = render_job_timeline(recent_jobs) if recent_jobs else {}
+            cache.set(RECENT_TIMELINE_CACHE_KEY, timeline_context, RECENT_TIMELINE_CACHE_TTL_SECONDS)
+        extra_context.update(timeline_context)
         return super().index(request, extra_context)
 
 

--- a/gateway/api/domain/job_timeline.py
+++ b/gateway/api/domain/job_timeline.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 from django.utils.safestring import mark_safe
 
 from core.model_managers.job_events import JobEventType
+from core.models import Job
 
 # Same palette and names as the job list's status badges (`.qs-status-badge` in
 # api/static/admin/css/carbon_theme.css), so a status reads the same color in both places.
@@ -92,7 +93,7 @@ def compute_timeline(job):
     # status would get no segment, no duration and no weight in the concurrency chart. The
     # comparison keeps the points in chronological order if an event carries a future timestamp.
     now = timezone.now()
-    if points and job["status"] not in OUTCOME_LABEL and now > points[-1][0]:
+    if points and job["status"] not in Job.TERMINAL_STATUSES and now > points[-1][0]:
         points.append((now, job["status"]))
 
     job["points"] = points
@@ -160,6 +161,30 @@ def concurrency_series(jobs):
     return series
 
 
+def _merge_series_max(series_list):
+    """Combine several step series into one, taking the max value across them at every timestamp.
+
+    Used to combine per-runner concurrency series into a single curve: Ray and Fleets run on
+    separate infrastructure (the same rule `find_overlaps` already applies), so a job on one
+    runner never contends with a job on the other, and their counts must never be added
+    together. Comparing them instant-by-instant instead keeps the concurrency chart's "peak
+    overlap" consistent with the per-job overlap badges, which also never count cross-runner
+    pairs.
+    """
+    if not series_list:
+        return []
+    events = sorted(
+        ((ts, idx, count) for idx, series in enumerate(series_list) for ts, count in series),
+        key=lambda e: e[0],
+    )
+    current = [0] * len(series_list)
+    merged = []
+    for ts, idx, count in events:
+        current[idx] = count
+        merged.append((ts, max(current)))
+    return merged
+
+
 def fmt_dt(dt):
     """Format datetime for display."""
     return dt.strftime("%d-%b %H:%M:%S") if dt else "-"
@@ -203,12 +228,15 @@ def build_svg(jobs, overlaps):  # pylint: disable=too-many-locals,too-many-state
 
     all_starts = [j["t_queue"] for j in jobs if j["t_queue"]]
     all_ends = [j["t_end"] for j in jobs if j["t_end"]]
-    t_min = min(all_starts)
-    t_max = max(all_ends)
-    span = (t_max - t_min).total_seconds() or 1
+    # the real bounds of the selected jobs, returned as-is for the "range X to Y" display text
+    real_t_min = min(all_starts)
+    real_t_max = max(all_ends)
+    span = (real_t_max - real_t_min).total_seconds() or 1
     pad = span * 0.02
-    t_min -= timedelta(seconds=pad)
-    t_max += timedelta(seconds=pad)
+    # the chart itself gets a little breathing room on each side; this padded range drives the
+    # chart geometry only, never the displayed range text
+    t_min = real_t_min - timedelta(seconds=pad)
+    t_max = real_t_max + timedelta(seconds=pad)
     span = (t_max - t_min).total_seconds()
 
     def x(dt):
@@ -240,6 +268,11 @@ def build_svg(jobs, overlaps):  # pylint: disable=too-many-locals,too-many-state
     bottom_of_gantt = margin_top + concurrency_h + 30 + gantt_h
 
     # --- very faint lines, one per exact hour ---
+    # the loop below is driven by wall-clock span, not by job count, so a selection spanning
+    # weeks/months (still well within MAX_TIMELINE_JOBS) could otherwise emit thousands of lines;
+    # widen the step so the total stays bounded regardless of how wide the selection is
+    total_hours = max(span / 3600, 1)
+    hour_step = max(1, int(total_hours // 500) + 1)
     hour = t_min.replace(minute=0, second=0, microsecond=0)
     if hour < t_min:
         hour += timedelta(hours=1)
@@ -249,7 +282,7 @@ def build_svg(jobs, overlaps):  # pylint: disable=too-many-locals,too-many-state
             f'<line x1="{hx:.1f}" y1="{top_of_chart}" x2="{hx:.1f}" y2="{bottom_of_gantt}" '
             f'class="qs-hour-line" stroke-width="0.5" opacity="0.06"/>'
         )
-        hour += timedelta(hours=1)
+        hour += timedelta(hours=hour_step)
 
     # --- time gridlines (shared by both charts) ---
     n_ticks = 16
@@ -268,15 +301,27 @@ def build_svg(jobs, overlaps):  # pylint: disable=too-many-locals,too-many-state
         )
 
     # --- concurrency chart (overlaps), one series for "All" plus one per compute profile ---
+    # Ray and Fleets never contend for the same resource (see `find_overlaps`), so a runner's own
+    # concurrency series is computed independently and merged with `_merge_series_max`, never by
+    # summing counts across runners: that keeps this chart's "peak overlap" consistent with the
+    # per-job overlap badges, which also never count a Ray/Fleets pair as overlapping.
     def cy(count, max_count):
         return margin_top + concurrency_h - (count / max_count) * (concurrency_h - 10)
 
-    series_all = concurrency_series(jobs_sorted)
-    max_conc = max((c for _, c in series_all), default=0) or 1
+    runners_present = sorted({j["runner"] for j in jobs_sorted})
+
+    def runner_scoped_series(job_subset):
+        return _merge_series_max(
+            [concurrency_series([j for j in job_subset if j["runner"] == r]) for r in runners_present]
+        )
+
+    series_all = runner_scoped_series(jobs_sorted)
+    real_max_conc = max((c for _, c in series_all), default=0)
+    max_conc = real_max_conc or 1  # avoid a division by zero in cy() below; the heading uses real_max_conc
 
     svg.append(
         f'<text x="{margin_left}" y="{margin_top - 6}" class="qs-heading" font-weight="bold">'
-        f"Concurrent RUNNING jobs (peak overlap: {max_conc})</text>"
+        f"Concurrent RUNNING jobs (peak overlap: {real_max_conc})</text>"
     )
     path_d = build_concurrency_path(series_all, t_min, t_max, x, lambda c: cy(c, max_conc))
     if path_d:
@@ -285,7 +330,7 @@ def build_svg(jobs, overlaps):  # pylint: disable=too-many-locals,too-many-state
             f'fill="#3b82f6" opacity="0.35" stroke="#60a5fa" stroke-width="1.5"/>'
         )
     for profile in profiles:
-        series_p = concurrency_series([j for j in jobs_sorted if j["profile"] == profile])
+        series_p = runner_scoped_series([j for j in jobs_sorted if j["profile"] == profile])
         path_d = build_concurrency_path(series_p, t_min, t_max, x, lambda c: cy(c, max_conc))
         if path_d:
             svg.append(
@@ -350,7 +395,7 @@ def build_svg(jobs, overlaps):  # pylint: disable=too-many-locals,too-many-state
             color = STATUS_COLOR.get(seg_status, "#64748b")
             svg.append(
                 f'<rect x="{sx1:.1f}" y="{y}" width="{max(sx2 - sx1, 1.5):.1f}" height="{row_h}" '
-                f'class="qs-seg-border qs-seg-{seg_status.lower()}" fill="{color}"/>'
+                f'class="qs-seg-border qs-seg-{html.escape(seg_status.lower())}" fill="{color}"/>'
             )
             # the segment's own status and duration, drawn inside it when they fit; otherwise
             # they join the other segments that didn't fit in a summary drawn after the bar
@@ -391,7 +436,7 @@ def build_svg(jobs, overlaps):  # pylint: disable=too-many-locals,too-many-state
     )
 
     svg.append("</svg>")
-    return "\n".join(svg), t_min, t_max, profiles
+    return "\n".join(svg), real_t_min, real_t_max, profiles
 
 
 def build_legend():
@@ -410,7 +455,7 @@ def build_legend():
             f'<span class="qs-legend-item qs-outcome qs-outcome--{outcome_status.lower()}">'
             f"{html.escape(text)}</span>"
         )
-    parts.append('<span class="qs-legend-item">⧉N = overlaps N other jobs — hover a job to see which</span>')
+    parts.append('<span class="qs-legend-item">⧉N = overlaps N other jobs, click a job to see which</span>')
     return "".join(parts)
 
 

--- a/gateway/api/static/admin/css/job_timeline.css
+++ b/gateway/api/static/admin/css/job_timeline.css
@@ -89,7 +89,7 @@ html[data-theme="dark"] .qs-timeline {
 .qs-timeline #hover-cursor { display: none; }
 .qs-timeline #hover-cursor.is-visible { display: block; }
 
-/* Legend. Keep these colors in sync with STATUS_COLOR, OUTCOME_LABEL and OVERLAP_STROKE in
+/* Legend. Keep these colors in sync with STATUS_COLOR and OUTCOME_LABEL in
    api/domain/job_timeline.py: fixed regardless of theme, same as the job list's status badges. */
 .qs-timeline .qs-legend-item { margin-right: 16px; }
 .qs-timeline .qs-swatch {
@@ -103,7 +103,6 @@ html[data-theme="dark"] .qs-timeline {
 .qs-timeline .qs-swatch--queued { background: #8a3ffc; }
 .qs-timeline .qs-swatch--pending { background: #f0ad4e; }
 .qs-timeline .qs-swatch--running { background: #5bc0de; }
-.qs-timeline .qs-swatch--overlap { background: #5bc0de; border: 2px solid #dc2626; }
 .qs-timeline .qs-outcome { font-weight: bold; }
 .qs-timeline .qs-outcome--succeeded { color: #00aa00; }
 .qs-timeline .qs-outcome--failed { color: #cc0000; }

--- a/gateway/tests/conftest.py
+++ b/gateway/tests/conftest.py
@@ -13,6 +13,7 @@
 """Global pytest fixtures for gateway tests."""
 
 import pytest
+from django.core.cache import cache
 
 
 @pytest.fixture(autouse=True)
@@ -23,3 +24,14 @@ def media_root_tmp(tmp_path, settings):
     the source tree (gateway/media/) during test runs.
     """
     settings.MEDIA_ROOT = str(tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def clear_django_cache():
+    """Clear the process-wide Django cache before every test.
+
+    `django_db` rolls back the database between tests, but Django's cache (e.g. the admin
+    dashboard's cached recent-Fleets-jobs timeline) is not tied to that transaction and would
+    otherwise leak a value cached by one test into the next.
+    """
+    cache.clear()


### PR DESCRIPTION
### Summary

Follow-up to #2444, which added the "Timeline" action to the job admin. A review pass over that PR turned up several defects that landed with it, and this fixes them. No new features, no behaviour anyone asked for changed on purpose: everything here is either a bug, a stale piece of text, or a performance guard.

The most substantive one is a real contradiction in how overlap was counted. `find_overlaps` deliberately treats a Ray job and a Fleets job as never conflicting, since they run on separate infrastructure, but the concurrency chart above the Gantt and its "peak overlap" heading still added both runners' counts together. So the headline number could claim a peak of 3 while no single job showed more than one overlap partner. Each runner's series is now computed on its own and combined by taking the maximum at every instant, which is the same rule the per-job badges already followed.

### Details and comments

- **Cross-runner overlap counting**: new `_merge_series_max` helper combines per-runner concurrency series by max instead of sum, so the chart and the per-job `⧉N` badges agree. Applies to the "All" series and to each compute-profile series.
- **Unescaped value in an attribute**: a job's status string reached an SVG `class` attribute without `html.escape()`, unlike every other dynamic value in that module. Escaped now.
- **Stale legend text**: the legend still read "hover a job to see which" after hover highlighting was replaced by click-only highlighting in #2444 itself. Reworded to match what the page does.
- **Hardcoded status set**: whether a job counts as unfinished was decided against a local three-status dict instead of `Job.TERMINAL_STATUSES`, which already exists on the model. Uses the model constant now, so the two cannot drift apart.
- **Misleading range text**: the "N jobs, range X to Y" line reported the chart's 2% padded bounds rather than the real earliest and latest job timestamps. The padded bounds now drive the chart geometry only, and the real ones are what gets displayed.
- **"peak overlap: 1" with no overlaps**: the `or 1` fallback that keeps the axis scaling from dividing by zero was also feeding the heading, so an empty peak read as 1. Display value and scaling value are separate now.
- **Unbounded hourly gridlines**: the faint hour lines were driven by wall-clock span, not job count, so a selection spanning months could emit thousands of SVG lines while staying well under the 200-job cap. The hour step widens for large spans to keep the total bounded.
- **Racy count plus slice**: `timeline_action` ran `.count()` and a separate sliced `.values_list()` against the same queryset, which can observe different rows if a matching job is created or deleted in between, making the "showing N of TOTAL" message describe a total inconsistent with the ids actually captured. Replaced with a single query that fetches one row past the limit.
- **Uncached dashboard widget**: the admin home is hit far more often than the Timeline page, and it was rebuilding the recent-Fleets-jobs query, overlap detection and SVG on every load. Cached for 30 seconds. Django's cache is not tied to the test database transaction, so an autouse fixture in `conftest.py` clears it between tests to stop a cached value leaking from one test into the next.
- **Dead CSS**: removed the `.qs-swatch--overlap` rule and a comment referring to an `OVERLAP_STROKE` constant, both left over from the permanent-border highlighting that #2444 replaced.

### Test plan

- [x] `pytest tests/` passes (1051 passed, 2 skipped)
- [x] `pylint -rn api main core scheduler` rates 10.00/10
- [x] `lint-imports` keeps all 3 architectural contracts
- [x] `black --line-length 120 --check` clean on the touched files