### PR TITLE
Exempt filler jobs from PROGRAM_TIMEOUT

### DIFF
--- a/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
+++ b/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
@@ -167,9 +167,6 @@ class UpdateFleetsJobsStatuses(SchedulerTask):
     def stop_job_if_timeout(self, job: Job) -> None:
         """Stop job if it has exceeded the maximum allowed duration."""
         if job.filler:
-            # Filler jobs are meant to run indefinitely; BalanceFillerJobs is the
-            # only task that stops them, when they no longer match the configured
-            # filler program or compute profile.
             return
 
         timeout = settings.PROGRAM_TIMEOUT

--- a/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
+++ b/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
@@ -166,6 +166,12 @@ class UpdateFleetsJobsStatuses(SchedulerTask):
 
     def stop_job_if_timeout(self, job: Job) -> None:
         """Stop job if it has exceeded the maximum allowed duration."""
+        if job.filler:
+            # Filler jobs are meant to run indefinitely; BalanceFillerJobs is the
+            # only task that stops them, when they no longer match the configured
+            # filler program or compute profile.
+            return
+
         timeout = settings.PROGRAM_TIMEOUT
         latest_event = JobEvent.objects.filter(job=job).order_by("-created").first()
         reference_time = latest_event.created if latest_event else job.created

--- a/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
+++ b/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
@@ -374,6 +374,25 @@ class TestStopJobIfTimeout:
         assert job.status == Job.RUNNING
         job.update_fields.assert_not_called()
 
+    def test_filler_job_never_stopped_regardless_of_age(self):
+        task = _make_task()
+        job = _make_fleets_job(status=Job.RUNNING)
+        job.filler = True
+
+        past_event = MagicMock()
+        past_event.created = datetime.now(timezone.utc) - timedelta(hours=1000)
+
+        with (
+            patch(f"{_MOD}.settings") as mock_settings,
+            patch(f"{_MOD}.JobEvent") as mock_event,
+        ):
+            mock_settings.PROGRAM_TIMEOUT = 1
+            mock_event.objects.filter.return_value.order_by.return_value.first.return_value = past_event
+            task.stop_job_if_timeout(job)
+
+        assert job.status == Job.RUNNING
+        job.update_fields.assert_not_called()
+
 
 class TestRun:
     """Tests for run()."""


### PR DESCRIPTION
### Summary
Filler jobs are meant to run indefinitely (see BalanceFillerJobs), but `stop_job_if_timeout()` in `UpdateFleetsJobsStatuses` applied `PROGRAM_TIMEOUT` (24h default) to every Fleets job, filler ones included. Once a healthy, still-running filler job crossed that timeout it was marked STOPPED in the DB, BalanceFillerJobs started a replacement for the same slot, and the original Code Engine job kept running orphaned, since marking a job STOPPED here does not cancel the underlying Code Engine job.

### Details and comments
`stop_job_if_timeout()` now returns immediately for `job.filler`, leaving PROGRAM_TIMEOUT enforcement to jobs that are not filler-owned. A filler job still reaches a terminal status normally if it exits on its own (SUCCEEDED/FAILED); this only exempts it from the age-based STOPPED path. The intended way to stop a running filler job stays BalanceFillerJobs, when it stops matching the configured filler program or that program's compute profile.

Note: this only takes effect once #2475 is merged, since right now filler jobs are excluded from this task's queryset entirely (#2473) and never reach `stop_job_if_timeout()`.