### PR TITLE
Surface T-shirt size elements in the backoffice admin

### DIFF
--- a/gateway/api/admin.py
+++ b/gateway/api/admin.py
@@ -5,6 +5,7 @@ import logging
 import uuid
 
 from django import forms
+from django.conf import settings
 from django.contrib import admin, messages
 from django.core.cache import cache
 from django.db.models import Count, F, Q
@@ -20,6 +21,7 @@ from api.domain.arguments_schema import (
 )
 from api.domain.job_timeline import render_job_timeline
 from api.domain.exceptions.invalid_arguments_exception import InvalidArgumentsException
+from api.use_cases.programs.upload import no_ce_project_message, seed_default_size
 from api.use_cases.programs.validate_arguments import validate_arguments
 from core.models import (
     CodeEngineProject,
@@ -242,6 +244,41 @@ class ProgramAdminForm(forms.ModelForm):
 
         return value
 
+    def clean(self):
+        """Assign a Code Engine project to a Fleets function, and refuse the save if none is available.
+
+        The upload endpoint auto-assigns a CE project (provider's project, or the deployment default)
+        and rejects a Fleets function it cannot place, since one is not runnable without an active
+        project. A plain admin save skips that, so replicate it here: fail loud with the same wording
+        rather than let an operator persist a function that can never run.
+
+        Runs before ``_post_clean`` copies cleaned values onto the instance, so the assigned project
+        is written back into ``cleaned_data`` for the save to pick up. Leaving a project the operator
+        chose alone falls out of ``assign_to_program`` being a no-op when one is already set.
+        """
+        cleaned_data = super().clean()
+
+        if cleaned_data.get("runner") != Program.FLEETS:
+            return cleaned_data
+
+        # Mirror the request onto the instance so the manager sees the values being saved, not the
+        # stored ones, then let it assign (in place) exactly as the upload use case does.
+        self.instance.runner = Program.FLEETS
+        self.instance.provider = cleaned_data.get("provider")
+        self.instance.code_engine_project = cleaned_data.get("code_engine_project")
+        try:
+            CodeEngineProject.objects.assign_to_program(self.instance)
+        except ValueError:
+            # select_default() raises when CE_DEFAULT_PROJECT_NAME is unconfigured; treat it as
+            # "no project available" and fall through to the rejection below.
+            pass
+
+        if not self.instance.code_engine_project:
+            raise forms.ValidationError(no_ce_project_message(self.instance))
+
+        cleaned_data["code_engine_project"] = self.instance.code_engine_project
+        return cleaned_data
+
 
 class ValidateArgumentsForm(forms.Form):
     """Arguments to try against a function's stored schema."""
@@ -377,6 +414,48 @@ class ProgramAdmin(admin.ModelAdmin):
         if obj:
             readonly_fields.append("title")
         return readonly_fields
+
+    def save_related(self, request, form, formsets, change):
+        """After the inline size rows are saved, seed a default size for a size-less Fleets function.
+
+        This mirrors the upload use case, which gives every Fleets function a size so runs resolve a
+        compute profile. It runs here rather than in ``save_model`` because the inline ``FunctionSize``
+        formset is only written by ``super().save_related``; before that a function whose operator
+        just declared sizes inline still looks size-less. The CE project is already guaranteed by the
+        form's ``clean`` for Fleets, so only sizing is left to do.
+        """
+        super().save_related(request, form, formsets, change)
+
+        obj = form.instance
+        if obj.runner != Program.FLEETS:
+            return
+
+        self._ensure_default_size(request, obj)
+
+    def _ensure_default_size(self, request, obj):
+        """Seed the deployment default size when a Fleets function declares none, like upload does.
+
+        Skipped when the operator already picked a default or declared any sizes inline, so an edit
+        never overwrites their choice. Seeding is non-fatal: if the default compute profile is not
+        registered the helper leaves the function size-less (it falls back to the platform default
+        profile at run time), and we say so rather than failing the save.
+        """
+        if obj.default_size_id:
+            return
+        if FunctionSize.objects.filter(function=obj).exists():
+            return
+
+        seed_default_size(obj)
+
+        # seed_default_size sets default_size on obj in place; a still-empty default means the
+        # configured DEFAULT_FUNCTION_SIZE_PROFILE has no ComputeProfile row.
+        if not obj.default_size_id:
+            messages.warning(
+                request,
+                f"Default compute profile '{settings.DEFAULT_FUNCTION_SIZE_PROFILE}' is not registered, "
+                "so this function was left with no default size and will run on the platform default "
+                "compute profile. Register the profile or add a size to give it an explicit default.",
+            )
 
     def render_change_form(self, request, context, *args, **kwargs):
         """Warn at the top of the page when the stored arguments_schema is unusable.

--- a/gateway/api/admin.py
+++ b/gateway/api/admin.py
@@ -126,9 +126,36 @@ class ComputeProfileAdmin(admin.ModelAdmin):
 
     # search_fields is required for FunctionSizeAdmin's autocomplete on compute_profile
     search_fields = ["compute_profile_id", "name"]
-    list_display = ["compute_profile_id", "name", "cpu", "gpu", "memory", "updated"]
+    list_display = ["compute_profile_id", "name", "cpu", "gpu", "memory", "sizes_using", "updated"]
     ordering = ["compute_profile_id"]
     readonly_fields = ["created", "updated"]
+
+    def get_queryset(self, request):
+        # Annotate the reference count once per changelist so `sizes_using` does not run a
+        # query per row. The FK to ComputeProfile is PROTECT, so this count is exactly what an
+        # operator needs to see before editing or trying to delete a profile.
+        return super().get_queryset(request).annotate(sizes_using_count=Count("function_sizes"))
+
+    @admin.display(description="Sizes using", ordering="sizes_using_count")
+    def sizes_using(self, obj):
+        """How many FunctionSize rows reference this profile (PROTECTs deletion when > 0)."""
+        return obj.sizes_using_count
+
+
+class FunctionSizeInline(admin.TabularInline):
+    """A function's size catalog (its sizes map) shown inline on the function page.
+
+    Each row maps a size key (e.g. ``s``/``m``/``l``) to the compute profile it runs on. Editing
+    the catalog here, next to ``default_size``, is what the upload endpoint's ``sizes`` payload
+    builds; the separate FunctionSize changelist stays available for cross-function views.
+    """
+
+    model = FunctionSize
+    extra = 0
+    fields = ["function_size", "compute_profile", "updated"]
+    readonly_fields = ["updated"]
+    autocomplete_fields = ["compute_profile"]
+    verbose_name_plural = "Sizes (compute profile per size)"
 
 
 @admin.register(FunctionSize)
@@ -263,6 +290,7 @@ class ProgramAdmin(admin.ModelAdmin):
     """ProgramAdmin."""
 
     form = ProgramAdminForm
+    inlines = [FunctionSizeInline]
     search_fields = ["title", "author__username"]
     list_filter = ["provider", "type", "runner", "disabled"]
     filter_horizontal = ["instances", "trial_instances"]
@@ -288,6 +316,18 @@ class ProgramAdmin(admin.ModelAdmin):
             "Execution",
             {"fields": ["runner", "gpu", "entrypoint", "artifact", "image", "dependencies", "arguments_schema"]},
         ),
+        (
+            "Sizes",
+            {
+                "fields": ["default_size"],
+                "description": (
+                    "T-shirt sizes for the Fleets runner. Edit the size catalog (each size &rarr; "
+                    "compute profile) in the <b>Sizes</b> table below, then pick the "
+                    "<code>default_size</code> used when a run omits a size. The default must be one "
+                    "of this function's own sizes."
+                ),
+            },
+        ),
         ("Fleets", {"fields": ["code_engine_project"]}),
         ("Ownership", {"fields": ["author", "provider", "instances", "trial_instances"]}),
     ]
@@ -298,8 +338,39 @@ class ProgramAdmin(admin.ModelAdmin):
         "author",
         "type",
         "runner",
+        "sizes_summary",
         "disabled",
     ]
+
+    def get_queryset(self, request):
+        # Count the size rows once per changelist for `sizes_summary`, and pull default_size along
+        # so rendering the default's label does not fire a query per row.
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("default_size")
+            .annotate(declared_sizes_count=Count("function_sizes"))
+        )
+
+    @admin.display(description="Sizes", ordering="declared_sizes_count")
+    def sizes_summary(self, obj):
+        """At-a-glance size config: how many sizes are declared and which is the default."""
+        if not obj.declared_sizes_count:
+            return "-"
+        default = obj.default_size.function_size if obj.default_size_id else "none"
+        return f"{obj.declared_sizes_count} (default: {default})"
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        # default_size must belong to this same function (Program.clean() enforces it), so the
+        # dropdown is limited to this function's own sizes rather than every FunctionSize row.
+        # On the add form there is no function yet and therefore no sizes to choose from.
+        if db_field.name == "default_size":
+            resolver_match = getattr(request, "resolver_match", None)
+            object_id = resolver_match.kwargs.get("object_id") if resolver_match else None
+            kwargs["queryset"] = (
+                FunctionSize.objects.filter(function_id=object_id) if object_id else FunctionSize.objects.none()
+            )
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
     def get_readonly_fields(self, request, obj=None):
         readonly_fields = list(super().get_readonly_fields(request, obj))

--- a/gateway/api/admin.py
+++ b/gateway/api/admin.py
@@ -353,20 +353,20 @@ class ProgramAdmin(admin.ModelAdmin):
             "Execution",
             {"fields": ["runner", "gpu", "entrypoint", "artifact", "image", "dependencies", "arguments_schema"]},
         ),
+        ("Fleets", {"fields": ["code_engine_project"]}),
+        ("Ownership", {"fields": ["author", "provider", "instances", "trial_instances"]}),
         (
-            "Sizes",
+            "Default size",
             {
                 "fields": ["default_size"],
                 "description": (
                     "T-shirt sizes for the Fleets runner. Edit the size catalog (each size &rarr; "
-                    "compute profile) in the <b>Sizes</b> table below, then pick the "
+                    "compute profile) in the <b>Sizes</b> table above, then pick the "
                     "<code>default_size</code> used when a run omits a size. The default must be one "
                     "of this function's own sizes."
                 ),
             },
         ),
-        ("Fleets", {"fields": ["code_engine_project"]}),
-        ("Ownership", {"fields": ["author", "provider", "instances", "trial_instances"]}),
     ]
 
     list_display = [

--- a/gateway/api/admin.py
+++ b/gateway/api/admin.py
@@ -5,7 +5,6 @@ import logging
 import uuid
 
 from django import forms
-from django.conf import settings
 from django.contrib import admin, messages
 from django.core.cache import cache
 from django.db.models import Count, F, Q
@@ -21,7 +20,7 @@ from api.domain.arguments_schema import (
 )
 from api.domain.job_timeline import render_job_timeline
 from api.domain.exceptions.invalid_arguments_exception import InvalidArgumentsException
-from api.use_cases.programs.upload import no_ce_project_message, seed_default_size
+from api.use_cases.programs.upload import no_ce_project_message
 from api.use_cases.programs.validate_arguments import validate_arguments
 from core.models import (
     CodeEngineProject,
@@ -414,48 +413,6 @@ class ProgramAdmin(admin.ModelAdmin):
         if obj:
             readonly_fields.append("title")
         return readonly_fields
-
-    def save_related(self, request, form, formsets, change):
-        """After the inline size rows are saved, seed a default size for a size-less Fleets function.
-
-        This mirrors the upload use case, which gives every Fleets function a size so runs resolve a
-        compute profile. It runs here rather than in ``save_model`` because the inline ``FunctionSize``
-        formset is only written by ``super().save_related``; before that a function whose operator
-        just declared sizes inline still looks size-less. The CE project is already guaranteed by the
-        form's ``clean`` for Fleets, so only sizing is left to do.
-        """
-        super().save_related(request, form, formsets, change)
-
-        obj = form.instance
-        if obj.runner != Program.FLEETS:
-            return
-
-        self._ensure_default_size(request, obj)
-
-    def _ensure_default_size(self, request, obj):
-        """Seed the deployment default size when a Fleets function declares none, like upload does.
-
-        Skipped when the operator already picked a default or declared any sizes inline, so an edit
-        never overwrites their choice. Seeding is non-fatal: if the default compute profile is not
-        registered the helper leaves the function size-less (it falls back to the platform default
-        profile at run time), and we say so rather than failing the save.
-        """
-        if obj.default_size_id:
-            return
-        if FunctionSize.objects.filter(function=obj).exists():
-            return
-
-        seed_default_size(obj)
-
-        # seed_default_size sets default_size on obj in place; a still-empty default means the
-        # configured DEFAULT_FUNCTION_SIZE_PROFILE has no ComputeProfile row.
-        if not obj.default_size_id:
-            messages.warning(
-                request,
-                f"Default compute profile '{settings.DEFAULT_FUNCTION_SIZE_PROFILE}' is not registered, "
-                "so this function was left with no default size and will run on the platform default "
-                "compute profile. Register the profile or add a size to give it an explicit default.",
-            )
 
     def render_change_form(self, request, context, *args, **kwargs):
         """Warn at the top of the page when the stored arguments_schema is unusable.

--- a/gateway/api/use_cases/programs/upload.py
+++ b/gateway/api/use_cases/programs/upload.py
@@ -44,11 +44,14 @@ def _normalize_dependency(raw_dependency) -> str:
     return dependency_name + dependency_version
 
 
-def _no_ce_project_message(function: Function) -> str:
+def no_ce_project_message(function: Function) -> str:
     """Message for a Fleets function with no Code Engine project, naming its provider if it has one.
 
     Distinguishes a provider with no project linked at all from one whose linked project
     is inactive, since those call for different administrator action.
+
+    Public because the Django admin reuses it to reject a Fleets function that cannot be
+    assigned an active project, keeping the admin's wording identical to this endpoint's.
     """
     if function.provider:
         project = function.provider.code_engine_project
@@ -157,6 +160,39 @@ def _apply_default_size(function: Function, default_size: str) -> None:
     function.save(update_fields=["default_size"])
 
 
+def seed_default_size(function: Function) -> None:
+    """Give a function with no declared catalog the deployment's default size.
+
+    Declaring sizes is still optional, so this is what gets every function to
+    a size. The seed is skipped rather than fatal when the profile row is
+    absent (an operator may not have populated ComputeProfile yet), leaving
+    the function to run on DEFAULT_COMPUTE_PROFILE as it did before sizes
+    existed.
+
+    Module-level so the Django admin can reuse the exact same seeding on a
+    hand-created Fleets function, keeping one source of truth.
+    """
+    compute_profile_id = settings.DEFAULT_FUNCTION_SIZE_PROFILE
+    profile = ComputeProfile.objects.get_by_id(compute_profile_id)
+    if profile is None:
+        logger.warning(
+            "program=%s | Default compute profile [%s] is not registered; "
+            "function created with no sizes and will run on the default compute profile.",
+            function.title,
+            compute_profile_id,
+        )
+        return
+
+    size_name = settings.DEFAULT_FUNCTION_SIZE
+    row = FunctionSize.objects.create(
+        function=function,
+        function_size=size_name,
+        compute_profile=profile,
+    )
+    function.default_size = row
+    function.save(update_fields=["default_size"])
+
+
 class UploadFunctionUseCase:
     """Use case for uploading (creating or updating) a Qiskit Function."""
 
@@ -229,7 +265,7 @@ class UploadFunctionUseCase:
 
         CodeEngineProject.objects.assign_to_program(function)
         if function.runner == Function.FLEETS and not function.code_engine_project:
-            message = _no_ce_project_message(function)
+            message = no_ce_project_message(function)
             logger.warning("user_id=%s program=%s | %s", user.id, function.title, message)
             raise FunctionConfigurationException(message)
 
@@ -259,33 +295,12 @@ class UploadFunctionUseCase:
         return function
 
     def _seed_default_size(self, function: Function) -> None:
-        """Give a function with no declared catalog the deployment's default size.
+        """Seed the deployment default size; delegates to the module-level helper.
 
-        Declaring sizes is still optional, so this is what gets every function to
-        a size. The seed is skipped rather than fatal when the profile row is
-        absent (an operator may not have populated ComputeProfile yet), leaving
-        the function to run on DEFAULT_COMPUTE_PROFILE as it did before sizes
-        existed.
+        Kept as a method so the ``_create`` call site and any caller reaching in
+        through the use-case stay unchanged, while the logic lives in one place.
         """
-        compute_profile_id = settings.DEFAULT_FUNCTION_SIZE_PROFILE
-        profile = ComputeProfile.objects.get_by_id(compute_profile_id)
-        if profile is None:
-            logger.warning(
-                "program=%s | Default compute profile [%s] is not registered; "
-                "function created with no sizes and will run on the default compute profile.",
-                function.title,
-                compute_profile_id,
-            )
-            return
-
-        size_name = settings.DEFAULT_FUNCTION_SIZE
-        row = FunctionSize.objects.create(
-            function=function,
-            function_size=size_name,
-            compute_profile=profile,
-        )
-        function.default_size = row
-        function.save(update_fields=["default_size"])
+        seed_default_size(function)
 
     @staticmethod
     def _apply_scalar_updates(instance: Function, data: UploadFunctionInput) -> None:
@@ -315,7 +330,7 @@ class UploadFunctionUseCase:
             instance.runner = data.runner
             CodeEngineProject.objects.assign_to_program(instance)
             if instance.runner == Function.FLEETS and not instance.code_engine_project:
-                message = _no_ce_project_message(instance)
+                message = no_ce_project_message(instance)
                 logger.warning("user_id=%s program=%s | %s", user.id, instance.title, message)
                 raise FunctionConfigurationException(message)
 

--- a/gateway/api/use_cases/programs/upload.py
+++ b/gateway/api/use_cases/programs/upload.py
@@ -160,39 +160,6 @@ def _apply_default_size(function: Function, default_size: str) -> None:
     function.save(update_fields=["default_size"])
 
 
-def seed_default_size(function: Function) -> None:
-    """Give a function with no declared catalog the deployment's default size.
-
-    Declaring sizes is still optional, so this is what gets every function to
-    a size. The seed is skipped rather than fatal when the profile row is
-    absent (an operator may not have populated ComputeProfile yet), leaving
-    the function to run on DEFAULT_COMPUTE_PROFILE as it did before sizes
-    existed.
-
-    Module-level so the Django admin can reuse the exact same seeding on a
-    hand-created Fleets function, keeping one source of truth.
-    """
-    compute_profile_id = settings.DEFAULT_FUNCTION_SIZE_PROFILE
-    profile = ComputeProfile.objects.get_by_id(compute_profile_id)
-    if profile is None:
-        logger.warning(
-            "program=%s | Default compute profile [%s] is not registered; "
-            "function created with no sizes and will run on the default compute profile.",
-            function.title,
-            compute_profile_id,
-        )
-        return
-
-    size_name = settings.DEFAULT_FUNCTION_SIZE
-    row = FunctionSize.objects.create(
-        function=function,
-        function_size=size_name,
-        compute_profile=profile,
-    )
-    function.default_size = row
-    function.save(update_fields=["default_size"])
-
-
 class UploadFunctionUseCase:
     """Use case for uploading (creating or updating) a Qiskit Function."""
 
@@ -295,12 +262,33 @@ class UploadFunctionUseCase:
         return function
 
     def _seed_default_size(self, function: Function) -> None:
-        """Seed the deployment default size; delegates to the module-level helper.
+        """Give a function with no declared catalog the deployment's default size.
 
-        Kept as a method so the ``_create`` call site and any caller reaching in
-        through the use-case stay unchanged, while the logic lives in one place.
+        Declaring sizes is still optional, so this is what gets every function to
+        a size. The seed is skipped rather than fatal when the profile row is
+        absent (an operator may not have populated ComputeProfile yet), leaving
+        the function to run on DEFAULT_COMPUTE_PROFILE as it did before sizes
+        existed.
         """
-        seed_default_size(function)
+        compute_profile_id = settings.DEFAULT_FUNCTION_SIZE_PROFILE
+        profile = ComputeProfile.objects.get_by_id(compute_profile_id)
+        if profile is None:
+            logger.warning(
+                "program=%s | Default compute profile [%s] is not registered; "
+                "function created with no sizes and will run on the default compute profile.",
+                function.title,
+                compute_profile_id,
+            )
+            return
+
+        size_name = settings.DEFAULT_FUNCTION_SIZE
+        row = FunctionSize.objects.create(
+            function=function,
+            function_size=size_name,
+            compute_profile=profile,
+        )
+        function.default_size = row
+        function.save(update_fields=["default_size"])
 
     @staticmethod
     def _apply_scalar_updates(instance: Function, data: UploadFunctionInput) -> None:

--- a/gateway/templates/program/change_form.html
+++ b/gateway/templates/program/change_form.html
@@ -16,3 +16,25 @@
         </li>
     {% endif %}
 {% endblock %}
+
+{# Render every fieldset except "Default size", which we render after the Sizes inline below so the
+   size catalog (the inline table) comes first and the default_size pointer sits right under it. #}
+{% block field_sets %}
+{% for fieldset in adminform %}
+    {% if fieldset.name != "Default size" %}
+        {% include "admin/includes/fieldset.html" with heading_level=2 prefix="fieldset" id_prefix=0 id_suffix=forloop.counter0 %}
+    {% endif %}
+{% endfor %}
+{% endblock %}
+
+{# Sizes inline (the catalog), then the "Default size" fieldset that points into it. #}
+{% block inline_field_sets %}
+{% for inline_admin_formset in inline_admin_formsets %}
+    {% include inline_admin_formset.opts.template %}
+{% endfor %}
+{% for fieldset in adminform %}
+    {% if fieldset.name == "Default size" %}
+        {% include "admin/includes/fieldset.html" with heading_level=2 prefix="fieldset" id_prefix=0 id_suffix=forloop.counter0 %}
+    {% endif %}
+{% endfor %}
+{% endblock %}

--- a/gateway/tests/test_tshirt_admin.py
+++ b/gateway/tests/test_tshirt_admin.py
@@ -1,0 +1,147 @@
+"""Tests for the T-shirt size elements of the backoffice admin.
+
+Covers the function size catalog (the sizes map) surfaced on the Program page, the ``default_size``
+dropdown restricted to a function's own sizes, and the reference count shown on ComputeProfile.
+"""
+
+import itertools
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import User
+from django.test.client import RequestFactory
+from django.urls import reverse
+
+from api.admin import ComputeProfileAdmin, ProgramAdmin
+from core.models import ComputeProfile, FunctionSize, Program, Provider
+
+# Unique per call so a test can make more than one function without colliding on username/provider.
+_counter = itertools.count()
+
+
+def _function() -> Program:
+    """A Fleets function with an author and provider, stored straight through the ORM."""
+    n = next(_counter)
+    user = User.objects.create_user(username=f"u{n}", password="x")
+    provider = Provider.objects.create(name=f"P{n}")
+    return Program.objects.create(title=f"t{n}", author=user, provider=provider, runner=Program.FLEETS)
+
+
+def _profile(compute_profile_id: str = "8x32") -> ComputeProfile:
+    return ComputeProfile.objects.create(compute_profile_id=compute_profile_id, cpu="8", memory="32")
+
+
+def _size(function: Program, name: str, profile: ComputeProfile) -> FunctionSize:
+    return FunctionSize.objects.create(function=function, function_size=name, compute_profile=profile)
+
+
+@pytest.mark.django_db
+def test_default_size_dropdown_is_limited_to_this_functions_sizes():
+    """The default must belong to the same function (Program.clean()), so only its own sizes
+    may appear in the dropdown — never sizes declared by some other function."""
+    function = _function()
+    profile = _profile()
+    mine = _size(function, "s", profile)
+
+    other = _function()
+    _size(other, "s", profile)  # a different function's size must not leak into the dropdown
+
+    admin = ProgramAdmin(Program, AdminSite())
+    request = RequestFactory().get(reverse("admin:api_program_change", args=[function.pk]))
+    request.resolver_match = type("M", (), {"kwargs": {"object_id": str(function.pk)}})
+
+    form_class = admin.get_form(request, obj=function)
+    choices = form_class().fields["default_size"].queryset
+
+    assert list(choices) == [mine]
+
+
+@pytest.mark.django_db
+def test_default_size_dropdown_is_empty_on_the_add_form():
+    """A function that does not exist yet has no sizes, so nothing is offered as a default."""
+    admin = ProgramAdmin(Program, AdminSite())
+    request = RequestFactory().get(reverse("admin:api_program_add"))
+    request.resolver_match = type("M", (), {"kwargs": {}})
+
+    form_class = admin.get_form(request, obj=None)
+
+    assert list(form_class().fields["default_size"].queryset) == []
+
+
+@pytest.mark.django_db
+def test_sizes_summary_reports_count_and_default():
+    """The changelist column shows how many sizes are declared and which one is the default."""
+    function = _function()
+    profile = _profile()
+    small = _size(function, "s", profile)
+    _size(function, "m", profile)
+    function.default_size = small
+    function.save(update_fields=["default_size"])
+
+    admin = ProgramAdmin(Program, AdminSite())
+    request = RequestFactory().get(reverse("admin:api_program_changelist"))
+    obj = admin.get_queryset(request).get(pk=function.pk)
+
+    assert admin.sizes_summary(obj) == "2 (default: s)"
+
+
+@pytest.mark.django_db
+def test_sizes_summary_is_a_dash_when_no_sizes_are_declared():
+    """A function without a size catalog reads as '-' rather than '0 (default: none)'."""
+    function = _function()
+    admin = ProgramAdmin(Program, AdminSite())
+    request = RequestFactory().get(reverse("admin:api_program_changelist"))
+    obj = admin.get_queryset(request).get(pk=function.pk)
+
+    assert admin.sizes_summary(obj) == "-"
+
+
+@pytest.mark.django_db
+def test_the_change_page_shows_the_size_catalog_inline(client):
+    """The whole sizes map is visible on the function page, not only on the FunctionSize list."""
+    function = _function()
+    profile = _profile("24x120x1l40s")
+    _size(function, "l", profile)
+    client.force_login(User.objects.create_superuser(username="admin", password="x", email="a@b.c"))
+
+    response = client.get(reverse("admin:api_program_change", args=[function.pk]))
+
+    assert response.status_code == 200
+    body = response.content.decode()
+    assert "24x120x1l40s" in body
+    assert "Sizes (compute profile per size)" in body
+
+
+@pytest.mark.django_db
+def test_the_change_page_offers_only_this_functions_sizes_as_default(client):
+    """End-to-end through the real admin URL: the default_size dropdown on the rendered page lists
+    this function's own size and not another function's, proving object_id reaches the formfield."""
+    function = _function()
+    profile = _profile()
+    _size(function, "mine", profile)
+
+    other = _function()
+    _size(other, "theirs", profile)
+
+    client.force_login(User.objects.create_superuser(username="admin", password="x", email="a@b.c"))
+    response = client.get(reverse("admin:api_program_change", args=[function.pk]))
+
+    default_field = response.context["adminform"].form.fields["default_size"]
+    labels = [str(obj) for obj in default_field.queryset]
+    assert any("mine" in label for label in labels)
+    assert not any("theirs" in label for label in labels)
+
+
+@pytest.mark.django_db
+def test_compute_profile_reports_how_many_sizes_use_it():
+    """An operator must see a profile is referenced before editing it (the FK is PROTECT)."""
+    function = _function()
+    profile = _profile()
+    _size(function, "s", profile)
+    _size(function, "m", profile)
+
+    admin = ComputeProfileAdmin(ComputeProfile, AdminSite())
+    request = RequestFactory().get(reverse("admin:api_computeprofile_changelist"))
+    obj = admin.get_queryset(request).get(pk=profile.pk)
+
+    assert admin.sizes_using(obj) == 2

--- a/gateway/tests/test_tshirt_admin.py
+++ b/gateway/tests/test_tshirt_admin.py
@@ -5,15 +5,19 @@ dropdown restricted to a function's own sizes, and the reference count shown on 
 """
 
 import itertools
+from types import SimpleNamespace
 
 import pytest
+from django import forms
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from api.admin import ComputeProfileAdmin, ProgramAdmin
-from core.models import ComputeProfile, FunctionSize, Program, Provider
+from api.admin import ComputeProfileAdmin, ProgramAdmin, ProgramAdminForm
+from core.models import CodeEngineProject, ComputeProfile, FunctionSize, Program, Provider
 
 # Unique per call so a test can make more than one function without colliding on username/provider.
 _counter = itertools.count()
@@ -33,6 +37,38 @@ def _profile(compute_profile_id: str = "8x32") -> ComputeProfile:
 
 def _size(function: Program, name: str, profile: ComputeProfile) -> FunctionSize:
     return FunctionSize.objects.create(function=function, function_size=name, compute_profile=profile)
+
+
+def _ce_project(name: str = "ce-proj", active: bool = True) -> CodeEngineProject:
+    """A minimally-populated active Code Engine project (CharFields default to '')."""
+    return CodeEngineProject.objects.create(
+        project_id=f"{name}-id",
+        project_name=name,
+        region="us-east",
+        active=active,
+    )
+
+
+def _request_with_messages():
+    """A request the admin can attach messages to (save_related emits warnings)."""
+    request = RequestFactory().post("/")
+    setattr(request, "session", {})
+    setattr(request, "_messages", FallbackStorage(request))
+    return request
+
+
+def _messages(request) -> list[str]:
+    return [str(m) for m in request._messages]
+
+
+def _save_related(admin: ProgramAdmin, request, obj: Program, change: bool = False) -> None:
+    """Drive ProgramAdmin.save_related with a stub form; inlines are written separately in the test.
+
+    super().save_related calls form.save_m2m(); the instance has no unsaved m2m here, so a no-op
+    stub is enough to reach the seeding logic under test.
+    """
+    form = SimpleNamespace(instance=obj, save_m2m=lambda: None)
+    admin.save_related(request, form, formsets=[], change=change)
 
 
 @pytest.mark.django_db
@@ -145,3 +181,250 @@ def test_compute_profile_reports_how_many_sizes_use_it():
     obj = admin.get_queryset(request).get(pk=profile.pk)
 
     assert admin.sizes_using(obj) == 2
+
+
+# --- Making a backoffice-created Fleets function runnable -------------------------------------
+#
+# ProgramAdminForm.clean() assigns a Code Engine project (like the upload endpoint) and blocks the
+# save when none is available; ProgramAdmin.save_related() seeds a default size for a size-less
+# Fleets function. These tests exercise clean() directly with a set cleaned_data (bypassing the
+# per-field validation of an "__all__" ModelForm), and drive save_related with a stub form.
+
+
+def _clean_program_form(instance: Program, cleaned_data: dict) -> ProgramAdminForm:
+    """Run ProgramAdminForm.clean() against a prepared instance + cleaned_data.
+
+    Returns the form so callers can inspect .cleaned_data; clean() raises ValidationError to block.
+    """
+    form = ProgramAdminForm(instance=instance)
+    form.cleaned_data = cleaned_data
+    form.cleaned_data = form.clean()
+    return form
+
+
+@pytest.mark.django_db
+def test_clean_assigns_the_providers_active_ce_project():
+    """A Fleets function with a provider and no chosen project gets the provider's active project."""
+    provider = Provider.objects.create(name="prov", code_engine_project=_ce_project("prov-proj"))
+    program = Program(title="fn", runner=Program.FLEETS, provider=provider)
+
+    form = _clean_program_form(program, {"runner": Program.FLEETS, "provider": provider, "code_engine_project": None})
+
+    assert form.cleaned_data["code_engine_project"].project_name == "prov-proj"
+
+
+@pytest.mark.django_db
+@override_settings(CE_DEFAULT_PROJECT_NAME="default-proj")
+def test_clean_assigns_the_default_ce_project_when_providerless():
+    """A providerless Fleets function gets the configured default project."""
+    default_project = _ce_project("default-proj")
+    program = Program(title="fn", runner=Program.FLEETS, provider=None)
+
+    form = _clean_program_form(program, {"runner": Program.FLEETS, "provider": None, "code_engine_project": None})
+
+    assert form.cleaned_data["code_engine_project"] == default_project
+
+
+@pytest.mark.django_db
+@override_settings(CE_DEFAULT_PROJECT_NAME="")
+def test_clean_blocks_the_save_when_default_project_is_unconfigured():
+    """An unconfigured CE_DEFAULT_PROJECT_NAME makes select_default() raise; the save is refused,
+    not 500'd."""
+    program = Program(title="fn", runner=Program.FLEETS, provider=None)
+
+    with pytest.raises(forms.ValidationError) as exc:
+        _clean_program_form(program, {"runner": Program.FLEETS, "provider": None, "code_engine_project": None})
+
+    assert "No active Code Engine project available" in str(exc.value)
+
+
+@pytest.mark.django_db
+def test_clean_blocks_the_save_when_provider_has_no_project():
+    """A Fleets function whose provider has no project cannot be saved."""
+    provider = Provider.objects.create(name="prov", code_engine_project=None)
+    program = Program(title="fn", runner=Program.FLEETS, provider=provider)
+
+    with pytest.raises(forms.ValidationError) as exc:
+        _clean_program_form(program, {"runner": Program.FLEETS, "provider": provider, "code_engine_project": None})
+
+    assert "No active Code Engine project for provider 'prov'" in str(exc.value)
+
+
+@pytest.mark.django_db
+def test_clean_blocks_the_save_when_providers_project_is_inactive():
+    """An inactive provider project is treated as no project, with its own message."""
+    provider = Provider.objects.create(name="prov", code_engine_project=_ce_project("prov-proj", active=False))
+    program = Program(title="fn", runner=Program.FLEETS, provider=provider)
+
+    with pytest.raises(forms.ValidationError) as exc:
+        _clean_program_form(program, {"runner": Program.FLEETS, "provider": provider, "code_engine_project": None})
+
+    assert "is not active" in str(exc.value)
+
+
+@pytest.mark.django_db
+def test_clean_keeps_an_operator_chosen_project():
+    """A project the operator picked is left untouched (assign_to_program no-ops)."""
+    chosen = _ce_project("chosen")
+    program = Program(title="fn", runner=Program.FLEETS, provider=None)
+
+    form = _clean_program_form(program, {"runner": Program.FLEETS, "provider": None, "code_engine_project": chosen})
+
+    assert form.cleaned_data["code_engine_project"] == chosen
+
+
+@pytest.mark.django_db
+def test_clean_ignores_ray_functions():
+    """A Ray function needs no CE project and must not be blocked or assigned one."""
+    program = Program(title="fn", runner=Program.RAY, provider=None)
+
+    form = _clean_program_form(program, {"runner": Program.RAY, "provider": None, "code_engine_project": None})
+
+    assert form.cleaned_data.get("code_engine_project") is None
+
+
+@pytest.mark.django_db
+@override_settings(DEFAULT_FUNCTION_SIZE="m", DEFAULT_FUNCTION_SIZE_PROFILE="16x128")
+def test_save_related_seeds_a_default_size_when_none_declared():
+    """A size-less Fleets function gets the deployment default size, like the upload path."""
+    _profile("16x128")
+    function = _function()
+    request = _request_with_messages()
+
+    _save_related(ProgramAdmin(Program, AdminSite()), request, function)
+
+    function.refresh_from_db()
+    sizes = list(FunctionSize.objects.filter(function=function))
+    assert len(sizes) == 1
+    assert sizes[0].function_size == "m"
+    assert sizes[0].compute_profile_id == "16x128"
+    assert function.default_size_id == sizes[0].id
+    assert _messages(request) == []
+
+
+@pytest.mark.django_db
+@override_settings(DEFAULT_FUNCTION_SIZE="m", DEFAULT_FUNCTION_SIZE_PROFILE="16x128")
+def test_save_related_warns_when_the_default_profile_is_not_registered():
+    """Seeding is non-fatal: no profile row means no size and a warning, not a crash."""
+    function = _function()  # note: no ComputeProfile "16x128" created
+    request = _request_with_messages()
+
+    _save_related(ProgramAdmin(Program, AdminSite()), request, function)
+
+    function.refresh_from_db()
+    assert not FunctionSize.objects.filter(function=function).exists()
+    assert function.default_size_id is None
+    assert any("16x128" in m and "not registered" in m for m in _messages(request))
+
+
+@pytest.mark.django_db
+@override_settings(DEFAULT_FUNCTION_SIZE="m", DEFAULT_FUNCTION_SIZE_PROFILE="16x128")
+def test_save_related_does_not_seed_when_sizes_are_declared():
+    """An operator who declared sizes inline must not get an extra seeded 'm' size."""
+    _profile("16x128")
+    function = _function()
+    profile = _profile("8x32")
+    _size(function, "s", profile)
+    request = _request_with_messages()
+
+    _save_related(ProgramAdmin(Program, AdminSite()), request, function)
+
+    function.refresh_from_db()
+    names = sorted(FunctionSize.objects.filter(function=function).values_list("function_size", flat=True))
+    assert names == ["s"]
+    assert function.default_size_id is None
+
+
+@pytest.mark.django_db
+@override_settings(DEFAULT_FUNCTION_SIZE="m", DEFAULT_FUNCTION_SIZE_PROFILE="16x128")
+def test_save_related_does_not_clobber_an_existing_default():
+    """Editing a function that already has a default size leaves it and the catalog alone."""
+    _profile("16x128")
+    function = _function()
+    profile = _profile("8x32")
+    small = _size(function, "s", profile)
+    function.default_size = small
+    function.save(update_fields=["default_size"])
+    request = _request_with_messages()
+
+    _save_related(ProgramAdmin(Program, AdminSite()), request, function, change=True)
+
+    function.refresh_from_db()
+    assert function.default_size_id == small.id
+    assert FunctionSize.objects.filter(function=function).count() == 1
+
+
+@pytest.mark.django_db
+@override_settings(DEFAULT_FUNCTION_SIZE="m", DEFAULT_FUNCTION_SIZE_PROFILE="16x128")
+def test_save_related_ignores_ray_functions():
+    """A Ray function is never seeded."""
+    _profile("16x128")
+    user = User.objects.create_user(username="ray-u", password="x")
+    function = Program.objects.create(title="ray-fn", author=user, runner=Program.RAY)
+    request = _request_with_messages()
+
+    _save_related(ProgramAdmin(Program, AdminSite()), request, function)
+
+    assert not FunctionSize.objects.filter(function=function).exists()
+    assert function.default_size_id is None
+
+
+def _program_add_post(author, **overrides) -> dict:
+    """A minimal POST body for the Program add page, including the empty inline formsets.
+
+    The size inline and the two m2m 'through' inlines each need their management form even when no
+    rows are added, or the admin rejects the whole submission before our clean() runs.
+    """
+    data = {
+        "title": "adminfn",
+        "type": Program.GENERIC,
+        "disabled_message": Program.DEFAULT_DISABLED_MESSAGE,
+        "runner": Program.FLEETS,
+        "entrypoint": "main.py",
+        "env_vars": "{}",
+        "dependencies": "[]",
+        "arguments_schema": "{}",
+        "author": str(author.pk),
+        "function_sizes-TOTAL_FORMS": "0",
+        "function_sizes-INITIAL_FORMS": "0",
+        "function_sizes-MIN_NUM_FORMS": "0",
+        "function_sizes-MAX_NUM_FORMS": "1000",
+    }
+    data.update(overrides)
+    return data
+
+
+@pytest.mark.django_db
+@override_settings(CE_DEFAULT_PROJECT_NAME="")
+def test_add_page_blocks_a_fleets_function_with_no_ce_project(client):
+    """End-to-end through the real add form: a providerless Fleets function with no assignable
+    project is rejected inline and never persisted."""
+    admin = User.objects.create_superuser(username="admin", password="x", email="a@b.c")
+    client.force_login(admin)
+
+    response = client.post(reverse("admin:api_program_add"), data=_program_add_post(admin), follow=False)
+
+    assert response.status_code == 200  # re-rendered form, not a redirect
+    assert "No active Code Engine project available" in response.content.decode()
+    assert not Program.objects.filter(title="adminfn").exists()
+
+
+@pytest.mark.django_db
+@override_settings(
+    CE_DEFAULT_PROJECT_NAME="default-proj", DEFAULT_FUNCTION_SIZE="m", DEFAULT_FUNCTION_SIZE_PROFILE="16x128"
+)
+def test_add_page_creates_a_runnable_fleets_function(client):
+    """End-to-end: with a default CE project and default profile registered, the add form creates a
+    Fleets function that gets both a CE project and a seeded default size."""
+    _ce_project("default-proj")
+    _profile("16x128")
+    admin = User.objects.create_superuser(username="admin", password="x", email="a@b.c")
+    client.force_login(admin)
+
+    response = client.post(reverse("admin:api_program_add"), data=_program_add_post(admin), follow=False)
+
+    assert response.status_code == 302  # saved, redirected to changelist
+    function = Program.objects.get(title="adminfn")
+    assert function.code_engine_project.project_name == "default-proj"
+    assert function.default_size is not None
+    assert function.default_size.function_size == "m"

--- a/gateway/tests/test_tshirt_admin.py
+++ b/gateway/tests/test_tshirt_admin.py
@@ -5,13 +5,11 @@ dropdown restricted to a function's own sizes, and the reference count shown on 
 """
 
 import itertools
-from types import SimpleNamespace
 
 import pytest
 from django import forms
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
-from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test import override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
@@ -47,28 +45,6 @@ def _ce_project(name: str = "ce-proj", active: bool = True) -> CodeEngineProject
         region="us-east",
         active=active,
     )
-
-
-def _request_with_messages():
-    """A request the admin can attach messages to (save_related emits warnings)."""
-    request = RequestFactory().post("/")
-    setattr(request, "session", {})
-    setattr(request, "_messages", FallbackStorage(request))
-    return request
-
-
-def _messages(request) -> list[str]:
-    return [str(m) for m in request._messages]
-
-
-def _save_related(admin: ProgramAdmin, request, obj: Program, change: bool = False) -> None:
-    """Drive ProgramAdmin.save_related with a stub form; inlines are written separately in the test.
-
-    super().save_related calls form.save_m2m(); the instance has no unsaved m2m here, so a no-op
-    stub is enough to reach the seeding logic under test.
-    """
-    form = SimpleNamespace(instance=obj, save_m2m=lambda: None)
-    admin.save_related(request, form, formsets=[], change=change)
 
 
 @pytest.mark.django_db
@@ -186,9 +162,8 @@ def test_compute_profile_reports_how_many_sizes_use_it():
 # --- Making a backoffice-created Fleets function runnable -------------------------------------
 #
 # ProgramAdminForm.clean() assigns a Code Engine project (like the upload endpoint) and blocks the
-# save when none is available; ProgramAdmin.save_related() seeds a default size for a size-less
-# Fleets function. These tests exercise clean() directly with a set cleaned_data (bypassing the
-# per-field validation of an "__all__" ModelForm), and drive save_related with a stub form.
+# save when none is available. These tests exercise clean() directly with a set cleaned_data
+# (bypassing the per-field validation of an "__all__" ModelForm).
 
 
 def _clean_program_form(instance: Program, cleaned_data: dict) -> ProgramAdminForm:
@@ -283,92 +258,6 @@ def test_clean_ignores_ray_functions():
     assert form.cleaned_data.get("code_engine_project") is None
 
 
-@pytest.mark.django_db
-@override_settings(DEFAULT_FUNCTION_SIZE="m", DEFAULT_FUNCTION_SIZE_PROFILE="16x128")
-def test_save_related_seeds_a_default_size_when_none_declared():
-    """A size-less Fleets function gets the deployment default size, like the upload path."""
-    _profile("16x128")
-    function = _function()
-    request = _request_with_messages()
-
-    _save_related(ProgramAdmin(Program, AdminSite()), request, function)
-
-    function.refresh_from_db()
-    sizes = list(FunctionSize.objects.filter(function=function))
-    assert len(sizes) == 1
-    assert sizes[0].function_size == "m"
-    assert sizes[0].compute_profile_id == "16x128"
-    assert function.default_size_id == sizes[0].id
-    assert _messages(request) == []
-
-
-@pytest.mark.django_db
-@override_settings(DEFAULT_FUNCTION_SIZE="m", DEFAULT_FUNCTION_SIZE_PROFILE="16x128")
-def test_save_related_warns_when_the_default_profile_is_not_registered():
-    """Seeding is non-fatal: no profile row means no size and a warning, not a crash."""
-    function = _function()  # note: no ComputeProfile "16x128" created
-    request = _request_with_messages()
-
-    _save_related(ProgramAdmin(Program, AdminSite()), request, function)
-
-    function.refresh_from_db()
-    assert not FunctionSize.objects.filter(function=function).exists()
-    assert function.default_size_id is None
-    assert any("16x128" in m and "not registered" in m for m in _messages(request))
-
-
-@pytest.mark.django_db
-@override_settings(DEFAULT_FUNCTION_SIZE="m", DEFAULT_FUNCTION_SIZE_PROFILE="16x128")
-def test_save_related_does_not_seed_when_sizes_are_declared():
-    """An operator who declared sizes inline must not get an extra seeded 'm' size."""
-    _profile("16x128")
-    function = _function()
-    profile = _profile("8x32")
-    _size(function, "s", profile)
-    request = _request_with_messages()
-
-    _save_related(ProgramAdmin(Program, AdminSite()), request, function)
-
-    function.refresh_from_db()
-    names = sorted(FunctionSize.objects.filter(function=function).values_list("function_size", flat=True))
-    assert names == ["s"]
-    assert function.default_size_id is None
-
-
-@pytest.mark.django_db
-@override_settings(DEFAULT_FUNCTION_SIZE="m", DEFAULT_FUNCTION_SIZE_PROFILE="16x128")
-def test_save_related_does_not_clobber_an_existing_default():
-    """Editing a function that already has a default size leaves it and the catalog alone."""
-    _profile("16x128")
-    function = _function()
-    profile = _profile("8x32")
-    small = _size(function, "s", profile)
-    function.default_size = small
-    function.save(update_fields=["default_size"])
-    request = _request_with_messages()
-
-    _save_related(ProgramAdmin(Program, AdminSite()), request, function, change=True)
-
-    function.refresh_from_db()
-    assert function.default_size_id == small.id
-    assert FunctionSize.objects.filter(function=function).count() == 1
-
-
-@pytest.mark.django_db
-@override_settings(DEFAULT_FUNCTION_SIZE="m", DEFAULT_FUNCTION_SIZE_PROFILE="16x128")
-def test_save_related_ignores_ray_functions():
-    """A Ray function is never seeded."""
-    _profile("16x128")
-    user = User.objects.create_user(username="ray-u", password="x")
-    function = Program.objects.create(title="ray-fn", author=user, runner=Program.RAY)
-    request = _request_with_messages()
-
-    _save_related(ProgramAdmin(Program, AdminSite()), request, function)
-
-    assert not FunctionSize.objects.filter(function=function).exists()
-    assert function.default_size_id is None
-
-
 def _program_add_post(author, **overrides) -> dict:
     """A minimal POST body for the Program add page, including the empty inline formsets.
 
@@ -410,14 +299,11 @@ def test_add_page_blocks_a_fleets_function_with_no_ce_project(client):
 
 
 @pytest.mark.django_db
-@override_settings(
-    CE_DEFAULT_PROJECT_NAME="default-proj", DEFAULT_FUNCTION_SIZE="m", DEFAULT_FUNCTION_SIZE_PROFILE="16x128"
-)
+@override_settings(CE_DEFAULT_PROJECT_NAME="default-proj")
 def test_add_page_creates_a_runnable_fleets_function(client):
-    """End-to-end: with a default CE project and default profile registered, the add form creates a
-    Fleets function that gets both a CE project and a seeded default size."""
+    """End-to-end: with a default CE project available, the add form creates a Fleets function and
+    assigns it that project so it can run."""
     _ce_project("default-proj")
-    _profile("16x128")
     admin = User.objects.create_superuser(username="admin", password="x", email="a@b.c")
     client.force_login(admin)
 
@@ -426,5 +312,3 @@ def test_add_page_creates_a_runnable_fleets_function(client):
     assert response.status_code == 302  # saved, redirected to changelist
     function = Program.objects.get(title="adminfn")
     assert function.code_engine_project.project_name == "default-proj"
-    assert function.default_size is not None
-    assert function.default_size.function_size == "m"


### PR DESCRIPTION
## Summary

The T-shirt size models (`ComputeProfile`, `FunctionSize`, `Program.default_size`) shipped in 0.36.0, but a function's **size catalog** (its sizes map) and its **default size** weren't surfaced in the backoffice admin where operators work. This PR adds them, and — as a second step — makes a Fleets function created *purely in the admin* actually runnable.

### Part 1 — Surface the size elements

**On the Program (Function) page**
- **`FunctionSizeInline`** — a function's whole sizes map (each size key → compute profile) is now editable inline on its own page, mirroring the catalog the upload endpoint's `sizes` payload builds. It renders as "Sizes (compute profile per size)".
- **`default_size`** field in its own "Default size" fieldset, rendered directly below the sizes catalog. Its dropdown is restricted to the function's *own* sizes (`Program.clean()` rejects a default belonging to another function). The fieldset and the inline are placed adjacent (via a small `change_form.html` override) and named apart so the two are not mistaken for duplicates.
- **`sizes_summary`** changelist column — `N (default: s)` or `-`.

**On the ComputeProfile page**
- **`sizes_using`** column — reference count, so an operator sees a profile is in use before editing/deleting it (the FK is `PROTECT`).

Both changelist columns are annotated to avoid per-row queries.

### Part 2 — Make a backoffice-created Fleets function runnable

A `Program` created purely in the admin previously got only model defaults, skipping a runnable-critical step the upload use case performs:

- **CE project assignment.** `ProgramAdminForm.clean()` assigns a Code Engine project to a Fleets function (provider's active project, or the deployment default) via `CodeEngineProject.objects.assign_to_program`, and **blocks the save** — with the upload endpoint's own message — when none is available. A Fleets function with no active CE project cannot run, so this fails loud rather than persisting a dead function.

Refactor: promoted `_no_ce_project_message` → `no_ce_project_message` so the admin reuses the endpoint's exact wording.

## Note: default-size seeding is intentionally left out

An earlier version of this PR also seeded a per-function default size (`DEFAULT_FUNCTION_SIZE` → `DEFAULT_FUNCTION_SIZE_PROFILE`) for a size-less Fleets function, mirroring the upload path. That has been removed.

The reason is a design decision that is not in the codebase yet but is coming: the fallback for a function that declared no sizes should be a single shared **`platform-default`** `FunctionSize` row (no `function` id), resolved at **job creation** rather than at function creation, so `Job.function_size` is never null and billing can always read the size off the job. The upload path's existing seeding is untouched (out of scope) and will be revisited when the platform-default work lands.

## Scope
- Admin-only. **No model or migration changes.**
- Does **not** touch `Job.compute_profile` (the deprecated string) — that's a separate branch's concern.

## Behavioral note (blocking tradeoff)
Because `clean()` blocks any Fleets save that can't get an active CE project, a legacy/misconfigured Fleets function whose provider has no active project (and no default configured) cannot be saved — even to disable it — until a project is assignable. This is the intended "fail-loud" behavior (mirrors the upload endpoint); the operator assigns a project in the same edit.

## Testing
- `gateway/tests/test_tshirt_admin.py` (16 tests): inline rendering, `default_size` dropdown scoping, `sizes_summary`, `sizes_using` count; CE auto-assign (provider + default paths), blocking when unconfigured / no project / inactive project, operator-chosen project preserved, Ray no-ops; plus two **end-to-end admin `client`** tests proving the real add form blocks a non-runnable function and creates a runnable one.
- `pylint` 10.00/10 on both source files; `black` clean.
