### PR TITLE
Cancel the Code Engine job when a Fleets job times out

### DIFF
--- a/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
+++ b/gateway/scheduler/tasks/update_fleets_jobs_statuses.py
@@ -174,6 +174,12 @@ class UpdateFleetsJobsStatuses(SchedulerTask):
             return
 
         logger.warning("job_id=%s user_id=%s timeout=%s hours: job stopped.", job.id, job.author.id, timeout)
+        try:
+            get_runner(job).stop()
+        except RunnerError as ex:
+            # Logged, not returned: the row must still reach STOPPED so the timeout keeps
+            # bounding the user's concurrency slot even when Code Engine is unreachable.
+            logger.error("job_id=%s error cancelling Fleets job on timeout: %s", job.id, str(ex))
         self.to_terminal(job, Job.STOPPED)
 
     def _increment_terminal_counter(self, job: Job) -> None:

--- a/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
+++ b/gateway/tests/scheduler/test_update_fleets_jobs_statuses.py
@@ -347,6 +347,7 @@ class TestStopJobIfTimeout:
         with (
             patch(f"{_MOD}.settings") as mock_settings,
             patch(f"{_MOD}.JobEvent") as mock_event,
+            patch(f"{_MOD}.get_runner", return_value=MagicMock()),
         ):
             mock_settings.PROGRAM_TIMEOUT = 1
             mock_event.objects.filter.return_value.order_by.return_value.first.return_value = past_event
@@ -355,6 +356,49 @@ class TestStopJobIfTimeout:
         assert job.status == Job.STOPPED
         assert job.sub_status is None
         task.metrics.increment_jobs_terminal.assert_called_once()
+
+    def test_cancels_the_fleet_before_marking_stopped(self):
+        """The timeout must not just write STOPPED, it must cancel the Code Engine job too."""
+        task = _make_task()
+        job = _make_fleets_job(status=Job.RUNNING)
+
+        past_event = MagicMock()
+        past_event.created = datetime.now(timezone.utc) - timedelta(hours=100)
+        mock_runner = MagicMock()
+
+        with (
+            patch(f"{_MOD}.settings") as mock_settings,
+            patch(f"{_MOD}.JobEvent") as mock_event,
+            patch(f"{_MOD}.get_runner", return_value=mock_runner) as mock_get_runner,
+        ):
+            mock_settings.PROGRAM_TIMEOUT = 1
+            mock_event.objects.filter.return_value.order_by.return_value.first.return_value = past_event
+            task.stop_job_if_timeout(job)
+
+        mock_get_runner.assert_called_once_with(job)
+        mock_runner.stop.assert_called_once_with()
+        assert job.status == Job.STOPPED
+
+    def test_still_marks_stopped_when_the_fleet_cannot_be_cancelled(self):
+        """A Code Engine outage must not make the timeout immortal too."""
+        task = _make_task()
+        job = _make_fleets_job(status=Job.RUNNING)
+
+        past_event = MagicMock()
+        past_event.created = datetime.now(timezone.utc) - timedelta(hours=100)
+        mock_runner = MagicMock()
+        mock_runner.stop.side_effect = RunnerError("Code Engine project 'p' is not active")
+
+        with (
+            patch(f"{_MOD}.settings") as mock_settings,
+            patch(f"{_MOD}.JobEvent") as mock_event,
+            patch(f"{_MOD}.get_runner", return_value=mock_runner),
+        ):
+            mock_settings.PROGRAM_TIMEOUT = 1
+            mock_event.objects.filter.return_value.order_by.return_value.first.return_value = past_event
+            task.stop_job_if_timeout(job)
+
+        assert job.status == Job.STOPPED
 
     def test_job_unchanged_when_within_timeout(self):
         task = _make_task()


### PR DESCRIPTION
### Summary
When a Fleets job goes past `PROGRAM_TIMEOUT`, `stop_job_if_timeout` writes `STOPPED` on the row but never asks Code Engine to cancel anything. The fleet keeps running, and since nothing else looks at a job that is already in a terminal status, nothing ever cleans it up. This adds the missing `runner.stop()` call before the status is written.

### Details and comments
The timeout is the one path that decides to stop a job on its own, without Code Engine having reported a terminal state first. The other branches of `update_job_status` reach `to_terminal` because the task store already says the job succeeded, failed or was cancelled, so there is genuinely nothing left to cancel there. The timeout branch fires while the fleet is very likely still running, or while its state is unknown because the status poll returned nothing or raised.

If the cancel fails, the error is logged and the row still moves to `STOPPED`. Leaving it in a running status instead would keep it holding the user's concurrency slot for as long as Code Engine stays unreachable, which is the problem the timeout exists to bound.

Ray is not affected. Its timeout path has the same shape, but `FreeResources` deletes the `RayCluster` for any job in a terminal status, so the teardown happens regardless of whether `stop()` was called. Fleets has no equivalent task.

Worth knowing for reviewers: a follow-up will replace this single write with a two-phase transition, where a stop request moves the job to a new `STOPPING` status and a later poll confirms the real `STOPPED`. That work changes what this branch writes, not whether the cancel happens, so landing this first is still a strict improvement over today.

Closes https://github.ibm.com/IBM-Q-Software/qiskit-serverless/issues/1831