### PR TITLE
Filler GPU nodes: metrics

### DIFF
--- a/gateway/scheduler/metrics/scheduler_metrics_collector.py
+++ b/gateway/scheduler/metrics/scheduler_metrics_collector.py
@@ -54,6 +54,22 @@ class SchedulerMetrics:  # pylint: disable=too-many-instance-attributes
             labelnames=("status", "provider"),
             registry=self.registry,
         )
+        self.filler_jobs_count = Gauge(
+            "scheduler_filler_jobs_count",
+            "Number of active filler jobs per status. Filler jobs are excluded from "
+            "scheduler_job_status_count, which describes user demand.",
+            labelnames=("status",),
+            registry=self.registry,
+        )
+        self.filler_jobs_ended_total = Counter(
+            "scheduler_filler_jobs_ended_total",
+            "Filler jobs that reached a terminal state without the balancer stopping them. "
+            "FAILED or SUCCEEDED means the filler function ended on its own, which it is "
+            "not meant to do, so a rising counter is a misconfigured filler program. "
+            "STOPPED here is the PROGRAM_TIMEOUT path.",
+            labelnames=("final_status",),
+            registry=self.registry,
+        )
         self.jobs_terminal_total = Counter(
             "scheduler_jobs_terminal_total",
             "Total jobs that reached a terminal state (SUCCEEDED, FAILED, STOPPED).",
@@ -103,6 +119,18 @@ class SchedulerMetrics:  # pylint: disable=too-many-instance-attributes
     def set_job_status_count(self, count: int, status: str, provider: str) -> None:
         """Set job count for a specific status and provider."""
         self.job_status_count.labels(status=status, provider=provider).set(count)
+
+    def clear_filler_jobs_counts(self) -> None:
+        """Remove all label combinations from filler_jobs_count to avoid stale values."""
+        self.filler_jobs_count.clear()
+
+    def set_filler_jobs_count(self, count: int, status: str) -> None:
+        """Set filler job count for a specific status."""
+        self.filler_jobs_count.labels(status=status).set(count)
+
+    def increment_filler_jobs_ended(self, final_status: str) -> None:
+        """Count one filler job that reached a terminal state on its own."""
+        self.filler_jobs_ended_total.labels(final_status=final_status).inc()
 
     def observe_job_execution_duration(self, duration_seconds: float, provider: str) -> None:
         """Record execution time from RUNNING to SUCCEEDED."""

--- a/gateway/scheduler/tasks/schedule_fleets_jobs.py
+++ b/gateway/scheduler/tasks/schedule_fleets_jobs.py
@@ -77,6 +77,11 @@ class ScheduleFleetsJobs(SchedulerTask):
 
     def add_queue_wait_time_metric(self, job: Job):
         """Add queue wait time metric."""
+        if job.filler:
+            # Filler jobs skip the queue by design; one that reaches here was
+            # rescued from QUEUED by fair-share, and its wait says nothing about
+            # how long real work waits.
+            return
         now = datetime.now(timezone.utc)
         wait_seconds = (now - job.created).total_seconds()
         job_compute_type = "gpu" if job.gpu else "cpu"

--- a/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
+++ b/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
@@ -163,11 +163,25 @@ class UpdateFleetsJobsStatuses(SchedulerTask):
 
     def _increment_terminal_counter(self, job: Job) -> None:
         """Increment terminal jobs counter."""
+        if job.filler:
+            # A filler job runs continuously, so counting it here would make a
+            # constant floor look like user demand. It gets its own counter, which
+            # is worth having because reaching a terminal state on this path means
+            # nothing asked the job to stop: FAILED or SUCCEEDED is a filler
+            # function that exited by itself, and STOPPED is the PROGRAM_TIMEOUT
+            # path. The scheduler task that will stop filler jobs deliberately
+            # writes their terminal status itself and never reaches this method.
+            self.metrics.increment_filler_jobs_ended(job.status)
+            return
         provider = job.program.provider.name if job.program_id and job.program.provider_id else "custom"
         self.metrics.increment_jobs_terminal(provider=provider, final_status=job.status)
 
     def _record_execution_duration(self, job: Job) -> None:
         """Record execution duration for a successfully completed job."""
+        if job.filler:
+            # Filler jobs run until something needs their slot, so their lifetime
+            # says nothing about how long real work takes.
+            return
         running_event = JobEvent.objects.filter(job=job, data__status=Job.RUNNING).order_by("-created").first()
         if running_event is None:
             return

--- a/gateway/scheduler/tasks/update_job_status_counts.py
+++ b/gateway/scheduler/tasks/update_job_status_counts.py
@@ -20,13 +20,15 @@ class UpdateJobStatusCounts(SchedulerTask):
         self.metrics = metrics
 
     def run(self):
-        """Update job counts per status and provider (active states only)."""
+        """Update job counts per status and provider (active states only).
+
+        Filler jobs run continuously, so counting them here would make a constant
+        floor look like user demand. They get their own gauge instead.
+        """
         statuses = [Job.QUEUED, Job.PENDING, Job.RUNNING]
-        rows = (
-            Job.objects.filter(status__in=statuses)
-            .values("status", "program__provider__name")
-            .annotate(count=Count("id"))
-        )
+        active = Job.objects.filter(status__in=statuses)
+
+        rows = active.exclude(filler=True).values("status", "program__provider__name").annotate(count=Count("id"))
         counts = {}
         for row in rows:
             status = row["status"]
@@ -35,3 +37,8 @@ class UpdateJobStatusCounts(SchedulerTask):
         self.metrics.clear_job_status_counts()
         for (status, provider), count in counts.items():
             self.metrics.set_job_status_count(count, status, provider)
+
+        filler_rows = list(active.filter(filler=True).values("status").annotate(count=Count("id")))
+        self.metrics.clear_filler_jobs_counts()
+        for row in filler_rows:
+            self.metrics.set_filler_jobs_count(row["count"], row["status"])

--- a/gateway/scheduler/tasks/update_ray_jobs_statuses.py
+++ b/gateway/scheduler/tasks/update_ray_jobs_statuses.py
@@ -146,11 +146,18 @@ class UpdateRayJobsStatuses(SchedulerTask):
 
     def _increment_terminal_counter(self, job: Job) -> None:
         """Increment terminal jobs counter."""
+        if job.filler:
+            # A filler job stopped to free capacity is not a job that finished.
+            return
         provider = job.program.provider.name if job.program_id and job.program.provider_id else "custom"
         self.metrics.increment_jobs_terminal(provider=provider, final_status=job.status)
 
     def _record_execution_duration(self, job: Job) -> None:
         """Record execution duration for a successfully completed job."""
+        if job.filler:
+            # Filler jobs run until something needs their slot, so their lifetime
+            # says nothing about how long real work takes.
+            return
         running_event = JobEvent.objects.filter(job=job, data__status=Job.RUNNING).order_by("-created").first()
         if running_event is None:
             return

--- a/gateway/tests/scheduler/test_schedule_fleets_jobs.py
+++ b/gateway/tests/scheduler/test_schedule_fleets_jobs.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
+from core.models import Job
 from scheduler.tasks.schedule_fleets_jobs import ScheduleFleetsJobs
 
 _MOD = "scheduler.tasks.schedule_fleets_jobs"
@@ -36,3 +37,24 @@ def test_fleets_execute_called_with_ctx():
         task._schedule_jobs_if_slots_available(max_slots_possible=5, number_of_slots_running=0)
 
     mock_execute.assert_called_once_with(mock_job, mock_ctx)
+
+
+def test_add_queue_wait_time_metric_skips_filler_jobs():
+    """Filler jobs skip the queue by design; the wait-time metric is only for real jobs."""
+    task = _make_task()
+
+    filler_job = MagicMock(spec=Job)
+    filler_job.filler = True
+    filler_job.created = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    filler_job.gpu = False
+
+    task.add_queue_wait_time_metric(filler_job)
+    task.metrics.observe_queue_wait_time.assert_not_called()
+
+    real_job = MagicMock(spec=Job)
+    real_job.filler = False
+    real_job.created = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    real_job.gpu = False
+
+    task.add_queue_wait_time_metric(real_job)
+    task.metrics.observe_queue_wait_time.assert_called_once()

--- a/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
+++ b/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
@@ -34,6 +34,7 @@ def _make_fleets_job(status=Job.RUNNING, fleet_id="fleet-123"):
     job.sub_status = None
     job.running_started_at = None
     job.instance_crn = "crn:v1:bluemix:public:quantum-computing:us-east:a/abc:def::"
+    job.filler = False
     job.in_terminal_state.return_value = status in Job.TERMINAL_STATUSES
 
     def _apply_update_fields(fields_map):
@@ -507,3 +508,33 @@ class TestEventStreamsIntegration:
 
         assert call_order == ["started", "license", "db"]
         task.event_streams_client.emit_license_fee.assert_called_once_with(job)
+
+
+def test_filler_jobs_are_left_out_of_the_job_metrics():
+    """A filler job neither counts as a terminal job nor contributes an execution duration."""
+    task = _make_task()
+    mock_job = MagicMock(spec=Job)
+    mock_job.filler = True
+
+    task._increment_terminal_counter(mock_job)
+    task._record_execution_duration(mock_job)
+
+    task.metrics.increment_jobs_terminal.assert_not_called()
+    task.metrics.observe_job_execution_duration.assert_not_called()
+
+
+def test_a_filler_job_that_ends_on_its_own_is_counted():
+    """Reaching a terminal state here means the balancer did not ask for it.
+
+    This is the counter that reveals a filler program which exits by itself, which
+    the balancer would otherwise replace once a second forever.
+    """
+    task = _make_task()
+    mock_job = MagicMock(spec=Job)
+    mock_job.filler = True
+    mock_job.status = Job.FAILED
+
+    task._increment_terminal_counter(mock_job)
+
+    task.metrics.increment_filler_jobs_ended.assert_called_once_with(Job.FAILED)
+    task.metrics.increment_jobs_terminal.assert_not_called()

--- a/gateway/tests/scheduler/test_update_job_status_counts.py
+++ b/gateway/tests/scheduler/test_update_job_status_counts.py
@@ -2,7 +2,13 @@
 
 from unittest.mock import MagicMock, patch, call
 
+import pytest
+from prometheus_client import CollectorRegistry
+
+from core.models import Job
+from scheduler.metrics.scheduler_metrics_collector import SchedulerMetrics
 from scheduler.tasks.update_job_status_counts import UpdateJobStatusCounts
+from tests.utils import TestUtils
 
 _MOD = "scheduler.tasks.update_job_status_counts"
 
@@ -26,9 +32,52 @@ def test_job_status_counts_clears_and_sets_metrics():
         MockJob.QUEUED = "QUEUED"
         MockJob.PENDING = "PENDING"
         MockJob.RUNNING = "RUNNING"
-        MockJob.objects.filter.return_value.values.return_value.annotate.return_value = fake_rows
+        MockJob.objects.filter.return_value.exclude.return_value.values.return_value.annotate.return_value = fake_rows
         task.run()
 
     task.metrics.clear_job_status_counts.assert_called_once()
     task.metrics.set_job_status_count.assert_any_call(3, "QUEUED", "ibm")
     task.metrics.set_job_status_count.assert_any_call(1, "RUNNING", "custom")
+
+
+def test_job_status_counts_exclude_filler_jobs():
+    """Filler jobs are excluded from the per-provider counts and reported on their own gauge."""
+    task = _make_task()
+
+    real_rows = [{"status": "RUNNING", "program__provider__name": "ibm", "count": 2}]
+    filler_rows = [{"status": "RUNNING", "count": 4}]
+
+    with patch(f"{_MOD}.Job") as MockJob:
+        MockJob.QUEUED = "QUEUED"
+        MockJob.PENDING = "PENDING"
+        MockJob.RUNNING = "RUNNING"
+        real_query = MockJob.objects.filter.return_value.exclude.return_value
+        real_query.values.return_value.annotate.return_value = real_rows
+        filler_query = MockJob.objects.filter.return_value.filter.return_value
+        filler_query.values.return_value.annotate.return_value = filler_rows
+        task.run()
+
+    MockJob.objects.filter.return_value.exclude.assert_called_once_with(filler=True)
+    task.metrics.set_job_status_count.assert_called_once_with(2, "RUNNING", "ibm")
+    task.metrics.clear_filler_jobs_counts.assert_called_once()
+    task.metrics.set_filler_jobs_count.assert_called_once_with(4, "RUNNING")
+
+
+@pytest.mark.django_db
+def test_the_gauges_split_real_and_filler_jobs_against_a_real_database():
+    """The SQL, not just the call, has to separate them, and stale series must go."""
+    metrics = SchedulerMetrics(CollectorRegistry())
+    task = UpdateJobStatusCounts(kill_signal=MagicMock(received=False), metrics=metrics)
+    program = TestUtils.create_program(program_title="counts-function", author="counts_user")
+    TestUtils.create_job(author="counts_user", program=program, status=Job.RUNNING)
+    filler = TestUtils.create_job(author="counts_user", program=program, status=Job.RUNNING, filler=True)
+
+    task.run()
+
+    assert metrics.job_status_count.labels(status=Job.RUNNING, provider="custom")._value.get() == 1
+    assert metrics.filler_jobs_count.labels(status=Job.RUNNING)._value.get() == 1
+
+    filler.delete()
+    task.run()
+
+    assert metrics.filler_jobs_count._metrics == {}

--- a/gateway/tests/scheduler/test_update_jobs_statuses.py
+++ b/gateway/tests/scheduler/test_update_jobs_statuses.py
@@ -95,3 +95,16 @@ class TestRayJobStatusUpdate:
             task.update_job_status(job)
 
         assert mock_runner.logs.call_count == 1
+
+
+def test_filler_jobs_are_left_out_of_the_job_metrics():
+    """A filler job neither counts as a terminal job nor contributes an execution duration."""
+    task = _make_task()
+    mock_job = MagicMock(spec=Job)
+    mock_job.filler = True
+
+    task._increment_terminal_counter(mock_job)
+    task._record_execution_duration(mock_job)
+
+    task.metrics.increment_jobs_terminal.assert_not_called()
+    task.metrics.observe_job_execution_duration.assert_not_called()

--- a/releasenotes/notes/filler-jobs-scheduler-metrics-8c1e5b47af02d6e9.yaml
+++ b/releasenotes/notes/filler-jobs-scheduler-metrics-8c1e5b47af02d6e9.yaml
@@ -1,0 +1,25 @@
+---
+features:
+  - |
+    Filler jobs are now reported separately in the scheduler metrics.
+    ``scheduler_filler_jobs_count`` is a gauge of how many are active, labelled by
+    status, and stale label combinations are cleared on every scheduler iteration so
+    a status that empties stops reporting rather than freezing at its last value.
+  - |
+    ``scheduler_filler_jobs_ended_total`` counts filler jobs that reached a terminal
+    state on the status-update path, labelled by ``final_status``. That path is only
+    reached when nothing asked the job to stop, so ``FAILED`` or ``SUCCEEDED`` there
+    is a filler function that exited by itself, which it is not meant to do. Being a
+    counter it only ever rises, so read it as a rate over a window rather than raw:
+    any sustained rate once ``STOPPED`` is filtered out means filler jobs are being
+    started and lost for nothing. ``STOPPED`` on this counter is the
+    ``PROGRAM_TIMEOUT`` path.
+upgrade:
+  - |
+    Filler jobs are excluded from ``scheduler_job_status_count``,
+    ``scheduler_jobs_terminal_total``, ``scheduler_job_execution_duration_seconds``
+    and ``scheduler_queue_wait_seconds``. They are meant to run continuously and to
+    be replaced when they end, so leaving them in those series would make a constant
+    floor look like user demand, and their lifetimes and queue waits say nothing
+    about how long real work takes or waits. Dashboards or alerts that expect those
+    series to cover every job need the filler series added to them.


### PR DESCRIPTION
### Summary

Filler jobs get their own scheduler metrics, and they stop polluting the ones that describe user demand. This is the observability groundwork for the filler jobs balancer, split out so that PR can be reviewed on its own.

Nothing observable changes today. The `Job.filler` column exists but nothing creates filler jobs yet, so the new gauge stays empty, the new counter never increments, and the four guards never fire. Both this and the balancer can merge in either order, with no dependency between them.

### Details and comments

`scheduler_filler_jobs_count` is a gauge of active filler jobs labelled by status. The whole label set is cleared on each scheduler iteration before being repopulated, so a status that empties stops reporting rather than freezing at its last value.

`scheduler_filler_jobs_ended_total` counts filler jobs that reached a terminal state on the status-update path, labelled by `final_status`. That path is only reached when nothing asked the job to stop, which is what makes the counter worth having: a filler function is meant to run until its slot is needed, so `FAILED` or `SUCCEEDED` there is one that exited by itself. It is a counter, so it only ever rises and resets when the scheduler pod restarts. Read it as a rate over a window rather than raw, with `STOPPED` filtered out, because `STOPPED` on this counter is the `PROGRAM_TIMEOUT` path.

The rest is four guards that keep existing series honest, and they are not new metrics. Filler jobs are excluded from `scheduler_job_status_count`, `scheduler_jobs_terminal_total`, `scheduler_job_execution_duration_seconds` and `scheduler_queue_wait_seconds`. A filler job is meant to run continuously and to be replaced when it ends, so leaving it in those series would make a constant floor look like user demand, its lifetime says nothing about how long real work takes, and its queue wait says nothing about how long real work waits.

