### PR TITLE
Create kafka external secret independently of billing

### DIFF
--- a/charts/qiskit-serverless/charts/gateway/values.yaml
+++ b/charts/qiskit-serverless/charts/gateway/values.yaml
@@ -141,6 +141,7 @@ secrets:
     secretRef: ""
     secretStoreName: qiskit-serverless
   kafka:
+    createExternalSecret: false
     name: ""
     secretRef: ""
     secretStoreName: qiskit-serverless

--- a/charts/qiskit-serverless/templates/kafka-credentials.yaml
+++ b/charts/qiskit-serverless/templates/kafka-credentials.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gateway.application.eventStreams.enabled -}}
+{{- if .Values.gateway.secrets.kafka.createExternalSecret -}}
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret

--- a/charts/qiskit-serverless/values.yaml
+++ b/charts/qiskit-serverless/values.yaml
@@ -95,6 +95,10 @@ gateway:
       secretRef: ""
       secretStoreName: qiskit-serverless
     kafka:
+      # Creation of the Kafka ExternalSecret is independent of
+      # application.eventStreams.enabled, so the credential can be provisioned
+      # and verified before billing events are switched on.
+      createExternalSecret: false
       name: ""
       secretRef: ""
       secretStoreName: qiskit-serverless


### PR DESCRIPTION
### Summary

The Kafka ExternalSecret was gated on `gateway.application.eventStreams.enabled`, so provisioning the credential was tied to turning billing on. It now has its own flag, `gateway.secrets.kafka.createExternalSecret`, so the credential can be set up and checked before events are switched on.

### Details and comments

The flag sits on the secret block, matching the `createExternalSecret` naming already used by `secret-psql.yaml`. It also reads a key that has a real default in this chart: `gateway.application.eventStreams` has none in the parent values, only in the gateway subchart, so the old gate relied on deployment values to define it.

Defaults to false. The deployment values that set it per environment go in a separate PR on the internal repo, which should merge first so staging keeps its secret.