### PR TITLE
Emit classical time events in seconds instead of miliseconds

### DIFF
--- a/gateway/core/ibm_cloud/event_streams/kafka_event_streams_client.py
+++ b/gateway/core/ibm_cloud/event_streams/kafka_event_streams_client.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import uuid
 from datetime import datetime, timezone
@@ -38,7 +39,7 @@ class KafkaEventStreamsClient(EventStreamsClient):
 
     Publishes CloudEvents 1.0 usage events for Fleets jobs. Each event carries a
     single metric in its `data` payload: `metric_type` (what is being billed) and
-    `metric_value` (how much, in milliseconds for time-based metrics), plus
+    `metric_value` (how much, in whole seconds for time-based metrics), plus
     `job_started` / `job_completed` flags so consumers can detect lifecycle
     boundaries without interpreting the metric type. License fee events also
     carry `business_model`.
@@ -90,7 +91,7 @@ class KafkaEventStreamsClient(EventStreamsClient):
         self._publish(
             job,
             metric_type=metric_type,
-            metric_value=self._usage_ms(job),
+            metric_value=self._usage_seconds(job),
             job_started=False,
             job_completed=False,
         )
@@ -99,12 +100,12 @@ class KafkaEventStreamsClient(EventStreamsClient):
         """Publish a job-completed event for the given metric with final usage."""
         if metric_type is None:
             metric_type = self._build_classical_metric_type(job)
-        usage_ms = self._usage_ms(job)
-        logger.info("job_id=%s Emitting job_completed event metric_value=%s", job.id, usage_ms)
+        usage_seconds = self._usage_seconds(job)
+        logger.info("job_id=%s Emitting job_completed event metric_value=%s", job.id, usage_seconds)
         self._publish(
             job,
             metric_type=metric_type,
-            metric_value=usage_ms,
+            metric_value=usage_seconds,
             job_started=False,
             job_completed=True,
         )
@@ -129,11 +130,12 @@ class KafkaEventStreamsClient(EventStreamsClient):
 
         return "_".join(parts)
 
-    def _usage_ms(self, job) -> int:
+    def _usage_seconds(self, job) -> int:
+        """Usage in whole seconds, rounded up so that any partial second is billed."""
         if job.running_started_at is None:
             return 0
         delta = datetime.now(timezone.utc) - job.running_started_at
-        return int(delta.total_seconds() * 1e3)
+        return math.ceil(delta.total_seconds())
 
     def _delivery_callback(self, err, msg):
         """Callback for message delivery reports."""

--- a/gateway/tests/core/services/ibm_cloud/event_streams/test_event_streams_client.py
+++ b/gateway/tests/core/services/ibm_cloud/event_streams/test_event_streams_client.py
@@ -136,7 +136,7 @@ class TestKafkaEventStreamsClient:
         assert call_kwargs["key"] == str(job.id).encode("utf-8")
         mock_producer.flush.assert_called_once()
 
-    def test_emit_job_in_progress_computes_usage_milliseconds(self):
+    def test_emit_job_in_progress_computes_usage_seconds(self):
         started_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
         job = _make_job(running_started_at=started_at)
 
@@ -161,12 +161,12 @@ class TestKafkaEventStreamsClient:
 
         published = json.loads(mock_producer.produce.call_args[1]["value"])
         assert published["data"]["metric_type"] == "classical_16x128"
-        assert published["data"]["metric_value"] == 5_000
+        assert published["data"]["metric_value"] == 5
         assert published["data"]["job_started"] is False
         assert published["data"]["job_completed"] is False
         assert published["data"]["job_started_at"] == started_at.isoformat()
 
-    def test_emit_job_completed_computes_usage_milliseconds(self):
+    def test_emit_job_completed_computes_usage_seconds(self):
         started_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
         job = _make_job(running_started_at=started_at)
 
@@ -191,10 +191,36 @@ class TestKafkaEventStreamsClient:
 
         published = json.loads(mock_producer.produce.call_args[1]["value"])
         assert published["data"]["metric_type"] == "classical_16x128"
-        assert published["data"]["metric_value"] == 30_000
+        assert published["data"]["metric_value"] == 30
         assert published["data"]["job_started"] is False
         assert published["data"]["job_completed"] is True
         assert published["data"]["job_started_at"] == started_at.isoformat()
+
+    def test_emit_job_completed_rounds_partial_second_up(self):
+        started_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        job = _make_job(running_started_at=started_at)
+
+        with patch(f"{_CLIENT_MOD}.Producer") as mock_producer_cls:
+            with patch(f"{_CLIENT_MOD}.uuid") as mock_uuid_mod:
+                with patch(f"{_CLIENT_MOD}.datetime") as mock_dt:
+                    with patch.dict(
+                        os.environ,
+                        {
+                            "EVENT_STREAMS_BOOTSTRAP_SERVERS": "b:9093",
+                            "EVENT_STREAMS_API_KEY": "k",
+                            "ENVIRONMENT": "production",
+                        },
+                    ):
+                        mock_uuid_mod.uuid4.return_value = uuid_module.uuid4()
+                        mock_dt.now.return_value = datetime(2026, 1, 1, 12, 0, 30, 1, tzinfo=timezone.utc)
+
+                        client = KafkaEventStreamsClient()
+                        mock_producer = mock_producer_cls.return_value
+                        mock_producer.flush.return_value = 0
+                        client.emit_job_completed(job)
+
+        published = json.loads(mock_producer.produce.call_args[1]["value"])
+        assert published["data"]["metric_value"] == 31
 
     def test_emit_raises_when_flush_times_out(self):
         job = _make_job()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

### Summary
Fleets jobs publish classical compute usage to IBM Cloud Event Streams as `metric_value` in the `quantum.<env>.function-usage.v1` topic. The field name carries no unit, so the value's meaning is a convention shared with the billing service rather than something the payload states. Historically that convention moved: nanoseconds when the client was introduced, then milliseconds once the events were aligned with the billing contract. Milliseconds no longer matched what the consumer expects, and a mismatched unit is silently wrong — it bills a plausible number rather than failing.


### Details and comments
`_usage_seconds` in `kafka_event_streams_client.py` is the single place the unit is defined. It computes `now - job.running_started_at` and returns `math.ceil(delta.total_seconds())`, so the value is whole seconds with any partial second rounded up and never a decimal. It feeds the in-progress and completed events; job-started sends `0` and the license fee sends `1`, both counts rather than durations. To change the unit again, edit that method, the class docstring stating the unit, and the expectations in `test_event_streams_client.py`.


### Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a [release note](https://github.com/Qiskit/qiskit-serverless/blob/main/CONTRIBUTING.md#release-notes) for any user-facing change (new feature, bug fix, deprecation, or breaking change), or this PR has no user-facing changes.
