### PR TITLE
Set `running_started_at` before emitting the job-started events

### DIFF
--- a/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
+++ b/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
@@ -142,14 +142,21 @@ class UpdateFleetsJobsStatuses(SchedulerTask):
             job.status,
             Job.RUNNING,
         )
+        # running_started_at is persisted before the events because the events carry it as
+        # job_started_at, and because it must survive a failed emit: publishing raises, the
+        # status stays PENDING and the job is retried next tick, but the moment the fleet was
+        # first seen RUNNING is already recorded. Stamping it after a successful emit instead
+        # would push it later by however many ticks failed. It is written only once — a retry
+        # reuses the stored value rather than moving the start time forward.
+        if job.running_started_at is None:
+            job.update_fields({"running_started_at": django_timezone.now()})
+
         self.event_streams_client.emit_job_started(job)
         # prevent custom function to emit license fee
         # since licenses is a provider feature
         if job.program.provider:
             self.event_streams_client.emit_license_fee(job)
-        # running_started_at is set only on first transition; already-RUNNING jobs picked up
-        # after a scheduler restart will have running_started_at=None (metric_value=0).
-        job.update_fields({"status": Job.RUNNING, "running_started_at": django_timezone.now()})
+        job.update_fields({"status": Job.RUNNING})
         JobEvent.objects.add_status_event(
             job_id=job.id,
             origin=JobEventOrigin.SCHEDULER,

--- a/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
+++ b/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
@@ -1,7 +1,7 @@
 """Unit tests for UpdateFleetsJobsStatuses."""
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -273,12 +273,65 @@ class TestToRunning:
             mock_dt.now.return_value = fake_now
             task.to_running(job)
 
-        job.update_fields.assert_called_once_with(
-            {
-                "status": Job.RUNNING,
-                "running_started_at": fake_now,
-            }
-        )
+        assert job.update_fields.call_args_list == [
+            call({"running_started_at": fake_now}),
+            call({"status": Job.RUNNING}),
+        ]
+
+    def test_to_running_persists_running_started_at_before_emitting_events(self):
+        """The events carry running_started_at as job_started_at, so it must be set first."""
+        task = _make_task()
+        job = _make_fleets_job(status=Job.PENDING)
+        fake_now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        seen = {}
+
+        task.event_streams_client.emit_job_started.side_effect = lambda j: seen.update(started=j.running_started_at)
+        task.event_streams_client.emit_license_fee.side_effect = lambda j: seen.update(license=j.running_started_at)
+
+        with (
+            patch(f"{_MOD}.JobEvent"),
+            patch(f"{_MOD}.django_timezone") as mock_dt,
+        ):
+            mock_dt.now.return_value = fake_now
+            task.to_running(job)
+
+        assert seen == {"started": fake_now, "license": fake_now}
+
+    def test_to_running_keeps_existing_running_started_at_on_retry(self):
+        """A retry after a failed emit must reuse the stored start time, not move it forward."""
+        task = _make_task()
+        job = _make_fleets_job(status=Job.PENDING)
+        original = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        job.running_started_at = original
+
+        with (
+            patch(f"{_MOD}.JobEvent"),
+            patch(f"{_MOD}.django_timezone") as mock_dt,
+        ):
+            mock_dt.now.return_value = datetime(2026, 1, 1, 12, 30, 0, tzinfo=timezone.utc)
+            task.to_running(job)
+
+        assert job.running_started_at == original
+        job.update_fields.assert_called_once_with({"status": Job.RUNNING})
+
+    def test_to_running_keeps_running_started_at_when_emit_fails(self):
+        """A failed publish leaves the job PENDING but the recorded start time persisted."""
+        task = _make_task()
+        job = _make_fleets_job(status=Job.PENDING)
+        fake_now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        task.event_streams_client.emit_job_started.side_effect = RuntimeError("kafka down")
+
+        with (
+            patch(f"{_MOD}.JobEvent"),
+            patch(f"{_MOD}.django_timezone") as mock_dt,
+        ):
+            mock_dt.now.return_value = fake_now
+            with pytest.raises(RuntimeError):
+                task.to_running(job)
+
+        assert job.running_started_at == fake_now
+        assert job.status == Job.PENDING
+        job.update_fields.assert_called_once_with({"running_started_at": fake_now})
 
 
 class TestStopJobIfTimeout:
@@ -384,19 +437,20 @@ class TestRun:
 class TestEventStreamsIntegration:
     """Tests that emit methods are called at the right lifecycle points."""
 
-    def test_to_running_emits_job_started_before_db_update(self):
+    def test_to_running_emits_job_started_before_the_status_is_written(self):
+        """running_started_at is persisted first, but the status must not be until the emit lands."""
         task = _make_task()
         job = _make_fleets_job(status=Job.PENDING)
 
         call_order = []
         task.event_streams_client.emit_job_started.side_effect = lambda j: call_order.append("publish")
-        job.update_fields = MagicMock(side_effect=lambda f: call_order.append("db"))
+        job.update_fields = MagicMock(side_effect=lambda f: call_order.append("db:" + ",".join(f)))
 
         with patch(f"{_MOD}.JobEvent"):
             with patch(f"{_MOD}.django_timezone"):
                 task.to_running(job)
 
-        assert call_order == ["publish", "db"]
+        assert call_order == ["db:running_started_at", "publish", "db:status"]
         task.event_streams_client.emit_job_started.assert_called_once_with(job)
 
     def test_to_running_raises_if_publish_fails(self):
@@ -405,11 +459,16 @@ class TestEventStreamsIntegration:
         job = _make_fleets_job(status=Job.PENDING)
 
         with patch(f"{_MOD}.JobEvent"):
-            with patch(f"{_MOD}.django_timezone"):
+            with patch(f"{_MOD}.django_timezone") as mock_dt:
+                fake_now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+                mock_dt.now.return_value = fake_now
                 with pytest.raises(Exception, match="broker down"):
                     task.to_running(job)
 
-        job.update_fields.assert_not_called()
+        # The start time is kept so a retry reports when the fleet really started, but the
+        # status is not written: the job stays PENDING and is picked up again next tick.
+        job.update_fields.assert_called_once_with({"running_started_at": fake_now})
+        assert job.status == Job.PENDING
 
     def test_to_terminal_emits_job_completed_before_db_update(self):
         task = _make_task()
@@ -503,13 +562,13 @@ class TestEventStreamsIntegration:
         call_order = []
         task.event_streams_client.emit_job_started.side_effect = lambda j: call_order.append("started")
         task.event_streams_client.emit_license_fee.side_effect = lambda j: call_order.append("license")
-        job.update_fields = MagicMock(side_effect=lambda f: call_order.append("db"))
+        job.update_fields = MagicMock(side_effect=lambda f: call_order.append("db:" + ",".join(f)))
 
         with patch(f"{_MOD}.JobEvent"):
             with patch(f"{_MOD}.django_timezone"):
                 task.to_running(job)
 
-        assert call_order == ["started", "license", "db"]
+        assert call_order == ["db:running_started_at", "started", "license", "db:status"]
         task.event_streams_client.emit_license_fee.assert_called_once_with(job)
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

### Summary
When a Fleets job moved from `PENDING` to `RUNNING`, `to_running` emitted the classical usage and license fee events *before* writing `running_started_at`. Both events carry that field as `job_started_at`, so it was always published as `null`. This splits the single write at the end of the method: `running_started_at` is now persisted first, then the events are emitted, then the status write follows. The status write deliberately stays after the emits, so a Kafka failure still raises, leaves the job `PENDING`, and lets the scheduler retry it on the next tick — that behaviour is unchanged.

Persisting the timestamp first also fixes a drift problem. If publishing fails while the fleet is already running in Code Engine, the start time is recorded anyway, so a retry two or three ticks later reports when the job *actually* started rather than when the emit finally succeeded. The write is guarded by `if job.running_started_at is None`, so retries reuse the stored value instead of pushing the start time forward. Note this means a `PENDING` row can briefly carry `running_started_at`; the only consumer, `api/domain/job_timeline.py`, uses it as a fallback and already discards inconsistent intervals.

Three tests in `TestEventStreamsIntegration` were updated: they previously asserted that *no* DB write happened before the emit, and now assert the narrower guarantee that the **status** write comes after it. New cases cover the timestamp being visible to both emit calls, a retry reusing the stored value, and a failed publish keeping the timestamp while leaving the job `PENDING`. To confirm the original bug, revert the production change and the "persists before emitting" test fails with `job_started_at` unset.

### Checklist

- [x] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [ ] I have added a [release note](https://github.com/Qiskit/qiskit-serverless/blob/main/CONTRIBUTING.md#release-notes) for any user-facing change (new feature, bug fix, deprecation, or breaking change), or this PR has no user-facing changes.
