### PR TITLE
Keep Job.updated in sync when bypassing save()

### DIFF
--- a/gateway/api/use_cases/jobs/set_sub_status.py
+++ b/gateway/api/use_cases/jobs/set_sub_status.py
@@ -4,6 +4,7 @@ import logging
 from uuid import UUID
 
 from django.contrib.auth.models import AbstractUser
+from django.utils import timezone
 
 from api.access_policies.jobs import JobAccessPolicies
 from api.domain.exceptions.invalid_access_exception import InvalidAccessException
@@ -43,7 +44,12 @@ class SetJobSubStatusUseCase:
 
         # update sub status in QUEUE + PENDING + RUNNING is allowed
         # we accept that we could have SET_SUB_STATUS events before RUNNING
-        updated = Job.objects.filter(id=job.id, status__in=Job.ACTIVE_STATUSES).update(sub_status=sub_status)
+        # The status filter is the guard, so this stays a conditional UPDATE rather
+        # than going through save_direct. updated is set by hand for the same reason
+        # save_direct sets it: a queryset UPDATE does not fire auto_now.
+        updated = Job.objects.filter(id=job.id, status__in=Job.ACTIVE_STATUSES).update(
+            sub_status=sub_status, updated=timezone.now()
+        )
 
         if not updated:
             logger.warning(

--- a/gateway/api/use_cases/jobs/stop.py
+++ b/gateway/api/use_cases/jobs/stop.py
@@ -37,7 +37,10 @@ class StopJobUseCase:
 
         if not job.in_terminal_state():
             job.status = Job.STOPPED
-            job.save(update_fields=["status"])
+            # "updated" has auto_now=True, but auto_now only fires for fields listed
+            # in update_fields, so it has to be named here explicitly or the column
+            # keeps the value it got when the job was created.
+            job.save(update_fields=["status", "updated"])
             JobEvent.objects.add_status_event(
                 job_id=job.id,
                 origin=JobEventOrigin.API,

--- a/gateway/core/models.py
+++ b/gateway/core/models.py
@@ -11,6 +11,7 @@ from django.core.exceptions import ValidationError
 from django.core.validators import FileExtensionValidator
 from django.db import models
 from django.db.models import F
+from django.utils import timezone
 from django_prometheus.models import ExportModelOperationsMixin
 
 from core.config_key import ConfigKey
@@ -665,8 +666,14 @@ class Job(models.Model):
         refresh_from_db is required afterwards to bring the instance version
         in sync with the value that was actually written to the DB, so
         subsequent saves from this same instance don't conflict with themselves.
+
+        updated is stamped here because auto_now only fires on Model.save(), and
+        skipping save() is the whole point of this method. Without it the column
+        would keep the value it got when the row was created.
         """
         update_kwargs = {field: getattr(self, field) for field in fields}
+        update_kwargs.setdefault("updated", timezone.now())
+        self.updated = update_kwargs["updated"]
         update_kwargs["version"] = F("version") + 1
         Job.objects.filter(pk=self.id).update(**update_kwargs)
         self.refresh_from_db(fields=["version"])
@@ -677,7 +684,11 @@ class Job(models.Model):
         Like save_direct, but the caller provides values directly instead of
         reading them from the instance. Also updates the instance attributes so
         the in-memory object stays consistent with the DB.
+
+        updated is stamped for the same reason it is in save_direct, and a caller
+        that passes it explicitly wins.
         """
+        fields_map = {"updated": timezone.now(), **fields_map}
         for field, value in fields_map.items():
             setattr(self, field, value)
         update_kwargs = dict(fields_map)

--- a/gateway/core/models.py
+++ b/gateway/core/models.py
@@ -805,7 +805,9 @@ class Config(models.Model):
     @classmethod
     def set(cls, key: ConfigKey, value: str):
         """Changes a configuration value in DB and cache."""
-        cls.objects.filter(name=key.value).update(value=value)
+        # A queryset UPDATE does not fire auto_now, so updated has to be stamped
+        # by hand or the admin's "updated" column would never move.
+        cls.objects.filter(name=key.value).update(value=value, updated=timezone.now())
         cache.set(cls._get_cache_key(key), value, settings.DYNAMIC_CONFIG_CACHE_TTL)
 
     @classmethod

--- a/gateway/scheduler/tasks/update_ray_jobs_statuses.py
+++ b/gateway/scheduler/tasks/update_ray_jobs_statuses.py
@@ -6,7 +6,6 @@ from collections import deque
 from datetime import datetime, timezone
 
 from django.conf import settings
-from django.db.models import F
 
 from core.services.runners.ray_runner import FilteredLogs
 from core.services.storage import get_logs_storage
@@ -55,9 +54,7 @@ class UpdateRayJobsStatuses(SchedulerTask):
             job.status = Job.FAILED
             job.sub_status = None
             job.env_vars = "{}"
-            Job.objects.filter(pk=job.id).update(
-                status=job.status, sub_status=job.sub_status, env_vars=job.env_vars, version=F("version") + 1
-            )
+            job.save_direct(["status", "sub_status", "env_vars"])
             JobEvent.objects.add_status_event(
                 job_id=job.id,
                 origin=JobEventOrigin.SCHEDULER,
@@ -135,13 +132,7 @@ class UpdateRayJobsStatuses(SchedulerTask):
                 save_logs_to_storage(job, lines)
 
         if status_has_changed:
-            Job.objects.filter(pk=job.id).update(
-                status=job.status,
-                sub_status=job.sub_status,
-                env_vars=job.env_vars,
-                version=F("version") + 1,
-            )
-            job.refresh_from_db(fields=["version"])
+            job.save_direct(["status", "sub_status", "env_vars"])
             JobEvent.objects.add_status_event(
                 job_id=job.id,
                 origin=JobEventOrigin.SCHEDULER,

--- a/gateway/tests/api/test_job.py
+++ b/gateway/tests/api/test_job.py
@@ -504,6 +504,9 @@ class TestJobApi:
         """Tests job stop."""
         self._authorize("test_user")
 
+        job_before = Job.objects.filter(id__exact="8317718f-5c0d-4fb6-9947-72e480b8a348").first()
+        updated_before = job_before.updated
+
         job_stop_response = self.client.post(
             reverse(
                 "v1:jobs-stop",
@@ -514,6 +517,8 @@ class TestJobApi:
         assert job_stop_response.status_code == status.HTTP_200_OK
         job = Job.objects.filter(id__exact="8317718f-5c0d-4fb6-9947-72e480b8a348").first()
         assert job.status == Job.STOPPED
+        assert job.updated is not None
+        assert job.updated != updated_before
         assert "Job has been stopped." in job_stop_response.data.get("message")
 
         job_events = JobEvent.objects.filter(job=job)

--- a/gateway/tests/core/test_config.py
+++ b/gateway/tests/core/test_config.py
@@ -68,6 +68,17 @@ class TestConfig:
         config = Config.objects.get(name=ConfigKey.MAINTENANCE.value)
         assert config.value == "true"
 
+    def test_set_moves_the_updated_timestamp(self):
+        """set() issues a queryset UPDATE, which does not fire auto_now on its own."""
+        Config.add_defaults()
+        before = Config.objects.get(name=ConfigKey.MAINTENANCE.value).updated
+
+        Config.set(ConfigKey.MAINTENANCE, "true")
+
+        after = Config.objects.get(name=ConfigKey.MAINTENANCE.value).updated
+        assert after is not None
+        assert after != before
+
     def test_get_int_returns_value_as_integer(self):
         """Test that get_int() parses the stored string as an int, default included."""
         Config.add_defaults()

--- a/gateway/tests/core/test_job_model.py
+++ b/gateway/tests/core/test_job_model.py
@@ -30,3 +30,28 @@ def test_filler_partial_index_is_declared():
     assert index is not None
     assert index.fields == ["created"]
     assert index.condition == models.Q(filler=True)
+
+
+def test_update_fields_moves_the_updated_timestamp():
+    """A status change through update_fields is a change, so updated must move."""
+    author = User.objects.create_user(username="updated-test-author-1")
+    job = Job.objects.create(author=author, status=Job.QUEUED)
+    before = job.updated
+
+    job.update_fields({"status": Job.RUNNING})
+
+    assert job.updated > before
+    assert Job.objects.get(pk=job.pk).updated == job.updated
+
+
+def test_save_direct_moves_the_updated_timestamp():
+    """save_direct bypasses save(), so it has to stamp updated itself."""
+    author = User.objects.create_user(username="updated-test-author-2")
+    job = Job.objects.create(author=author, status=Job.QUEUED)
+    before = job.updated
+
+    job.status = Job.RUNNING
+    job.save_direct(["status"])
+
+    assert job.updated > before
+    assert Job.objects.get(pk=job.pk).updated == job.updated

--- a/releasenotes/notes/job-updated-timestamp-3f1b8c92ad47e065.yaml
+++ b/releasenotes/notes/job-updated-timestamp-3f1b8c92ad47e065.yaml
@@ -1,11 +1,21 @@
 ---
 fix:
   - |
-    ``Job.updated`` now records the last time the row actually changed. Every job
-    status transition goes through ``save_direct`` or ``update_fields``, which issue
+    ``Job.updated`` now records the last time the row actually changed. Most job
+    status transitions go through ``save_direct`` or ``update_fields``, which issue
     a queryset ``UPDATE`` to skip the optimistic-locking check, and a queryset
     ``UPDATE`` does not fire the field's ``auto_now``. The column therefore kept the
     value it was given when the job was created, which is what the job list in the
     admin showed, and what the job timeline used as the end time when a job had no
     status events to derive one from. Setting a job's ``sub_status`` now moves it as
     well.
+  - |
+    Stopping a job through the API also left ``Job.updated`` stale: unlike the
+    scheduler's paths, it goes through a plain ``Model.save(update_fields=["status"])``,
+    and Django only fires a field's ``auto_now`` when that field is itself named in
+    ``update_fields`` — omitting it silently skips the timestamp rather than raising.
+    ``updated`` is now named alongside ``status``.
+  - |
+    ``Config.set()`` had the same queryset-``UPDATE`` gap as the job status paths
+    above, so the "updated" column the admin shows for dynamic config values never
+    moved when a value was changed through it.

--- a/releasenotes/notes/job-updated-timestamp-3f1b8c92ad47e065.yaml
+++ b/releasenotes/notes/job-updated-timestamp-3f1b8c92ad47e065.yaml
@@ -1,0 +1,11 @@
+---
+fix:
+  - |
+    ``Job.updated`` now records the last time the row actually changed. Every job
+    status transition goes through ``save_direct`` or ``update_fields``, which issue
+    a queryset ``UPDATE`` to skip the optimistic-locking check, and a queryset
+    ``UPDATE`` does not fire the field's ``auto_now``. The column therefore kept the
+    value it was given when the job was created, which is what the job list in the
+    admin showed, and what the job timeline used as the end time when a job had no
+    status events to derive one from. Setting a job's ``sub_status`` now moves it as
+    well.


### PR DESCRIPTION
### Summary

`Job.updated` has a plain `auto_now=True`, but every job status transition goes through `save_direct` or `update_fields`, and both of those issue a queryset `UPDATE` instead of calling `save()`. A queryset `UPDATE` does not fire `auto_now`, so in practice the column keeps whatever value it got when the row was created and never moves again. This makes both methods stamp it, and does the same for the two remaining places that write a job row the same way.

### Details and comments

Two things read the column today and both are wrong because of this. The job list in the admin shows `updated` as a sortable column (`gateway/api/admin.py:476`), where it currently repeats the creation time for every job whatever has happened to it since. And the job timeline falls back to `job.updated` for the end of the bar when a job has no status events to derive one from (`gateway/api/domain/job_timeline.py:61` and `:115`), which makes that job's duration come out as zero.

Skipping `save()` is deliberate in both methods: django-concurrency raises `RecordModifiedError` when the version in the database has moved on, and these two exist precisely to write without that check. So the fix is not to start calling `save()`, it is to put `updated` in the `UPDATE` alongside the `version` bump that is already there. The instance attribute is set too, which is what `update_fields` already promises in its docstring. A caller that passes `updated` explicitly still wins.

`Job` is the only model with these helpers, so no other model needed anything.

Two other paths wrote a job row the same way and had the same problem. In `UpdateRayJobsStatuses` there were two hand-written copies of exactly what `save_direct` does, down to the `version=F("version") + 1`, so they now call `save_direct` and inherit the timestamp along with everything else; one of them was also missing the `refresh_from_db` that keeps the in-memory version usable, and the other had it written out by hand. `SetJobSubStatusUseCase` is different: its `status__in=ACTIVE_STATUSES` filter is the guard that decides whether the update is allowed at all, and the row count is the answer, so it stays a conditional `UPDATE` and sets the timestamp by hand. Reporting progress on a running job is a change worth recording.

This came up while working on the filler jobs balancer, which needs to know when a filler job died on its own so it can stop replacing one that keeps dying. With the column frozen, the only reliable source for that is the terminal `JobEvent` row, which means a join against `api_jobevent`, a table with nothing indexed but its primary key and `job_id`, once per scheduler loop. With `updated` telling the truth, that becomes a single-table query on `api_job` which the existing partial index on filler rows already covers. That work sits behind this and is not part of this PR.
