### PR TITLE
Fix fleets stuck in "Canceling" by cancelling processing tasks

### DIFF
--- a/gateway/core/ibm_cloud/code_engine/fleets/handler.py
+++ b/gateway/core/ibm_cloud/code_engine/fleets/handler.py
@@ -51,12 +51,8 @@ logger = logging.getLogger("FleetHandler")
 
 _UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 
-# Literal JSON field name sent in the cancel_fleet request body. cancel_job passes a plain
-# dict as the body, which bypasses the swagger model's attribute_map (snake<->camel)
-# conversion in ApiClient.sanitize_for_serialization, so this string is the wire key
-# verbatim. snake_case matches the CE engineer's guidance and the snake_case body already
-# built in submit_job (e.g. scale_cpu_limit). If CE rejects it, flip the casing here — this
-# is the single source of truth.
+# Literal JSON key in the cancel_fleet body (a plain dict bypasses the model's
+# attribute_map). Flip the casing here if CE rejects the field.
 _CANCEL_PROCESSING_TASKS_KEY = "cancel_processing_tasks"
 
 

--- a/gateway/core/ibm_cloud/code_engine/fleets/handler.py
+++ b/gateway/core/ibm_cloud/code_engine/fleets/handler.py
@@ -51,6 +51,14 @@ logger = logging.getLogger("FleetHandler")
 
 _UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 
+# Literal JSON field name sent in the cancel_fleet request body. cancel_job passes a plain
+# dict as the body, which bypasses the swagger model's attribute_map (snake<->camel)
+# conversion in ApiClient.sanitize_for_serialization, so this string is the wire key
+# verbatim. snake_case matches the CE engineer's guidance and the snake_case body already
+# built in submit_job (e.g. scale_cpu_limit). If CE rejects it, flip the casing here — this
+# is the single source of truth.
+_CANCEL_PROCESSING_TASKS_KEY = "cancel_processing_tasks"
+
 
 class FleetHandler:
     """Uses the swagger-generated FleetsAPI to manage fleet jobs."""
@@ -223,6 +231,7 @@ class FleetHandler:
         *,
         wait: bool = True,
         delete: bool = False,
+        cancel_processing_tasks: bool = True,
         timeout_seconds: int = 300,
         poll_interval_seconds: float = 2.0,
     ) -> None:
@@ -240,6 +249,11 @@ class FleetHandler:
             identifier: Fleet UUID or fleet name.
             wait: If True, poll the fleet until terminal after the cancel decision.
             delete: If True, delete the fleet after optional wait.
+            cancel_processing_tasks: If True, Code Engine kills the running task immediately
+                instead of waiting for it to finish before completing the cancelation.
+                Defaults to True so a cancel is honored even when the task never terminates
+                on its own, which otherwise leaves the fleet stuck in "Canceling"
+                indefinitely.
             timeout_seconds: Max time to wait for terminal state when wait=True.
             poll_interval_seconds: Delay between polls.
 
@@ -266,7 +280,11 @@ class FleetHandler:
 
         if should_attempt_cancel:
             try:
-                self._fleets_api.cancel_fleet(project_id=self.project_id, id=fleet_id)
+                self._fleets_api.cancel_fleet(
+                    project_id=self.project_id,
+                    id=fleet_id,
+                    body={_CANCEL_PROCESSING_TASKS_KEY: cancel_processing_tasks},
+                )
             except ApiException as exc:
                 if exc.status != 404:
                     raise

--- a/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_fleet_handler.py
+++ b/gateway/tests/core/services/ibm_cloud/code_engine/fleets/test_fleet_handler.py
@@ -25,7 +25,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from core.ibm_cloud.code_engine.ce_client.rest import ApiException
 
-from core.ibm_cloud.code_engine.fleets.handler import FleetHandler
+from core.ibm_cloud.code_engine.fleets.handler import _CANCEL_PROCESSING_TASKS_KEY, FleetHandler
 from core.ibm_cloud.code_engine.fleets.utils import (
     FleetJobPaths,
     build_run_env_variables,
@@ -297,7 +297,9 @@ def test_cancel_job_happy_path_waits_no_delete_by_default(project_id):
         ):
             handler.cancel_job(fleet_uuid, wait=True, timeout_seconds=10, poll_interval_seconds=0.01)
 
-    fleets_api.cancel_fleet.assert_called_once_with(project_id=project_id, id=fleet_uuid)
+    fleets_api.cancel_fleet.assert_called_once_with(
+        project_id=project_id, id=fleet_uuid, body={_CANCEL_PROCESSING_TASKS_KEY: True}
+    )
     waiter.assert_called_once()
     fleets_api.delete_fleet.assert_not_called()
 
@@ -317,7 +319,9 @@ def test_cancel_job_waits_and_deletes_when_flag_set(project_id):
         ):
             handler.cancel_job(fleet_uuid, wait=True, delete=True)
 
-    fleets_api.cancel_fleet.assert_called_once_with(project_id=project_id, id=fleet_uuid)
+    fleets_api.cancel_fleet.assert_called_once_with(
+        project_id=project_id, id=fleet_uuid, body={_CANCEL_PROCESSING_TASKS_KEY: True}
+    )
     waiter.assert_called_once()
     fleets_api.delete_fleet.assert_called_once_with(project_id=project_id, id=fleet_uuid)
 
@@ -337,7 +341,9 @@ def test_cancel_job_no_wait_skips_poller(project_id):
         ):
             handler.cancel_job(fleet_uuid, wait=False)
 
