### PR TITLE
Run exactly one scheduler pod, including during a rollout

### DIFF
--- a/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
+++ b/charts/qiskit-serverless/charts/gateway/templates/deployment.yaml
@@ -352,9 +352,12 @@ metadata:
   labels:
     {{- include "scheduler.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  # The scheduler loop is not safe to run twice: replicas stays at 1 whatever
+  # autoscaling does to the gateway, and Recreate keeps the old pod from
+  # overlapping with the new one during a rollout.
   replicas: 1
-  {{- end }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "scheduler.selectorLabels" . | nindent 6 }}

--- a/releasenotes/notes/scheduler-single-replica-6e46ca255ebb5bf4.yaml
+++ b/releasenotes/notes/scheduler-single-replica-6e46ca255ebb5bf4.yaml
@@ -1,0 +1,20 @@
+---
+upgrade:
+  - |
+    The scheduler Deployment now uses the ``Recreate`` strategy and pins
+    ``replicas`` to 1 unconditionally. The scheduler loop is not safe to run in
+    two pods at once, and a rolling update on a single replica starts the new pod
+    before the old one is torn down, so every rollout used to run two schedulers
+    for a few seconds. The trade-off is that a rollout to a broken scheduler image
+    now leaves zero schedulers running instead of keeping the old pod up: no queued
+    job is promoted and ``PROGRAM_TIMEOUT`` is not enforced until the rollout is
+    rolled back. The scheduler has a liveness probe but no readiness probe, so
+    nothing reports this and the only symptom is that jobs stop moving. Watch a
+    scheduler rollout to completion, and roll back on a crash loop.
+  - |
+    ``replicas`` on the scheduler Deployment no longer depends on
+    ``autoscaling.enabled``. That value belongs to the gateway, and any deployment
+    with gateway autoscaling on rendered the scheduler with no ``replicas`` field
+    at all, leaving the pod count unmanaged by the chart. The count was 1 in
+    practice, so this changes nothing at rest, but a scheduler that was scaled out
+    of band is now scaled back to 1 on the next upgrade.


### PR DESCRIPTION
### Summary

The scheduler runs a single-threaded loop that no task in it is written to share: two scheduler pods running at once each pick up the same queued work. `replicas: 1` does not give us that, because it describes the steady state and not a rollout, so every deploy ran two schedulers for a few seconds. This pins the scheduler Deployment to one pod and switches it to the `Recreate` strategy so the old pod is gone before the new one starts.

### Details and comments

Two separate holes, both in the scheduler Deployment only. The gateway Deployment is untouched, since its HPA does target it.

**The rollout overlap.** With no `strategy` set, Kubernetes defaults to `RollingUpdate` with `maxSurge: 25%` and `maxUnavailable: 25%`. On one replica those round to a surge of 1 and an unavailability of 0, which means "never drop below one available pod, and you may go up to two": the new pod is created and becomes Ready before the old one gets its SIGTERM. The scheduler has a `livenessProbe` but no `readinessProbe`, and its HTTP server only registers `/liveness` (`gateway/scheduler/http_server.py:37`), so the new pod counts as available as soon as its container starts. That keeps the window short, a few seconds, but the loop iterates once a second (`gateway/scheduler/main.py:104`), so it is still several full iterations with two schedulers live.

Nothing in the loop survives that. The optimistic locking behind `Job.save_direct` guards updates to existing rows, not inserts, and there is no lock or unique constraint anywhere else. The filler-jobs balancer coming in a separate PR made this measurable: two overlapping loops each read the running count and each created a full set, so eight Code Engine fleets got billed to fill four slots and the next iteration cancelled four of them, on every deploy. The balancer is the loudest case, not the only one.

**The replica count was tied to the wrong value.** The scheduler's `replicas: 1` sat inside `{{- if not .Values.autoscaling.enabled }}`, and `autoscaling` describes the gateway. In any deployment that enables gateway autoscaling, the scheduler Deployment rendered with no `replicas` field at all (checked with `helm template`). It works today because Kubernetes defaults an absent field to 1 on create and the chart's only HPA targets the gateway, but nothing pins it: a `kubectl scale deployment/scheduler --replicas=2` out of band sticks forever, because with the field missing from the desired manifest neither `helm upgrade` nor Argo CD sees a diff to reconcile. `Recreate` does not help there, since that is not a rollout.

**What this costs.** `Recreate` tears the old pod down first, so a rollout to a broken scheduler image now leaves zero schedulers instead of keeping the working one up. Nothing reports it: there is no readiness probe, and the liveness probe only turns unhealthy after five consecutive database errors (`gateway/scheduler/health.py`), which an image that never starts never reaches. The visible symptom is that queued jobs stop being promoted and `PROGRAM_TIMEOUT` stops being enforced. Shutdown is fast, the loop checks its kill signal every second, so the switch is cheap in the normal case, but a scheduler rollout is now worth watching to completion.

Worth being clear that this is not a lock either. It removes the overlap we cause ourselves on every deploy, which is the case that actually fires, but a pod eviction, a node drain or a network partition can still produce two schedulers. The durable fix is a PostgreSQL advisory lock or a Kubernetes Lease held by the loop, which is a bigger change and belongs in its own PR.

Verified by rendering the subchart both ways. Before, with gateway autoscaling on, the scheduler `spec` went straight from `spec:` to `selector:` with no `replicas`. After, both `autoscaling.enabled=true` and `autoscaling.enabled=false` render:

```yaml
spec:
  replicas: 1
  strategy:
    type: Recreate
```

The gateway Deployment still renders with no `replicas` under autoscaling and with `replicas: 1` without it, exactly as before, and `helm lint` passes.
