### PR TITLE
Bugfix: do not set job FAILED if status cannot be read

### DIFF
--- a/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
+++ b/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
@@ -52,10 +52,18 @@ class UpdateFleetsJobsStatuses(SchedulerTask):
         try:
             new_status = runner.status()
         except RunnerError as ex:
+            # status() raises on configuration and data problems, not on a job that
+            # failed: a deleted program, a missing or inactive Code Engine project, an
+            # unconfigured task store bucket. A COS read that fails returns None
+            # instead. So the status is unknown and the fleet may well still be
+            # running; leave it alone and let the timeout bound the wait.
             logger.error(
-                "job_id=%s user_id=%s error=%s Error getting status, set job as FAILED", job.id, job.author.id, str(ex)
+                "job_id=%s user_id=%s error=%s Error getting status, leaving it unchanged",
+                job.id,
+                job.author.id,
+                str(ex),
             )
-            self.to_terminal(job, Job.FAILED)
+            self.stop_job_if_timeout(job)
             return False
 
         if new_status is None:

--- a/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
+++ b/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
@@ -9,6 +9,7 @@ from core.model_managers.job_events import JobEventContext, JobEventOrigin
 from core.models import Job, Program
 from core.services.runners import RunnerError
 from scheduler.tasks.update_fleets_jobs_statuses import UpdateFleetsJobsStatuses
+from tests.utils import TestUtils
 
 _MOD = "scheduler.tasks.update_fleets_jobs_statuses"
 
@@ -58,20 +59,22 @@ class TestUpdateJobStatus:
         assert result is False
         mock_get_runner.assert_not_called()
 
-    def test_runner_error_calls_to_terminal_failed_and_returns_false(self):
+    def test_runner_error_leaves_the_status_alone_and_checks_the_timeout(self):
         task = _make_task()
         job = _make_fleets_job()
 
         mock_runner = MagicMock()
-        mock_runner.status.side_effect = RunnerError("connection error")
+        mock_runner.status.side_effect = RunnerError("Code Engine project 'p' is not active")
 
         with (
             patch(f"{_MOD}.get_runner", return_value=mock_runner),
             patch.object(task, "to_terminal") as mock_terminal,
+            patch.object(task, "stop_job_if_timeout") as mock_timeout,
         ):
             result = task.update_job_status(job)
 
-        mock_terminal.assert_called_once_with(job, Job.FAILED)
+        mock_terminal.assert_not_called()
+        mock_timeout.assert_called_once_with(job)
         assert result is False
 
     def test_succeeded_calls_to_terminal_and_records_duration(self):
@@ -538,3 +541,29 @@ def test_a_filler_job_that_ends_on_its_own_is_counted():
 
     task.metrics.increment_filler_jobs_ended.assert_called_once_with(Job.FAILED)
     task.metrics.increment_jobs_terminal.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_an_inactive_project_does_not_fail_a_running_job():
+    """A deactivated Code Engine project is a config problem, not a job that failed.
+
+    Exercises the real FleetsRunner so the RunnerError comes from the inactive
+    project rather than from a mock, which is how this reached production: the
+    fleet keeps running in Code Engine while the row says FAILED.
+    """
+    project = TestUtils.get_or_create_ce_project(
+        project_name="inactive-project",
+        project_id="project-uuid",
+        active=False,
+        cos_bucket_user_data_name="bucket",
+    )
+    program = TestUtils.create_program("inactive-project-program", runner=Program.FLEETS, code_engine_project=project)
+    job = Job.objects.create(
+        program=program, author=program.author, runner=Program.FLEETS, status=Job.RUNNING, fleet_id="fleet-abc"
+    )
+
+    task = _make_task()
+    task.update_job_status(job)
+
+    job.refresh_from_db()
+    assert job.status == Job.RUNNING

--- a/releasenotes/notes/fleets-status-config-error-8c31f9a4be07d2e5.yaml
+++ b/releasenotes/notes/fleets-status-config-error-8c31f9a4be07d2e5.yaml
@@ -1,0 +1,11 @@
+---
+fix:
+  - |
+    A Fleets job that is running is no longer marked as ``FAILED`` when the scheduler
+    cannot read its status because of a configuration problem. Marking a Code Engine
+    project inactive, clearing its task store bucket or deleting a function used to
+    fail every running job of that project on the next scheduler iteration, while the
+    fleets themselves kept running in Code Engine. The status is now left unchanged
+    and ``PROGRAM_TIMEOUT`` still bounds the wait, which is what already happened when
+    the status read itself failed. Submitting a new job to an inactive project still
+    fails, as it should.


### PR DESCRIPTION
### Summary

A Fleets job that is running is no longer marked as `FAILED` when the scheduler cannot read its status because of a configuration problem. The status is left unchanged and `PROGRAM_TIMEOUT` still bounds the wait, which is what already happened when the status read itself failed.

### Details and comments

`FleetsRunner.status()` reads the task state from COS, and a failed COS read returns `None` rather than raising, which the caller already handles by leaving the job alone. So every `RunnerError` that comes out of `status()` is a configuration or data problem instead: a deleted function, a function with no Code Engine project assigned, an inactive Code Engine project, a project with no task store bucket configured, or a job with no fleet id. None of those means the job failed. The fleet is very likely still running in Code Engine while the row says otherwise.

Marking a Code Engine project inactive is ordinary operational work, and it used to fail every running job of every function in that project on the next scheduler iteration.

Submitting a new job to an inactive project still fails, which is the correct behaviour there because the job never starts: `submit()` reaches the same check through `_get_handler()` and raises, and `execute_fleets_job` turns that into a `FAILED` job. Confirmed while working on this.

The regression test drives the real `FleetsRunner` against an inactive project rather than a mocked error, since that is the path this reached production through. It fails before the change with `assert 'FAILED' == 'RUNNING'`.

The Ray status poll has the same shape at `scheduler/tasks/update_ray_jobs_statuses.py`, and is left alone here.
