### PR TITLE
Revert "Exclude filler jobs from the Fleets status/timeout update task"

### DIFF
--- a/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
+++ b/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
@@ -213,8 +213,7 @@ class UpdateFleetsJobsStatuses(SchedulerTask):
         # Note: with LIMITS_MAX_FLEETS potentially reaching 1000+ concurrent jobs, updating statuses
         # sequentially will become a bottleneck. This loop should be parallelized using multiple
         # threads or batched processing for performance reasons.
-        # Filler jobs are excluded: BalanceFillerJobs owns their full lifecycle
-        jobs = Job.objects.filter(status__in=Job.RUNNING_STATUSES, runner=Program.FLEETS, filler=False)
+        jobs = Job.objects.filter(status__in=Job.RUNNING_STATUSES, runner=Program.FLEETS)
         for job in jobs:
             if self.kill_signal.received:
                 logger.info("Kill signal received, stopping status update cycle")

--- a/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
+++ b/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
@@ -378,23 +378,6 @@ class TestStopJobIfTimeout:
 class TestRun:
     """Tests for run()."""
 
-    def test_excludes_filler_jobs_from_the_query(self):
-        """Filler jobs are owned end-to-end by BalanceFillerJobs, this task must not touch them."""
-        task = _make_task()
-
-        with (
-            patch(f"{_MOD}.settings") as mock_settings,
-            patch(f"{_MOD}.Job") as mock_job_cls,
-        ):
-            mock_settings.LIMITS_MAX_FLEETS = 10
-            mock_job_cls.objects.filter.return_value = []
-            mock_job_cls.RUNNING_STATUSES = Job.RUNNING_STATUSES
-            task.run()
-
-        mock_job_cls.objects.filter.assert_called_once_with(
-            status__in=Job.RUNNING_STATUSES, runner=Program.FLEETS, filler=False
-        )
-
     def test_early_return_when_fleets_disabled(self):
         task = _make_task()
 


### PR DESCRIPTION
### Summary
Rolls back #2473. That PR excluded filler jobs (`filler=True`) from the queryset that `UpdateFleetsJobsStatuses.run()` iterates, meaning `update_job_status()` is never called for them at all.

The fix was not correct: `update_job_status()` is also where a Fleets job transitions from PENDING to RUNNING once Code Engine reports it running (`to_running()`), and where SUCCEEDED/FAILED are detected. With filler jobs excluded from the queryset, a filler job stuck in PENDING would never move to RUNNING, and one that exits on its own would never reach a terminal status either, since nothing else in the scheduler polls Fleets status for a job in `RUNNING_STATUSES`.

### Details and comments
This PR only reverts the change (queryset filter and its test) back to how it was before #2473. It does not attempt an alternative fix for the underlying problem #2473 was addressing (a filler job hitting PROGRAM_TIMEOUT gets marked STOPPED in the DB while the underlying Code Engine job keeps running, since BalanceFillerJobs then spins up a replacement for the same slot).