-    fleets_api.cancel_fleet.assert_called_once_with(project_id=project_id, id=fleet_uuid)
+    fleets_api.cancel_fleet.assert_called_once_with(
+        project_id=project_id, id=fleet_uuid, body={_CANCEL_PROCESSING_TASKS_KEY: True}
+    )
     waiter.assert_not_called()
     fleets_api.delete_fleet.assert_not_called()
 
@@ -380,7 +386,9 @@ def test_cancel_job_raises_on_non_404_delete_error(project_id):
                 handler.cancel_job(fleet_uuid, wait=True, delete=True)
 
     assert exc.value.status == 409
-    fleets_api.cancel_fleet.assert_called_once_with(project_id=project_id, id=fleet_uuid)
+    fleets_api.cancel_fleet.assert_called_once_with(
+        project_id=project_id, id=fleet_uuid, body={_CANCEL_PROCESSING_TASKS_KEY: True}
+    )
     fleets_api.delete_fleet.assert_called_once_with(project_id=project_id, id=fleet_uuid)
 
 
@@ -456,8 +464,55 @@ def test_cancel_job_times_out_raises_assertion(project_id):
             with pytest.raises(AssertionError):
                 handler.cancel_job(fleet_uuid, wait=True, delete=False, timeout_seconds=0)
 
-    fleets_api.cancel_fleet.assert_called_once_with(project_id=project_id, id=fleet_uuid)
+    fleets_api.cancel_fleet.assert_called_once_with(
+        project_id=project_id, id=fleet_uuid, body={_CANCEL_PROCESSING_TASKS_KEY: True}
+    )
     fleets_api.delete_fleet.assert_not_called()
+
+
+def test_cancel_job_sends_cancel_processing_tasks_true_by_default(project_id):
+    """cancel_job sends cancel_processing_tasks=true so CE kills a never-ending task.
+
+    Asserts the literal wire key (not the constant) to pin the on-the-wire field name and
+    catch an accidental rename or snake_case/camelCase flip. This is the regression guard
+    for the "fleet stuck in Canceling forever" bug.
+    """
+    with patch(f"{_HANDLER_MOD}.FleetsApi") as mock_fleets_api_cls:
+        fleets_api = MagicMock()
+        mock_fleets_api_cls.return_value = fleets_api
+        fleet_uuid = "f-00000000-0000-0000-0000-00000000000a"
+
+        handler = FleetHandler(ce_api_client=MagicMock(), project_id=project_id)
+        with (
+            patch.object(handler, "_resolve_fleet_id", return_value=fleet_uuid),
+            patch.object(handler, "_wait_until_terminal_or_canceled"),
+            patch.object(handler, "get_job_status", return_value={"status": "running"}),
+        ):
+            handler.cancel_job(fleet_uuid, wait=False)
+
+    fleets_api.cancel_fleet.assert_called_once_with(
+        project_id=project_id, id=fleet_uuid, body={"cancel_processing_tasks": True}
+    )
+
+
+def test_cancel_job_honors_cancel_processing_tasks_false(project_id):
+    """cancel_job forwards cancel_processing_tasks=false when explicitly requested."""
+    with patch(f"{_HANDLER_MOD}.FleetsApi") as mock_fleets_api_cls:
+        fleets_api = MagicMock()
+        mock_fleets_api_cls.return_value = fleets_api
+        fleet_uuid = "f-00000000-0000-0000-0000-00000000000b"
+
+        handler = FleetHandler(ce_api_client=MagicMock(), project_id=project_id)
+        with (
+            patch.object(handler, "_resolve_fleet_id", return_value=fleet_uuid),
+            patch.object(handler, "_wait_until_terminal_or_canceled"),
+            patch.object(handler, "get_job_status", return_value={"status": "running"}),
+        ):
+            handler.cancel_job(fleet_uuid, wait=False, cancel_processing_tasks=False)
+
+    fleets_api.cancel_fleet.assert_called_once_with(
+        project_id=project_id, id=fleet_uuid, body={"cancel_processing_tasks": False}
+    )
 
 
 def test_delete_job_happy_path(project_id):


### PR DESCRIPTION
## Summary

`FleetHandler.cancel_job` called Code Engine's `cancel_fleet` with **no request body**, so CE applied its default `cancel_processing_tasks=false`. With that default, CE waits for the fleet's running task to finish before completing the cancelation — so a task that never terminates on its own leaves the fleet stuck in **"Canceling" indefinitely**.

This sends `body={"cancel_processing_tasks": true}` on cancel, so CE terminates the in-flight task immediately and the cancel completes.

## Changes

- `cancel_job` now sends the `cancel_processing_tasks` flag in the cancel body, exposed as a keyword-only parameter defaulting to `True` (a cancel should be honored regardless of whether the task self-terminates). `FleetsRunner.stop()` inherits the corrected default with no change.
- The wire field name is isolated in a single module constant (`_CANCEL_PROCESSING_TASKS_KEY`) so the snake_case/camelCase choice has one source of truth.
- Reuses the existing raw-dict-body pattern already used by `submit_job` (serialized as-is by `ApiClient.sanitize_for_serialization`); no new client model needed.

## Behavior change

Cancelling any fleet now kills its in-flight task immediately rather than waiting for it to finish. This is the expected meaning of a cancel; jobs whose tasks terminate quickly are unaffected in practice.

## Tests

- Updated existing `cancel_job` handler assertions to expect the new body.
- Added a test pinning the literal wire key `cancel_processing_tasks=true` (regression guard against an accidental rename/casing flip) and one verifying the `false` override.
- All handler + fleets-runner unit tests pass; black + pylint clean.

## Validation note

Validated against CE API.