### PR TITLE
Exclude filler jobs from the Fleets status/timeout update task

### DIFF
--- a/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
+++ b/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
@@ -213,9 +213,7 @@ class UpdateFleetsJobsStatuses(SchedulerTask):
         # Note: with LIMITS_MAX_FLEETS potentially reaching 1000+ concurrent jobs, updating statuses
         # sequentially will become a bottleneck. This loop should be parallelized using multiple
         # threads or batched processing for performance reasons.
-        # Filler jobs are excluded: BalanceFillerJobs owns their full lifecycle, and this
-        # task's timeout would otherwise stop one without cancelling its Code Engine job,
-        # leaving it orphaned once the balancer stops tracking it as a filler job.
+        # Filler jobs are excluded: BalanceFillerJobs owns their full lifecycle
         jobs = Job.objects.filter(status__in=Job.RUNNING_STATUSES, runner=Program.FLEETS, filler=False)
         for job in jobs:
             if self.kill_signal.received:

--- a/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
+++ b/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
@@ -213,7 +213,10 @@ class UpdateFleetsJobsStatuses(SchedulerTask):
         # Note: with LIMITS_MAX_FLEETS potentially reaching 1000+ concurrent jobs, updating statuses
         # sequentially will become a bottleneck. This loop should be parallelized using multiple
         # threads or batched processing for performance reasons.
-        jobs = Job.objects.filter(status__in=Job.RUNNING_STATUSES, runner=Program.FLEETS)
+        # Filler jobs are excluded: BalanceFillerJobs owns their full lifecycle, and this
+        # task's timeout would otherwise stop one without cancelling its Code Engine job,
+        # leaving it orphaned once the balancer stops tracking it as a filler job.
+        jobs = Job.objects.filter(status__in=Job.RUNNING_STATUSES, runner=Program.FLEETS, filler=False)
         for job in jobs:
             if self.kill_signal.received:
                 logger.info("Kill signal received, stopping status update cycle")

--- a/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
+++ b/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
@@ -378,6 +378,23 @@ class TestStopJobIfTimeout:
 class TestRun:
     """Tests for run()."""
 
+    def test_excludes_filler_jobs_from_the_query(self):
+        """Filler jobs are owned end-to-end by BalanceFillerJobs, this task must not touch them."""
+        task = _make_task()
+
+        with (
+            patch(f"{_MOD}.settings") as mock_settings,
+            patch(f"{_MOD}.Job") as mock_job_cls,
+        ):
+            mock_settings.LIMITS_MAX_FLEETS = 10
+            mock_job_cls.objects.filter.return_value = []
+            mock_job_cls.RUNNING_STATUSES = Job.RUNNING_STATUSES
+            task.run()
+
+        mock_job_cls.objects.filter.assert_called_once_with(
+            status__in=Job.RUNNING_STATUSES, runner=Program.FLEETS, filler=False
+        )
+
     def test_early_return_when_fleets_disabled(self):
         task = _make_task()
 


### PR DESCRIPTION
### Summary
BalanceFillerJobs is meant to own the full lifecycle of filler jobs (jobs with filler == true), but UpdateFleetsJobsStatuses.run() queried all Fleets jobs in RUNNING_STATUSES without excluding them.

Filler jobs are meant to run indefinitely, so once one crossed PROGRAM_TIMEOUT (24h default) it got marked STOPPED by stop_job_if_timeout. Once that row left RUNNING_STATUSES, BalanceFillerJobs stopped tracking it and created a replacement, leaving the original Code Engine job orphaned and running..

### Details and comments
Excludes filler=True from the queryset in UpdateFleetsJobsStatuses.run(), so filler jobs stay fully owned by BalanceFillerJobs and are never touched by this task.

